### PR TITLE
Remove dead code

### DIFF
--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -170,15 +170,6 @@ impl PackBuilder {
         self.chunks.is_empty()
     }
 
-    /// Current compressed size of the pack under construction.
-    pub fn size(&self) -> u64 {
-        self.buffer.len() as u64
-    }
-
-    pub fn chunk_count(&self) -> usize {
-        self.chunks.len()
-    }
-
     /// Finalize: the pack hash is the SHA-256 of the complete blob, which
     /// makes packs content-addressed (`pack-{hash}` cache keys).
     pub fn finish(self) -> Pack {

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -218,19 +218,6 @@ impl GcPlan {
         self.repack_jobs.iter().map(RepackJob::upload_bytes).sum()
     }
 
-    /// True when executing this plan would perform no cache operation.
-    /// (The manifest may still be committed to record mark-phase clocks.)
-    pub fn is_noop(&self) -> bool {
-        self.evicted_packs.is_empty()
-            && self.heal_paths.is_empty()
-            && self.drop_roots.is_empty()
-            && self.drop_paths.is_empty()
-            && self.touch_packs.is_empty()
-            && self.repack_jobs.is_empty()
-            && self.delete_packs.is_empty()
-            && self.orphan_keys.is_empty()
-    }
-
     /// One-line human summary for logs and `--dry-run`.
     pub fn summary(&self) -> String {
         format!(
@@ -1576,7 +1563,11 @@ mod tests {
             .build();
 
         let plan = plan(&manifest, &observe_all(&manifest, NOW), NOW, &policy());
-        assert!(plan.is_noop(), "{}", plan.summary());
+        let noop = GcPlan {
+            now: NOW,
+            ..GcPlan::default()
+        };
+        assert_eq!(plan, noop, "{}", plan.summary());
     }
 
     // -----------------------------------------------------------------------
@@ -1741,6 +1732,10 @@ mod tests {
         let (committed, _) = apply(manifest, &first, &repacks);
 
         let second = plan(&committed, &observe_all(&committed, NOW), NOW, &policy());
-        assert!(second.is_noop(), "second plan: {}", second.summary());
+        let noop = GcPlan {
+            now: NOW,
+            ..GcPlan::default()
+        };
+        assert_eq!(second, noop, "second plan: {}", second.summary());
     }
 }

--- a/src/gha/rest.rs
+++ b/src/gha/rest.rs
@@ -166,15 +166,6 @@ pub struct CacheList {
     pub actions_caches: Vec<CacheEntry>,
 }
 
-/// Repository cache usage (quota pressure signal for GC).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CacheUsage {
-    #[serde(default)]
-    pub full_name: String,
-    pub active_caches_count: u64,
-    pub active_caches_size_in_bytes: u64,
-}
-
 #[derive(Debug, Clone)]
 pub struct RestClient {
     http: reqwest::Client,
@@ -270,17 +261,6 @@ impl RestClient {
             }
             page += 1;
         }
-    }
-
-    /// Repository-wide cache usage (quota pressure).
-    pub async fn usage(&self) -> Result<CacheUsage, Error> {
-        let url = format!(
-            "{}/repos/{}/actions/cache/usage",
-            self.api_url.trim_end_matches('/'),
-            self.repo
-        );
-        let response = self.request(reqwest::Method::GET, &url).send().await?;
-        Self::check(&url, response).await
     }
 
     /// Delete all cache entries with exactly this key (across versions/refs).
@@ -380,17 +360,5 @@ mod tests {
         assert_eq!(list.actions_caches[0].key, "pack-abc123");
         assert_eq!(list.actions_caches[0].git_ref, "refs/heads/main");
         assert_eq!(list.actions_caches[0].size_in_bytes, 1024);
-    }
-
-    #[test]
-    fn usage_deserializes_github_response() {
-        let json = r#"{
-            "full_name": "nix-community/hestia",
-            "active_caches_size_in_bytes": 312329,
-            "active_caches_count": 5
-        }"#;
-        let usage: CacheUsage = serde_json::from_str(json).unwrap();
-        assert_eq!(usage.active_caches_count, 5);
-        assert_eq!(usage.active_caches_size_in_bytes, 312329);
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -420,29 +420,6 @@ impl Manifest {
             }
         }
     }
