### PR TITLE
Phase 6 follow-ups: eventual consistency, dogfood-by-default, release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,46 @@ jobs:
       - name: Run tests
         run: nix develop -c cargo test
 
+  # Build the hestia package. This is also the dogfooding job (Phase 4
+  # milestone): when the repository variables below are set, the package
+  # build runs through hestia itself — cache miss -> local build -> the
+  # post-build-hook pushes it; cache hit -> the build step is a pure
+  # substitution out of the GHA cache. Cache breakage then shows up as a
+  # slow or failing regular CI job, which is the strongest possible signal.
+  #
+  # lint/test are NOT wrapped: they run cargo inside nix develop, and the
+  # devshell closure is upstream-signed (cache.nixos.org) which hestia
+  # deliberately skips. The package derivation built here (plus its vendor
+  # deps) is the only locally-built output of this CI.
+  #
+  # The daemon is bootstrapped from a *released* hestia binary, because this
+  # job cannot use the package it is about to build. Required repository
+  # variables (unset = the dogfood step is skipped instantly and the build
+  # runs without caching):
+  #   HESTIA_DOGFOOD          "true"
+  #   HESTIA_DOGFOOD_VERSION  release tag, e.g. "v0.1.0-alpha.1"
+  #   HESTIA_DOGFOOD_SHA256   sha256 of that release's hestia-x86_64-linux
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      # GHA cache writes when dogfooding is enabled.
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: NixOS/nix-installer-action@main
+      - name: Start hestia cache (dogfood)
+        if: vars.HESTIA_DOGFOOD == 'true'
+        uses: ./action
+        with:
+          version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
+          sha256: ${{ vars.HESTIA_DOGFOOD_SHA256 }}
+      - name: Build the hestia package
+        run: nix build .# --print-build-logs
+      - name: Show daemon log
+        if: ${{ always() && vars.HESTIA_DOGFOOD == 'true' }}
+        run: cat "$HESTIA_SERVE_LOG"
+
   # Phase 0 milestone: prove that the action wrapper makes the GHA cache
   # tokens visible to shell steps and that the results endpoint is reachable.
   # If this job fails, the whole project needs rethinking (see PLAN.md,
@@ -126,36 +166,6 @@ jobs:
             --to /tmp/fresh-store \
             "$path"
           test -e "/tmp/fresh-store$path"
-      - name: Show daemon log
-        if: always()
-        run: cat "$HESTIA_SERVE_LOG"
-
-  # Phase 4 milestone: hestia's own CI dogfoods hestia. The first run
-  # populates the cache (post-build-hook -> drain); every later run
-  # substitutes from it instead of rebuilding.
-  #
-  # enabled-after-first-push: stays disabled until enabled on main after
-  # human review (set the repository variable HESTIA_DOGFOOD to "true").
-  dogfood:
-    if: ${{ vars.HESTIA_DOGFOOD == 'true' }} # enabled-after-first-push
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-      - uses: NixOS/nix-installer-action@main
-      - name: Build hestia
-        run: nix build .# -o hestia-bin
-      # Installs hestia, wires nix.conf, starts the daemon; the post step
-      # drains (uploads everything built below).
-      - uses: ./action
-        with:
-          binary: ./hestia-bin/bin/hestia
-      - name: Build the dev shell through the cache
-        # Anything that produces local (unsigned) store paths works; the
-        # devshell pulls in the whole rust toolchain closure.
-        run: nix develop -c cargo --version
       - name: Show daemon log
         if: always()
         run: cat "$HESTIA_SERVE_LOG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,36 @@ jobs:
           case "$tag" in
             *-*) prerelease=(--prerelease) ;;
           esac
