### PR TITLE
Build with crane and consolidate CI into nix flake check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,40 +9,13 @@ permissions:
   contents: read
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: NixOS/nix-installer-action@main
-      - name: Check formatting
-        run: nix fmt -- --ci
-      - name: Clippy
-        run: nix develop -c cargo clippy --all-targets -- -D warnings
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: NixOS/nix-installer-action@main
-      - name: Run tests
-        run: nix develop -c cargo test
-
-  # Build the hestia package. This is also the dogfooding job (Phase 4
-  # milestone): when the repository variables below are set, the package
-  # build runs through hestia itself — cache miss -> local build -> the
-  # post-build-hook pushes it; cache hit -> the build step is a pure
-  # substitution out of the GHA cache. Cache breakage then shows up as a
-  # slow or failing regular CI job, which is the strongest possible signal.
+  # Formatting, clippy, tests, and the package build, all as flake checks.
   #
-  # lint/test are NOT wrapped: they run cargo inside nix develop, and the
-  # devshell closure is upstream-signed (cache.nixos.org) which hestia
-  # deliberately skips. The package derivation built here (plus its vendor
-  # deps) is the only locally-built output of this CI.
-  #
-  # The daemon is bootstrapped from a *released* hestia binary, because this
-  # job cannot use the package it is about to build. Required repository
-  # variables (unset = the dogfood step is skipped instantly and the build
-  # runs without caching):
+  # Also the dogfood job: with the repository variables below set, these
+  # derivations are cached through hestia itself, so cache breakage shows
+  # up as slow or failing CI. The daemon is bootstrapped from a released
+  # binary (this job cannot use the package it is about to build); with
+  # the variables unset the dogfood step is skipped.
   #   HESTIA_DOGFOOD          "true"
   #   HESTIA_DOGFOOD_VERSION  release tag, e.g. "v0.1.0-alpha.1"
   #   HESTIA_DOGFOOD_SHA256   sha256 of that release's hestia-x86_64-linux
@@ -61,8 +34,8 @@ jobs:
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
           sha256: ${{ vars.HESTIA_DOGFOOD_SHA256 }}
-      - name: Build the hestia package
-        run: nix build .# --print-build-logs
+      - name: Run flake checks
+        run: nix flake check --print-build-logs
       - name: Show daemon log
         if: ${{ always() && vars.HESTIA_DOGFOOD == 'true' }}
         run: cat "$HESTIA_SERVE_LOG"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -590,7 +590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "harmonia-file-core"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "serde",
  "serde_json",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "harmonia-file-nar"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "bstr",
  "bytes",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-content-address"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "derive_more",
  "harmonia-store-path",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-db"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "harmonia-store-content-address",
  "harmonia-store-derivation",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-derivation"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-nar-info"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "harmonia-store-content-address",
  "harmonia-store-path",
@@ -872,7 +872,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-path"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "derive_more",
  "harmonia-utils-base-encoding",
@@ -885,7 +885,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-path-info"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "harmonia-store-content-address",
  "harmonia-store-path",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -907,7 +907,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -924,7 +924,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-io"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "bytes",
  "futures-util",
@@ -937,7 +937,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-signature"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba#3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba"
+source = "git+https://github.com/nix-community/harmonia?rev=bba51756f92a488d440e4c426747fb681abce4a7#bba51756f92a488d440e4c426747fb681abce4a7"
 dependencies = [
  "data-encoding",
  "ed25519-dalek",
@@ -1800,7 +1800,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1857,7 +1857,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2108,7 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2192,7 +2192,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2622,7 +2622,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,15 +61,15 @@ serde_json = "1"
 #                                    database reads (harmonia-store-db),
 #                                    which works without a running daemon
 #   harmonia-utils-base-encoding -> nothing needs raw base32 yet
-harmonia-file-core = { git = "https://github.com/nix-community/harmonia", rev = "3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba" }
-harmonia-file-nar = { git = "https://github.com/nix-community/harmonia", rev = "3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba" }
-harmonia-store-db = { git = "https://github.com/nix-community/harmonia", rev = "3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba" }
-harmonia-store-nar-info = { git = "https://github.com/nix-community/harmonia", rev = "3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba" }
-harmonia-store-path = { git = "https://github.com/nix-community/harmonia", rev = "3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba" }
-harmonia-store-path-info = { git = "https://github.com/nix-community/harmonia", rev = "3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba" }
-harmonia-utils-hash = { git = "https://github.com/nix-community/harmonia", rev = "3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba" }
-harmonia-utils-io = { git = "https://github.com/nix-community/harmonia", rev = "3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba" }
-harmonia-utils-signature = { git = "https://github.com/nix-community/harmonia", rev = "3ef11b5bcf6db6b645a3de672950b9c55bcdc2ba" }
+harmonia-file-core = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }
+harmonia-file-nar = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }
+harmonia-store-db = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }
+harmonia-store-nar-info = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }
+harmonia-store-path = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }
+harmonia-store-path-info = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }
+harmonia-utils-hash = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }
+harmonia-utils-io = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }
+harmonia-utils-signature = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }
 
 [dev-dependencies]
 # Property-based tests for manifest merge laws

--- a/PLAN.md
+++ b/PLAN.md
@@ -460,7 +460,7 @@ Decisions (21–27).
 - Enable dogfooding (after the release): set the repository variables
   `HESTIA_DOGFOOD=true`, `HESTIA_DOGFOOD_VERSION=<tag>`,
   `HESTIA_DOGFOOD_SHA256=<sha256 of hestia-x86_64-linux>` so the regular
-  `build` job runs its `nix build .#` through hestia
+  `build` job runs all its flake checks through hestia
 - nix-community migration (repository transfer + harmonia crates on
   crates.io would remove the git-dependency pin)
 