-
-    /// Liveness predicate (PLAN.md):
-    ///
-    /// ```text
-    /// live(path) := reachable from any root via references
-    ///            OR now - last_pushed < push_ttl
-    /// ```
-    ///
-    /// `reachable` is passed in so GC computes it once per run.
-    pub fn is_live(
-        &self,
-        path: &PathHash,
-        reachable: &BTreeSet<PathHash>,
-        now: u64,
-        push_ttl_secs: u64,
-    ) -> bool {
-        if reachable.contains(path) {
-            return true;
-        }
-        self.paths
-            .get(path)
-            .is_some_and(|entry| now.saturating_sub(entry.last_pushed) < push_ttl_secs)
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -907,36 +884,6 @@ mod tests {
             },
         );
         assert_eq!(manifest.reachable().len(), 2);
-    }
-
-    #[test]
-    fn liveness_is_reachable_or_recently_pushed() {
-        let mut manifest = Manifest::new();
-        manifest
-            .paths
-            .insert(path_hash(1), entry_with_refs(1, vec![], 1000)); // reachable
-        manifest
-            .paths
-            .insert(path_hash(2), entry_with_refs(2, vec![], 1000)); // recently pushed
-        manifest
-            .paths
-            .insert(path_hash(3), entry_with_refs(3, vec![], 10)); // neither
-        manifest.roots.insert(
-            "main".into(),
-            Root {
-                paths: BTreeSet::from([path_hash(1)]),
-                updated: 0,
-            },
-        );
-
-        let reachable = manifest.reachable();
-        let now = 2000;
-        let push_ttl = 1500;
-        assert!(manifest.is_live(&path_hash(1), &reachable, now, push_ttl));
-        assert!(manifest.is_live(&path_hash(2), &reachable, now, push_ttl));
-        assert!(!manifest.is_live(&path_hash(3), &reachable, now, push_ttl));
-        // Unknown path: not live.
-        assert!(!manifest.is_live(&path_hash(42), &reachable, now, push_ttl));
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -82,13 +82,6 @@ impl AccessLog {
     pub fn snapshot(&self) -> BTreeSet<PathHash> {
         self.inner.lock().expect("access log lock poisoned").clone()
     }
-
-    pub fn is_empty(&self) -> bool {
-        self.inner
-            .lock()
-            .expect("access log lock poisoned")
-            .is_empty()
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -475,14 +468,13 @@ mod tests {
     fn access_log_is_shared_between_clones() {
         let log = AccessLog::new();
         let clone = log.clone();
-        assert!(log.is_empty());
+        assert!(log.snapshot().is_empty());
 
         let hash: PathHash = "00000000000000000000000000000000"
             .parse()
             .expect("valid path hash");
         clone.record(hash);
 
-        assert!(!log.is_empty());
         assert_eq!(log.snapshot(), BTreeSet::from([hash]));
         // Recording the same hash twice is idempotent.
         log.record(hash);

--- a/tests/gha_fake.rs
+++ b/tests/gha_fake.rs
@@ -326,7 +326,7 @@ async fn savemutable_conflict_gives_up_eventually() {
 }
 
 #[tokio::test]
-async fn rest_list_pagination_usage_and_delete() {
+async fn rest_list_pagination_and_delete() {
     let fake = FakeGha::start().await;
     let http = reqwest::Client::new();
     let twirp = fake.twirp(&http);
@@ -347,11 +347,6 @@ async fn rest_list_pagination_usage_and_delete() {
 
     let everything = rest.list_caches("").await.unwrap();
     assert_eq!(everything.len(), 6);
-
-    // Usage reflects all finalized entries.
-    let usage = rest.usage().await.unwrap();
-    assert_eq!(usage.active_caches_count, 6);
-    assert_eq!(usage.active_caches_size_in_bytes, 5 * 100 + 8);
 
     // Delete one pack; it disappears from list and Twirp lookups.
     let deleted = rest.delete_by_key("pack-03").await.unwrap();

--- a/tests/gha_real.rs
+++ b/tests/gha_real.rs
@@ -208,18 +208,3 @@ async fn real_miss_and_restore_key_prefix() {
         let _ = rest.delete_by_key(&format!("{family}#{version}")).await;
     }
 }
-
-#[tokio::test]
-#[ignore = "requires real GHA cache tokens (run in CI)"]
-async fn real_rest_usage() {
-    let http = reqwest::Client::new();
-    let rest = rest_client(&http);
-
-    // Just verify the endpoint answers and the shape parses; actual values
-    // depend on whatever else the repository has cached.
-    let usage = rest.usage().await.unwrap();
-    assert!(
-        !usage.full_name.is_empty(),
-        "usage response missing repository name"
-    );
-}

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -289,7 +289,7 @@ async fn narinfo_miss_is_404() {
             .await;
         assert_eq!(response.status(), 404);
         // Misses are not liveness signals.
-        assert!(substituter.access_log.is_empty());
+        assert!(substituter.access_log.snapshot().is_empty());
 
         // Malformed requests are 404 too (never 500).
         for path in ["zzz.narinfo", "x", "nar/zzz.nar", "nar/x"] {

--- a/tests/support/fake_gha.rs
+++ b/tests/support/fake_gha.rs
@@ -8,7 +8,7 @@
 //!   GetCacheEntryDownloadURL, with real reservation semantics
 //!   (`already_exists` blocks reserved-but-unfinalized keys too).
 //! * Azure blob: PUT BlockBlob / GET with Range, gated on signed URLs.
-//! * GitHub REST: list (prefix + pagination) / usage / delete by key.
+//! * GitHub REST: list (prefix + pagination) / delete by key.
 //!
 //! Test-only injection endpoints simulate the failure modes GitHub will
 //! throw at us in production:
@@ -461,17 +461,6 @@ async fn rest_list(State(state): State<AppState>, Query(query): Query<ListQuery>
     .into_response()
 }
 
-async fn rest_usage(State(state): State<AppState>) -> Response {
-    let inner = state.inner.lock().unwrap();
-    let finalized: Vec<&Entry> = inner.entries.iter().filter(|e| e.finalized).collect();
-    Json(json!({
-        "full_name": "fake/repo",
-        "active_caches_count": finalized.len(),
-        "active_caches_size_in_bytes": finalized.iter().map(|e| e.size).sum::<u64>(),
-    }))
-    .into_response()
-}
-
 async fn rest_delete(State(state): State<AppState>, Query(query): Query<ListQuery>) -> Response {
     let mut inner = state.inner.lock().unwrap();
     let removed = inner.remove_by_key(&query.key);
@@ -582,7 +571,6 @@ impl FakeGha {
                 "/repos/{owner}/{repo}/actions/caches",
                 get(rest_list).delete(rest_delete),
             )
-            .route("/repos/{owner}/{repo}/actions/cache/usage", get(rest_usage))
             .route("/test/evict/{key}", post(test_evict))
             .route("/test/expire-urls", post(test_expire_urls))
             .route(

--- a/tests/support/sim.rs
+++ b/tests/support/sim.rs
@@ -57,7 +57,6 @@ pub fn test_data(len: usize, seed: u64) -> Bytes {
 pub struct SimPath {
     pub name: String,
     pub files: Vec<(String, Bytes)>,
-    pub references: Vec<StorePath>,
 }
 
 impl SimPath {
@@ -66,14 +65,7 @@ impl SimPath {
         Self {
             name: name.to_string(),
             files: vec![("blob".to_string(), test_data(size, seed))],
-            references: vec![],
         }
-    }
-
-    /// Record a runtime reference to another path (closure edge).
-    pub fn with_reference(mut self, other: &SimPath) -> Self {
-        self.references.push(other.store_path());
-        self
     }
 
     pub fn path_hash(&self) -> PathHash {
@@ -203,7 +195,7 @@ impl SimCache {
                     store_path: path.store_path(),
                     nar_hash,
                     nar_size,
-                    references: path.references.clone(),
+                    references: vec![],
                     ca: None,
                     deriver: None,
                     tree,


### PR DESCRIPTION

None of these had a production caller:

- PackBuilder::size() / chunk_count(): never called
- Manifest::is_live(): GC implements liveness inline in plan(); this
  copy only served its own unit test
- AccessLog::is_empty(): tests use snapshot().is_empty()
- GcPlan::is_noop(): tests compare against a default GcPlan instead
  (field-by-field equality is a stronger assertion)
- RestClient::usage() / CacheUsage, fake-GHA usage endpoint and tests:
  hestia never inspects repository quota; GC reacts to evictions
  instead of predicting them
- SimPath::with_reference() and the references field: no sim test
  builds closure edges; gc.rs unit tests cover reference reachability