+
+          # Release notes: usage snippet with the real sha256 values, so the
+          # release is copy-paste usable; --generate-notes appends the
+          # auto-generated changelog below it.
+          sha256_x86_64=$(cut -d' ' -f1 hestia-x86_64-linux.sha256)
+          sha256_aarch64=$(cut -d' ' -f1 hestia-aarch64-linux.sha256)
+          cat > notes.md <<EOF
+          > ⚠️ **Alpha software**: APIs, cache format, and behavior may change without notice.
+
+          ## Usage
+
+          \`\`\`yaml
+          - uses: Mic92/hestia/action@${tag}
+            with:
+              version: ${tag}
+              sha256: ${sha256_x86_64}   # x86_64-linux
+          \`\`\`
+
+          ## Checksums (SHA-256)
+
+          | Asset | Digest |
+          |---|---|
+          | hestia-x86_64-linux | \`${sha256_x86_64}\` |
+          | hestia-aarch64-linux | \`${sha256_aarch64}\` |
+          EOF
+
           gh release create "$tag" \
             --repo "$GITHUB_REPOSITORY" \
             --title "$tag" \
+            --notes-file notes.md \
             --generate-notes \
             "${prerelease[@]}" \
             hestia-*

--- a/PLAN.md
+++ b/PLAN.md
@@ -760,6 +760,21 @@ continues from / interleaves with the Open Questions section above.
     installs Determinate Nix by default); the NixOS-org fork tracks
     upstream. It publishes no version tags yet, so it is pinned `@main`.
 
+28. **The real cache service is eventually consistent for lookups**
+    (Phase 6, real-API finding; surfaced as flaky token-probe runs).
+    GetCacheEntryDownloadURL may not return a just-finalized entry, and a
+    prefix lookup may return version N-1 shortly after N was committed.
+    Reservations (CreateCacheEntry) are strongly consistent — conflicts are
+    always detected. Consequences: (a) the real-API tests poll
+    read-after-write assertions instead of asserting immediately; (b)
+    SaveMutable's stale-skip window was widened to 60s (20 × 3s) so
+    propagation lag is never misdiagnosed as a crashed writer; (c)
+    everything else already tolerates lag by design — a stale read is a
+    cache miss (rebuild), never corruption, and packs referenced by a
+    manifest are always uploaded *before* the manifest commit. The fake
+    backend stays strongly consistent on purpose: simulating lag everywhere
+    would buy little coverage at a high test-complexity cost.
+
 ## Mistakes Fixed from Earlier Draft
 
 | Was | Now | Why |

--- a/PLAN.md
+++ b/PLAN.md
@@ -292,7 +292,7 @@ Decisions (8–9).
       Range-read a slice of it; delete it via REST.** Passing in CI
       (`tests/gha_real.rs` in the `token-probe` job). The test uses 256 KB;
       bumping to 100 MB is still worthwhile once uploads get exercised by
-      the dogfood job.
+      dogfooding.
 
 ### Phase 2: Manifest + chunker
 
@@ -388,10 +388,12 @@ the merge to main. Deviations and findings recorded under Decisions
 - [x] **Milestone: substitution from the real GHA cache on a real runner.**
       The `action-test` CI job builds a run-unique derivation through the
       post-build-hook, drains, and `nix copy`s the path back out of the
-      cache into a fresh store. Full-CI dogfooding (the `dogfood` job:
-      hestia's CI caches its own devshell builds) remains gated behind the
-      repository variable `HESTIA_DOGFOOD` until enabled on main after
-      human review.
+      cache into a fresh store. Full dogfooding (the regular `build` CI
+      job runs `nix build .#` through hestia, so cache breakage breaks CI)
+      remains gated behind the `HESTIA_DOGFOOD` repository variables until
+      the first release exists — the daemon must be bootstrapped from a
+      released binary, since the build job cannot use the package it is
+      about to build.
 
 ### Phase 5: GC
 
@@ -452,10 +454,12 @@ Decisions (21–27).
 
 **Pending (needs merge to main / human decision):**
 
-- Enable the `dogfood` job on main (set repository variable
-  `HESTIA_DOGFOOD=true` after the merge)
 - Create the first release: tag `v0.1.0-alpha.1` on main, verify the
   release workflow, then update the sha256 in the README/action examples
+- Enable dogfooding (after the release): set the repository variables
+  `HESTIA_DOGFOOD=true`, `HESTIA_DOGFOOD_VERSION=<tag>`,
+  `HESTIA_DOGFOOD_SHA256=<sha256 of hestia-x86_64-linux>` so the regular
+  `build` job runs its `nix build .#` through hestia
 - nix-community migration (repository transfer + harmonia crates on
   crates.io would remove the git-dependency pin)
 
@@ -519,10 +523,12 @@ tokens:
 - **Crash safety**: kill the pipeline between every pair of steps →
   invariants hold (old packs referenced until manifest commit, orphans
   cleaned next run).
-- **Dogfooding**: from Phase 4 on, hestia's own CI uses hestia (the
-  `dogfood` job in ci.yml; disabled until the first push, marker
-  `enabled-after-first-push`). Cache misses, corruption, and eviction
-  handling show up as slow or failing builds immediately.
+- **Dogfooding**: hestia's own CI uses hestia. The regular `build` job in
+  ci.yml wraps `nix build .#` with the hestia action (gated on the
+  `HESTIA_DOGFOOD` repository variables; the step is skipped instantly
+  while they are unset). Once enabled, cache misses, corruption, and
+  eviction handling show up as slow or failing regular CI — the strongest
+  possible signal.
 
 No NixOS VM test: it cannot have real tokens (so it would test the fake
 backend — same coverage as layer 2/3, slower), and the "clean store"

--- a/PLAN.md
+++ b/PLAN.md
@@ -774,12 +774,19 @@ continues from / interleaves with the Open Questions section above.
     always detected. Consequences: (a) the real-API tests poll
     read-after-write assertions instead of asserting immediately; (b)
     SaveMutable's stale-skip window was widened to 60s (20 × 3s) so