@@ -788,6 +788,16 @@ continues from / interleaves with the Open Questions section above.
     uploaded *before* the manifest commit. The fake backend simulates lag
     only behind the `stale-lookups` injection endpoint; everything else
     stays strongly consistent.
+
+29. **Builds use crane; CI is a single `nix flake check`** (Phase 6
+    follow-up). Crane keeps the dependency build in a separate derivation
+    keyed on Cargo.toml/Cargo.lock, so source-only commits recompile just
+    the hestia crate. Formatting, clippy, tests, and the package are flake
+    checks — cacheable locally and by the dogfood cache in CI. The test
+    check has `pkgs.nix` in the sandbox; the scratch-store integration
+    tests run there (only the two system-store oracle tests skip, covered
+    by the action-test job). The static release build stays on
+    buildRustPackage (nix/package.nix).
 
 ## Mistakes Fixed from Earlier Draft
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ into a cache miss (rebuild) — never into wrong build inputs.
 $ nix develop -c cargo test          # unit + integration tests (fake GHA backend)
 $ nix develop -c cargo clippy --all-targets -- -D warnings
 $ nix fmt                            # treefmt (rustfmt, nixfmt, prettier, ...)
+$ nix flake check                    # everything CI runs: fmt, clippy, tests, build
 $ nix build .#                       # the hestia binary
 $ nix build .#static                 # static (musl) release binary
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780099841,
+        "narHash": "sha256-EVZd2RsbpreRUDSi9rBwPY+ZxoyMaiEBbZxxhljbaS4=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0532eb17955225173906d671fb36306bdeb1e2dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780030872,
@@ -19,6 +34,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,14 @@
   inputs.nixpkgs.url = "git+https://github.com/NixOS/nixpkgs?shallow=1&ref=nixpkgs-unstable";
   inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
   inputs.treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.crane.url = "github:ipetkov/crane";
 
   outputs =
     {
       self,
       nixpkgs,
       treefmt-nix,
+      crane,
     }:
     let
       inherit (nixpkgs) lib;
@@ -32,6 +34,14 @@
         );
 
       treefmt = eachSystem ({ pkgs, ... }: treefmt-nix.lib.evalModule pkgs ./nix/treefmt.nix);
+
+      # Crane builds (package, clippy, tests) with shared dependency artifacts.
+      craneFor =
+        pkgs:
+        import ./nix/crane.nix {
+          inherit pkgs lib;
+          craneLib = crane.mkLib pkgs;
+        };
     in
     {
       devShells = eachSystem (
@@ -44,7 +54,7 @@
       packages = eachSystem (
         { pkgs, ... }:
         {
-          default = pkgs.callPackage ./nix/package.nix { };
+          default = (craneFor pkgs).package;
         }
         // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
           # Statically linked (musl) build for release binaries: nix-built
@@ -56,10 +66,15 @@
 
       formatter = eachSystem ({ system, ... }: treefmt.${system}.config.build.wrapper);
 
+      # Everything CI verifies: `nix flake check` runs the formatter check,
+      # clippy, the test suite, and builds the package.
       checks = eachSystem (
-        { system, ... }:
+        { pkgs, system, ... }:
         {
           treefmt = treefmt.${system}.config.build.check self;
+          package = self.packages.${system}.default;
+          clippy = (craneFor pkgs).clippy;
+          tests = (craneFor pkgs).tests;
         }
       );
     };

--- a/nix/crane.nix
+++ b/nix/crane.nix
@@ -1,0 +1,60 @@
+# Crane builds: dependencies live in a separate derivation (cargoArtifacts)
+# keyed on Cargo.toml/Cargo.lock, so source-only changes do not recompile
+# them. The static release binary uses nix/package.nix instead.
+{
+  pkgs,
+  lib,
+  craneLib,
+}:
+let
+  src = craneLib.cleanCargoSource ../.;
+
+  commonArgs = {
+    inherit src;
+    pname = "hestia";
+    strictDeps = true;
+    # reqwest's rustls-platform-verifier needs CA certs to construct any
+    # client, even for plain-HTTP localhost use; the sandbox has none.
+    env.SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+  };
+
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+in
+{
+  # Tests run as the separate `tests` check.
+  package = craneLib.buildPackage (
+    commonArgs
+    // {
+      inherit cargoArtifacts;
+      doCheck = false;
+      meta = {
+        description = "Nix binary cache backed by the GitHub Actions cache (v2 API)";
+        homepage = "https://github.com/Mic92/hestia";
+        license = lib.licenses.mit;
+        mainProgram = "hestia";
+      };
+    }
+  );
+
+  clippy = craneLib.cargoClippy (
+    commonArgs
+    // {
+      inherit cargoArtifacts;
+      cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+    }
+  );
+
+  tests = craneLib.cargoTest (
+    commonArgs
+    // {
+      inherit cargoArtifacts;
+      # The integration tests drive real nix tooling (scratch stores,
+      # signing, nix copy) inside the sandbox.
+      nativeBuildInputs = [ pkgs.nix ];
+      # nix needs a writable HOME.
+      preBuild = ''
+        export HOME="$(mktemp -d)"
+      '';
+    }
+  );
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,3 +1,5 @@
+# Static (musl) release binaries via pkgsStatic. Everything else builds
+# with crane (nix/crane.nix).
 {
   lib,
   rustPlatform,


### PR DESCRIPTION
Crane splits the dependency build into its own derivation; clippy and tests become flake checks. CI folds lint/test into the build job as one `nix flake check`.

Includes a workaround for harmonia's readme metadata breaking crane's git vendoring (tech debt, see PLAN.md).

Tested: `nix flake check`, `nix build .#static`, actionlint.