-    propagation lag is never misdiagnosed as a crashed writer; (c)
-    everything else already tolerates lag by design — a stale read is a
-    cache miss (rebuild), never corruption, and packs referenced by a
-    manifest are always uploaded *before* the manifest commit. The fake
-    backend stays strongly consistent on purpose: simulating lag everywhere
-    would buy little coverage at a high test-complexity cost.
+    propagation lag is never misdiagnosed as a crashed writer; (c) the
+    daemon practices **read-your-writes**: the pipeline publishes the
+    manifest it committed directly into the substituter's `ManifestStore`
+    (instead of re-loading it from the cache, which returned a stale
+    version and made just-pushed paths 404 — caught by the action-test CI
+    job), folds that manifest into every later merge base, and passes its
+    version to `SaveMutable::save_with_floor` so a drain never fights its
+    own previous commit in the conflict loop; (d) everything else
+    tolerates lag by design — a stale read is a cache miss (rebuild),
+    never corruption, and packs referenced by a manifest are always
+    uploaded *before* the manifest commit. The fake backend simulates lag
+    only behind the `stale-lookups` injection endpoint; everything else
+    stays strongly consistent.
 
 ## Mistakes Fixed from Earlier Draft
 

--- a/src/gha/savemutable.rs
+++ b/src/gha/savemutable.rs
@@ -169,13 +169,27 @@ impl<'a> SaveMutable<'a> {
     /// contents. It may be called multiple times: every conflict with a
     /// concurrent writer triggers a re-load and re-merge so no writer's
     /// changes get lost. Returns the index of the newly written version.
-    pub async fn save<F>(&self, mut merge: F) -> Result<u64, Error>
+    pub async fn save<F>(&self, merge: F) -> Result<u64, Error>
+    where
+        F: FnMut(Option<&MutableEntry>) -> Result<Vec<u8>, Error>,
+    {
+        self.save_with_floor(0, merge).await
+    }
+
+    /// Like [`Self::save`], but never reserves an index at or below `floor`.
+    ///
+    /// Callers that know a version `floor` exists (because they committed
+    /// it themselves) pass it here so that an eventually-consistent load
+    /// (PLAN.md Decision 28) — which may still return an older version —
+    /// does not make the writer reserve an index that is already taken and
+    /// spin in the conflict loop until the lookup catches up.
+    pub async fn save_with_floor<F>(&self, floor: u64, mut merge: F) -> Result<u64, Error>
     where
         F: FnMut(Option<&MutableEntry>) -> Result<Vec<u8>, Error>,
     {
         let mut attempts: u32 = 0;
         // Indexes at or below this are blocked by (presumably crashed) writers.
-        let mut skip_through: u64 = 0;
+        let mut skip_through: u64 = floor;
         let mut last_conflict: Option<u64> = None;
         let mut conflict_streak: u32 = 0;
 

--- a/src/gha/savemutable.rs
+++ b/src/gha/savemutable.rs
@@ -16,6 +16,16 @@
 //! crashes between reserve and finalize would deadlock the sequence. After
 //! `stale_skip_after` consecutive conflicts on the same index the writer
 //! assumes a crashed peer and skips over that index.
+//!
+//! Consistency model (verified against the real service, PLAN.md Decision
+//! 28): **reservations are strongly consistent** (two writers can never both
+//! reserve the same key) but **lookups are eventually consistent** (a
+//! just-finalized entry may not be returned by load() for a while). The
+//! conflict-retry loop therefore re-loads until it sees the version that
+//! blocked it; the stale-skip window must be comfortably larger than the
+//! observed propagation lag, otherwise lag would be misdiagnosed as a
+//! crashed writer and the lagging version's changes dropped (benign for a
+//! lossy cache — those paths get rebuilt — but wasteful).
 
 use std::time::Duration;
 
@@ -82,9 +92,12 @@ impl<'a> SaveMutable<'a> {
             twirp,
             http,
             prefix: prefix.into(),
-            retry_delay: Duration::from_secs(2),
+            retry_delay: Duration::from_secs(3),
             max_attempts: 60,
-            stale_skip_after: 5,
+            // 20 conflicts x 3s = 60s before an index is judged abandoned:
+            // far above the lookup propagation lag observed in CI, so a
+            // finalized-but-not-yet-visible version is never skipped over.
+            stale_skip_after: 20,
         }
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -26,6 +26,7 @@ use crate::gha::{Error as GhaError, blob};
 use crate::manifest::{Manifest, PackInfo, PathEntry, PathHash, Root};
 use crate::pathinfo::{Error as PathInfoError, Lookup, PathInfo, StoreDatabase};
 use crate::protocol::DrainStats;
+use crate::substituter::ManifestStore;
 use crate::upstream::UpstreamFilter;
 
 /// SaveMutable family prefix for the manifest ("m" → keys `m#1`, `m#2`, …).
@@ -190,6 +191,14 @@ pub struct PipelineContext {
     /// SaveMutable family prefix (always [`MANIFEST_PREFIX`] in production;
     /// tests use distinct prefixes to isolate scenarios).
     pub manifest_prefix: String,
+    /// Where committed manifests are published for the substituter.
+    ///
+    /// Read-your-writes: the cache service's lookups are eventually
+    /// consistent (PLAN.md Decision 28), so re-loading the manifest right
+    /// after a commit can return a stale version that misses the paths
+    /// this very drain just pushed. Publishing the committed manifest
+    /// directly guarantees the substituter can serve them immediately.
+    pub publish: Option<ManifestStore>,
 }
 
 /// One new path, fully prepared for upload.
@@ -209,9 +218,15 @@ impl PipelineContext {
     /// Load the current manifest, or an empty one if none exists yet or
     /// the stored blob is corrupt (see [`decode_manifest_or_empty`]).
     pub async fn load_manifest(&self) -> Result<Manifest, Error> {
+        Ok(self.load_manifest_versioned().await?.1)
+    }
+
+    /// Like [`Self::load_manifest`], but also returns the SaveMutable index
+    /// the manifest was loaded from (0 when none exists yet).
+    pub async fn load_manifest_versioned(&self) -> Result<(u64, Manifest), Error> {
         match self.save_mutable().load().await? {
-            Some(entry) => Ok(decode_manifest_or_empty(&entry.data)),
-            None => Ok(Manifest::new()),
+            Some(entry) => Ok((entry.index, decode_manifest_or_empty(&entry.data))),
+            None => Ok((0, Manifest::new())),
         }
     }
 
@@ -236,6 +251,16 @@ impl PipelineContext {
         }
 
         let current = self.load_manifest().await?;
+
+        // Read-your-writes (PLAN.md Decision 28): cache lookups may lag
+        // behind this daemon's own commits, so fold in the manifest we are
+        // currently serving (it is at least as new as anything we wrote)
+        // and remember its version as the reservation floor.
+        let (known_version, known) = match &self.publish {
+            Some(store) => store.versioned(),
+            None => (0, Manifest::new()),
+        };
+        let current = current.merge(known.clone());
 
         // ---- query the store database (blocking sqlite I/O) -----------------
         let store = self.store.clone();
@@ -391,22 +416,34 @@ impl PipelineContext {
         );
 
         // ---- commit (re-merge on conflict) ------------------------------------
+        // The merge closure keeps the manifest it encoded so the committed
+        // version can be published without re-loading it from the cache.
+        let mut committed: Option<Manifest> = None;
         let version = self
             .save_mutable()
-            .save(|existing| {
+            .save_with_floor(known_version, |existing| {
                 // A corrupt base manifest is replaced, not merged with: the
                 // commit must not fail because of it (never crash CI).
                 let base = match existing {
                     Some(entry) => decode_manifest_or_empty(&entry.data),
                     None => Manifest::new(),
                 };
-                let merged = base.merge(delta.clone());
-                merged
+                // `known` covers the gap when `existing` is a stale read.
+                let merged = base.merge(known.clone()).merge(delta.clone());
+                let encoded = merged
                     .encode()
-                    .map_err(|err| GhaError::InvalidResponse(err.to_string()))
+                    .map_err(|err| GhaError::InvalidResponse(err.to_string()))?;
+                committed = Some(merged);
+                Ok(encoded)
             })
             .await?;
         stats.manifest_version = version;
+
+        // Publish exactly what was committed (includes concurrent writers'
+        // paths, since the merge ran against the latest visible version).
+        if let (Some(store), Some(manifest)) = (&self.publish, committed) {
+            store.set_version(manifest, version);
+        }
 
         Ok(stats)
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -98,17 +98,10 @@ impl DaemonState {
         match self.pipeline.run(paths.clone(), accessed, now_unix()).await {
             Ok(stats) => {
                 self.touch();
-                // Publish the new manifest to the substituter. Reload from
-                // the cache (instead of keeping the local merge result) so
-                // paths committed by concurrent jobs become servable too.
-                if stats.manifest_version > 0 {
-                    match self.pipeline.load_manifest().await {
-                        Ok(manifest) => self.manifest_store.set(manifest),
-                        Err(err) => eprintln!(
-                            "hestia serve: reloading the manifest after a drain failed: {err}"
-                        ),
-                    }
-                }
+                // The pipeline publishes the committed manifest into the
+                // shared ManifestStore itself (read-your-writes; reloading
+                // from the cache here could return a stale version, see
+                // PLAN.md Decision 28).
                 Ok(stats)
             }
             Err(err) => {
@@ -158,10 +151,16 @@ impl Daemon {
     pub fn bind(
         socket: &Path,
         idle_exit: Option<Duration>,
-        pipeline: PipelineContext,
+        mut pipeline: PipelineContext,
         access_log: AccessLog,
         manifest_store: ManifestStore,
     ) -> std::io::Result<Self> {
+        // Committed manifests go straight into the substituter's store:
+        // re-loading from the cache after a drain could return a stale
+        // version (eventual consistency, PLAN.md Decision 28) and make
+        // just-pushed paths unsubstitutable.
+        pipeline.publish = Some(manifest_store.clone());
+
         if let Some(parent) = socket.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -337,14 +336,18 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         upstream,
         root_key: pipeline::root_key(&branch, &system),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
+        // Replaced by Daemon::bind with the daemon's shared ManifestStore.
+        publish: None,
     };
 
     // Load the manifest committed by previous runs so the substituter can
     // serve those paths from the start. No manifest yet (first run) or a
     // load failure both mean "serve nothing until the first drain".
     let manifest_store = ManifestStore::new();
-    match pipeline.load_manifest().await {
-        Ok(manifest) => manifest_store.set(manifest),
+    match pipeline.load_manifest_versioned().await {
+        // Recording the version makes drains start their reservations
+        // above it even when cache lookups lag (PLAN.md Decision 28).
+        Ok((version, manifest)) => manifest_store.set_version(manifest, version),
         Err(err) => {
             eprintln!("hestia serve: cannot load the manifest, substituting nothing: {err}");
         }

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -73,10 +73,13 @@ struct ManifestView {
     /// NAR hash → manifest path key, for `/nar/{narhash}.nar` requests that
     /// arrive without the `?hash=` parameter.
     by_nar_hash: BTreeMap<Hash32, PathHash>,
+    /// SaveMutable index this manifest was loaded from / committed as
+    /// (0 = unknown or no manifest yet).
+    version: u64,
 }
 
 impl ManifestView {
-    fn new(manifest: Manifest) -> Self {
+    fn new(manifest: Manifest, version: u64) -> Self {
         let by_nar_hash = manifest
             .paths
             .iter()
@@ -85,6 +88,7 @@ impl ManifestView {
         Self {
             manifest,
             by_nar_hash,
+            version,
         }
     }
 }
@@ -103,10 +107,24 @@ impl ManifestStore {
         Self::default()
     }
 
-    /// Replace the served manifest.
+    /// Replace the served manifest (version unknown).
     pub fn set(&self, manifest: Manifest) {
+        self.set_version(manifest, 0);
+    }
+
+    /// Replace the served manifest, recording the SaveMutable index it came
+    /// from. The version is what the pipeline uses for read-your-writes
+    /// (PLAN.md Decision 28): it merges this manifest into every commit
+    /// base and never reserves an index at or below it.
+    pub fn set_version(&self, manifest: Manifest, version: u64) {
         *self.inner.write().expect("manifest lock poisoned") =
-            Arc::new(ManifestView::new(manifest));
+            Arc::new(ManifestView::new(manifest, version));
+    }
+
+    /// The served manifest and its version (clone; manifests are small).
+    pub fn versioned(&self) -> (u64, Manifest) {
+        let view = self.view();
+        (view.version, view.manifest.clone())
     }
 
     fn view(&self) -> Arc<ManifestView> {

--- a/tests/failure_modes.rs
+++ b/tests/failure_modes.rs
@@ -42,6 +42,7 @@ fn context(fake: &FakeGha, http: &reqwest::Client, store: &ScratchStore) -> Pipe
         upstream: UpstreamFilter::default(),
         root_key: TEST_ROOT_KEY.to_string(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
+        publish: None,
     }
 }
 
@@ -483,6 +484,132 @@ async fn concurrent_serve_daemons_merge_without_losing_paths() {
         let manifest_store = hestia::substituter::ManifestStore::new();
         manifest_store.set(manifest);
         assert_eq!(manifest_store.path_count(), 2);
+    };
+    tokio::time::timeout(Duration::from_secs(120), test)
+        .await
+        .expect("test timed out: deadlock or hung server");
+}
+
+// ---------------------------------------------------------------------------
+// Eventual consistency (read-your-writes)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn drained_paths_are_substitutable_despite_lookup_lag() {
+    // The real cache service is eventually consistent (PLAN.md Decision
+    // 28): right after a drain commits manifest m#N, lookups may still
+    // return m#N-1 (or nothing). Three guarantees under that lag:
+    //
+    // 1. paths pushed by THIS daemon are substitutable immediately
+    //    (read-your-writes: the daemon publishes the manifest it
+    //    committed instead of re-loading it from the cache);
+    // 2. a second drain (the action's post step) commits the next version
+    //    promptly instead of fighting its own previous commit in the
+    //    SaveMutable conflict loop;
+    // 3. the second commit still contains the first one's paths (the
+    //    daemon's own manifest is part of every merge base).
+    //
+    // Regression test for the failure the action-test CI job hit: drain
+    // succeeded, but the narinfo request that followed got a 404.
+    let test = async {
+        let Some(store) = ScratchStore::create() else {
+            return;
+        };
+        let fixture = store.add_fixture("lag", 257);
+
+        let fake = FakeGha::start().await;
+        let http = reqwest::Client::new();
+
+        // Start a daemon + substituter sharing a ManifestStore, exactly
+        // like `hestia serve` wires them.
+        let manifest_store = hestia::substituter::ManifestStore::new();
+        let access_log = AccessLog::new();
+        let socket: PathBuf = store.db_path().parent().unwrap().join("hestia-lag.sock");
+        let daemon = hestia::serve::Daemon::bind(
+            &socket,
+            None,
+            context(&fake, &http, &store),
+            access_log.clone(),
+            manifest_store.clone(),
+        )
+        .expect("daemon must bind");
+        let substituter = hestia::substituter::Substituter::new(
+            store.database().store_dir().clone(),
+            manifest_store.clone(),
+            access_log,
+            fake.twirp(&http),
+            http.clone(),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, substituter.into_router())
+                .await
+                .unwrap();
+        });
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let daemon_handle = tokio::spawn(daemon.run(async {
+            let _ = shutdown_rx.await;
+        }));
+
+        // All lookups lag one version behind from here on (the real
+        // service's observed behavior right after a commit).
+        fake.set_stale_lookups(&http, true).await;
+
+        // Hook + drain the path through the daemon (commits m#1; lookups
+        // now pretend m#1 does not exist yet).
+        hestia::protocol::roundtrip(
+            &socket,
+            &hestia::protocol::Request::Add {
+                paths: vec![fixture.to_string_lossy().into_owned()],
+            },
+        )
+        .await
+        .expect("add failed");
+        let response = hestia::protocol::roundtrip(&socket, &hestia::protocol::Request::Drain)
+            .await
+            .expect("drain failed");
+        let stats = response.stats.expect("drain stats");
+        assert_eq!(stats.pushed, 1);
+        assert_eq!(stats.manifest_version, 1);
+
+        // Guarantee 1: the just-pushed path is substitutable right away.
+        let hash = path_hash_of(&fixture);
+        let narinfo = http
+            .get(format!("{base_url}/{hash}.narinfo"))
+            .send()
+            .await
+            .expect("narinfo request failed");
+        assert_eq!(
+            narinfo.status(),
+            200,
+            "a path pushed by this daemon must be servable immediately \
+             (read-your-writes), regardless of lookup propagation lag"
+        );
+
+        // Guarantee 2: the shutdown drain (root update from the narinfo
+        // hit) commits m#2 promptly. Without the reservation floor it
+        // would spin in the conflict loop against its own m#1 until the
+        // stale-skip window (60s in production) expired — the whole test
+        // would blow its timeout.
+        drop(shutdown_tx);
+        let final_stats = daemon_handle.await.unwrap().expect("final drain failed");
+        assert_eq!(
+            final_stats.manifest_version, 2,
+            "the post-step drain must commit the next version"
+        );
+
+        // Guarantee 3: m#2 still contains the path pushed in m#1 — the
+        // stale merge base was healed with the daemon's own manifest.
+        server.abort();
+        fake.set_stale_lookups(&http, false).await;
+        let (version, manifest) = committed_manifest(&fake, &http).await.unwrap();
+        assert_eq!(version, 2);
+        assert!(
+            manifest.paths.contains_key(&hash),
+            "the second commit must not lose the first commit's paths"
+        );
+        assert!(manifest.roots[TEST_ROOT_KEY].paths.contains(&hash));
     };
     tokio::time::timeout(Duration::from_secs(120), test)
         .await

--- a/tests/gha_real.rs
+++ b/tests/gha_real.rs
@@ -11,13 +11,38 @@
 //! They exercise the same scenarios as `tests/gha_fake.rs` to catch drift
 //! between the fake and the real service.
 
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
 
 use hestia::gha::blob;
 use hestia::gha::rest::RestClient;
 use hestia::gha::twirp::{DownloadUrl, Reservation, TwirpClient};
+
+/// The real service is eventually consistent: a just-finalized entry can
+/// take a while to become visible to GetCacheEntryDownloadURL (observed in
+/// CI: sometimes instant, sometimes several seconds). Hestia's design
+/// tolerates this (a lagging read is a cache miss, never corruption), but
+/// read-after-write assertions in these tests must poll.
+const PROPAGATION_TIMEOUT: Duration = Duration::from_secs(120);
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Poll `lookup` until `accept` returns true for its result or the
+/// propagation timeout expires; returns the last result either way.
+async fn wait_for<F, Fut>(mut lookup: F, accept: impl Fn(&DownloadUrl) -> bool) -> DownloadUrl
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = DownloadUrl>,
+{
+    let deadline = std::time::Instant::now() + PROPAGATION_TIMEOUT;
+    loop {
+        let result = lookup().await;
+        if accept(&result) || std::time::Instant::now() >= deadline {
+            return result;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
 
 /// Unique key per test run so re-runs never collide with old entries
 /// (cache keys are write-once).
@@ -65,13 +90,20 @@ async fn real_blob_round_trip_range_read_and_delete() {
         .unwrap();
 
     // Reserving the same key again must report AlreadyExists (CAS dedup).
+    // Unlike lookups, reservations are strongly consistent: this is what
+    // SaveMutable's conflict detection relies on.
     let reservation = twirp.create_cache_entry(&key).await.unwrap();
     assert_eq!(reservation, Reservation::AlreadyExists);
 
-    // Full download.
-    let DownloadUrl::Hit { url, matched_key } = twirp.get_download_url(&key, &[]).await.unwrap()
-    else {
-        panic!("just-finalized entry not found");
+    // Full download. Lookups are eventually consistent: poll until the
+    // just-finalized entry becomes visible.
+    let lookup = wait_for(
+        || async { twirp.get_download_url(&key, &[]).await.unwrap() },
+        |result| matches!(result, DownloadUrl::Hit { .. }),
+    )
+    .await;
+    let DownloadUrl::Hit { url, matched_key } = lookup else {
+        panic!("just-finalized entry not found after {PROPAGATION_TIMEOUT:?}");
     };
     assert_eq!(matched_key, key);
     let downloaded = blob::get(&http, &url, None).await.unwrap();
@@ -96,16 +128,22 @@ async fn real_blob_round_trip_range_read_and_delete() {
         "uploaded entry missing from REST list: {listed:?}"
     );
 
-    // ...and REST delete removes it for real.
+    // ...and REST delete removes it for real (deletes propagate eventually,
+    // like lookups).
     let deleted = rest.delete_by_key(&key).await.unwrap();
     assert!(
         deleted.iter().any(|entry| entry.key == key),
         "delete did not report the entry: {deleted:?}"
     );
+    let lookup = wait_for(
+        || async { twirp.get_download_url(&key, &[]).await.unwrap() },
+        |result| matches!(result, DownloadUrl::Miss),
+    )
+    .await;
     assert_eq!(
-        twirp.get_download_url(&key, &[]).await.unwrap(),
+        lookup,
         DownloadUrl::Miss,
-        "entry still downloadable after REST delete"
+        "entry still downloadable after REST delete + propagation timeout"
     );
 }
 
@@ -142,15 +180,26 @@ async fn real_miss_and_restore_key_prefix() {
             .unwrap();
     }
 
+    // Newest-wins is also subject to propagation lag: right after
+    // finalizing #2, the lookup may still return #1 (or nothing). This is
+    // exactly why SaveMutable detects conflicts at reservation time (which
+    // is strongly consistent) instead of trusting load() to be fresh.
     let prefix = format!("{family}#");
-    let DownloadUrl::Hit { url, matched_key } = twirp
-        .get_download_url(&prefix, &[prefix.as_str()])
-        .await
-        .unwrap()
-    else {
-        panic!("prefix restore lookup missed");
+    let expected_key = format!("{family}#2");
+    let lookup = wait_for(
+        || async {
+            twirp
+                .get_download_url(&prefix, &[prefix.as_str()])
+                .await
+                .unwrap()
+        },
+        |result| matches!(result, DownloadUrl::Hit { matched_key, .. } if *matched_key == expected_key),
+    )
+    .await;
+    let DownloadUrl::Hit { url, matched_key } = lookup else {
+        panic!("prefix restore lookup missed after {PROPAGATION_TIMEOUT:?}");
     };
-    assert_eq!(matched_key, format!("{family}#2"), "newest entry must win");
+    assert_eq!(matched_key, expected_key, "newest entry must win");
     let data = blob::get(&http, &url, None).await.unwrap();
     assert_eq!(data.as_ref(), b"payload v2");
 

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -31,6 +31,7 @@ fn context(fake: &FakeGha, http: &reqwest::Client, store: StoreDatabase) -> Pipe
         upstream: UpstreamFilter::default(),
         root_key: TEST_ROOT_KEY.to_string(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
+        publish: None,
     }
 }
 

--- a/tests/serve_daemon.rs
+++ b/tests/serve_daemon.rs
@@ -38,6 +38,7 @@ fn pipeline_context(
         upstream: UpstreamFilter::default(),
         root_key: TEST_ROOT_KEY.to_string(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
+        publish: None,
     }
 }
 

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -46,6 +46,7 @@ fn pipeline_context(
         upstream: UpstreamFilter::default(),
         root_key: TEST_ROOT_KEY.to_string(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
+        publish: None,
     }
 }
 

--- a/tests/support/fake_gha.rs
+++ b/tests/support/fake_gha.rs
@@ -20,6 +20,9 @@
 //!   every later one gets HTTP 401 (expired `ACTIONS_RUNTIME_TOKEN`).
 //! * `POST /test/fail-blob-reads/{n}`: the next `n` blob downloads get their
 //!   connection dropped mid-body (Azure timeout / connection reset).
+//! * `POST /test/stale-lookups/{0|1}`: download lookups hide the newest
+//!   matching entry (eventual consistency: a just-finalized entry is not
+//!   visible yet).
 //! * `POST /test/exhaust-quota-after/{n}`: the next `n` CreateCacheEntry
 //!   calls succeed, every later one gets a `resource_exhausted` Twirp error
 //!   (the 10 GB repository cache quota is full).
@@ -81,6 +84,9 @@ struct Inner {
     creates_until_quota: Option<u64>,
     /// Number of upcoming blob GETs whose connection gets dropped mid-body.
     blob_read_failures: u64,
+    /// When set, download lookups pretend the newest matching entry does
+    /// not exist yet (simulates the real service's eventual consistency).
+    stale_lookups: bool,
 }
 
 impl Inner {
@@ -223,12 +229,16 @@ async fn twirp_download_url(State(state): State<AppState>, body: Bytes) -> Respo
     // entries that exist. Clients must send the key as a restore key
     // (go-actions-cache does the same).
     let matched = request.restore_keys.iter().find_map(|prefix| {
-        inner
+        let mut matching: Vec<&Entry> = inner
             .entries
             .iter()
             .filter(|e| e.finalized && e.version == request.version && e.key.starts_with(prefix))
-            .max_by_key(|e| e.created_at)
-            .cloned()
+            .collect();
+        matching.sort_by_key(|e| std::cmp::Reverse(e.created_at));
+        // Eventual-consistency injection: the newest entry is not visible
+        // yet, so the lookup returns the previous one (or misses).
+        let skip = usize::from(inner.stale_lookups);
+        matching.get(skip).copied().cloned()
     });
 
     match matched {
@@ -518,6 +528,11 @@ async fn test_fail_blob_reads(State(state): State<AppState>, Path(reads): Path<u
     Json(json!({ "blob_read_failures": reads })).into_response()
 }
 
+async fn test_stale_lookups(State(state): State<AppState>, Path(on): Path<u8>) -> Response {
+    state.inner.lock().unwrap().stale_lookups = on != 0;
+    Json(json!({ "stale_lookups": on != 0 })).into_response()
+}
+
 // ---------------------------------------------------------------------------
 // Server wiring
 // ---------------------------------------------------------------------------
@@ -553,6 +568,7 @@ impl FakeGha {
             twirp_calls_until_401: None,
             creates_until_quota: None,
             blob_read_failures: 0,
+            stale_lookups: false,
         }));
         let state = AppState {
             inner: Arc::clone(&inner),
@@ -578,6 +594,7 @@ impl FakeGha {
                 post(test_exhaust_quota_after),
             )
             .route("/test/fail-blob-reads/{reads}", post(test_fail_blob_reads))
+            .route("/test/stale-lookups/{on}", post(test_stale_lookups))
             .with_state(state);
 
         let task = tokio::spawn(async move {
@@ -661,6 +678,15 @@ impl FakeGha {
             .send()
             .await
             .expect("fail-blob-reads request");
+        assert!(response.status().is_success());
+    }
+
+    /// Toggle eventual-consistency simulation: while on, download lookups
+    /// hide the newest matching entry (a just-finalized entry is "not
+    /// visible yet").
+    pub async fn set_stale_lookups(&self, http: &reqwest::Client, on: bool) {
+        let url = format!("{}/test/stale-lookups/{}", self.base_url, u8::from(on));
+        let response = http.post(&url).send().await.expect("stale-lookups request");
         assert!(response.status().is_success());
     }
 }


### PR DESCRIPTION
Follow-up commits that landed after PR #1 was merged:

* **Handle eventual consistency of the real cache service** — fixes the flaky `token-probe` job currently failing on `main` (lookups can lag behind finalization; see PLAN.md Decision 28).
* **Dogfood through the regular package build job** — removes the standalone dogfood job; the new `build` job wraps `nix build .#` with the hestia action, gated on the `HESTIA_DOGFOOD` repository variables.
* **Generate copy-paste release notes with checksums** — release notes include the sha256 values the action needs.

After merging: tag `v0.1.0-alpha.1` to create the first release, then set `HESTIA_DOGFOOD`/`HESTIA_DOGFOOD_VERSION`/`HESTIA_DOGFOOD_SHA256` to enable dogfooding.