### PR TITLE
ci: stop rebuilding hestia in action-test and token-probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
           sha256: ${{ vars.HESTIA_DOGFOOD_SHA256 }}
       - name: Run flake checks
         run: nix flake check --print-build-logs
+      # No-op after the flake checks; asserts the closures the dependent
+      # jobs substitute are complete and pushed.
+      - name: Assert package closures are complete
+        run: nix build .# .#gha-real-tests --no-link
       - name: Show daemon log
         if: ${{ always() && vars.HESTIA_DOGFOOD == 'true' }}
         run: cat "$HESTIA_SERVE_LOG"
@@ -53,6 +57,8 @@ jobs:
   # GET) and manage entries via the REST API.
   token-probe:
     runs-on: ubuntu-latest
+    # The build job pushes the gha-real-tests closure to the cache.
+    needs: build
     permissions:
       # actions:write is needed by the REST delete test
       actions: write
@@ -60,7 +66,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
-      # No binary/version input: token-capture-only mode.
+      # Dogfood substituter, so the nix build below substitutes instead of
+      # compiling. Must run before the token-only invocation below.
+      - name: Start hestia cache (dogfood)
+        if: vars.HESTIA_DOGFOOD == 'true'
+        uses: ./action
+        with:
+          version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
+          sha256: ${{ vars.HESTIA_DOGFOOD_SHA256 }}
+      # No binary/version input: token-capture-only mode (must stay tested).
       - uses: ./action
       - name: Assert cache tokens are visible to shell steps
         run: |
@@ -86,7 +100,10 @@ jobs:
             exit 1
           fi
       - name: Run real-API integration tests
-        run: nix develop -c cargo test --test gha_real -- --ignored --nocapture
+        run: |
+          set -euo pipefail
+          nix build .#gha-real-tests -o gha-real-tests
+          ./gha-real-tests/bin/gha-real-tests --ignored --nocapture
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -95,17 +112,31 @@ jobs:
   # capture, manifest commit, and substitution back out of the cache.
   action-test:
     runs-on: ubuntu-latest
+    # The build job pushes the package closure to the cache.
+    needs: build
     permissions:
       actions: write
       contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
+      # Dogfood substituter, so the nix build below substitutes instead of
+      # compiling (forks without the variables build from source).
+      - name: Start hestia cache (dogfood)
+        if: vars.HESTIA_DOGFOOD == 'true'
+        uses: ./action
+        with:
+          version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
+          sha256: ${{ vars.HESTIA_DOGFOOD_SHA256 }}
       - name: Build hestia
         run: nix build .# -o hestia-bin
+      # Instance under test on its own port/socket, started last: the
+      # HESTIA_* variables and the post-build-hook then point at it.
       - uses: ./action
         with:
           binary: ./hestia-bin/bin/hestia
+          listen: 127.0.0.1:37516
+          socket: /tmp/hestia-test/hook.sock
       - name: Build a run-unique derivation through the post-build-hook
         run: |
           set -euo pipefail

--- a/action/main.js
+++ b/action/main.js
@@ -221,8 +221,11 @@ async function main() {
 
   const listen = getInput('listen') || '127.0.0.1:37515';
   const socket = getInput('socket') || '/tmp/hestia/hook.sock';
-  const installDir = path.join(process.env.RUNNER_TEMP || '/tmp', 'hestia-cache');
-  fs.mkdirSync(installDir, { recursive: true });
+  // Unique per invocation: a job can run this action more than once, and a
+  // shared directory would overwrite the first daemon's binary and log.
+  const tempDir = process.env.RUNNER_TEMP || '/tmp';
+  fs.mkdirSync(tempDir, { recursive: true });
+  const installDir = fs.mkdtempSync(path.join(tempDir, 'hestia-cache-'));
   const logFile = path.join(installDir, 'serve.log');
 
   const hestiaBin = await installBinary(installDir);

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,8 @@
         { pkgs, ... }:
         {
           default = (craneFor pkgs).package;
+          # Real-API test binary; CI's token-probe job substitutes it.
+          gha-real-tests = (craneFor pkgs).ghaRealTests;
         }
         // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
           # Statically linked (musl) build for release binaries: nix-built
@@ -75,6 +77,7 @@
           package = self.packages.${system}.default;
           clippy = (craneFor pkgs).clippy;
           tests = (craneFor pkgs).tests;
+          gha-real-tests = self.packages.${system}.gha-real-tests;
         }
       );
     };

--- a/nix/crane.nix
+++ b/nix/crane.nix
@@ -44,6 +44,40 @@ in
     }
   );
 
+  # The gha_real integration test binary as an installable package, so CI
+  # can substitute it instead of recompiling the workspace. Build only:
+  # the tests need real GHA credentials.
+  ghaRealTests = craneLib.mkCargoDerivation (
+    commonArgs
+    // {
+      inherit cargoArtifacts;
+      pname = "gha-real-tests";
+      doInstallCargoArtifacts = false;
+      nativeBuildInputs = [
+        pkgs.jq
+        pkgs.makeWrapper
+      ];
+      # The test executable lands in target/.../deps/ with a hash suffix;
+      # --message-format json reports its exact path.
+      buildPhaseCargoCommand = ''
+        cargoWithProfile test --test gha_real --no-run --message-format json > cargo-test-build.json
+      '';
+      installPhaseCommand = ''
+        bin=$(jq -r 'select(.reason == "compiler-artifact" and .target.name == "gha_real" and .executable != null) | .executable' cargo-test-build.json | tail -n1)
+        if [ -z "$bin" ]; then
+          echo "error: could not locate the gha_real test executable" >&2
+          exit 1
+        fi
+        install -D -m755 "$bin" "$out/bin/gha-real-tests"
+        # rustls-platform-verifier needs CA certs to construct any reqwest
+        # client; set-default keeps the runner's own SSL_CERT_FILE if set.
+        wrapProgram "$out/bin/gha-real-tests" \
+          --set-default SSL_CERT_FILE ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+      '';
+      meta.mainProgram = "gha-real-tests";
+    }
+  );
+
   tests = craneLib.cargoTest (
     commonArgs
     // {

--- a/tests/gha_real.rs
+++ b/tests/gha_real.rs
@@ -29,10 +29,10 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Poll `lookup` until `accept` returns true for its result or the
 /// propagation timeout expires; returns the last result either way.
-async fn wait_for<F, Fut>(mut lookup: F, accept: impl Fn(&DownloadUrl) -> bool) -> DownloadUrl
+async fn wait_for<T, F, Fut>(mut lookup: F, accept: impl Fn(&T) -> bool) -> T
 where
     F: FnMut() -> Fut,
-    Fut: Future<Output = DownloadUrl>,
+    Fut: Future<Output = T>,
 {
     let deadline = std::time::Instant::now() + PROPAGATION_TIMEOUT;
     loop {
@@ -121,11 +121,16 @@ async fn real_blob_round_trip_range_read_and_delete() {
     let touch = blob::get(&http, &url, Some(0..1)).await.unwrap();
     assert_eq!(touch.len(), 1);
 
-    // REST: the entry shows up in a prefix list...
-    let listed = rest.list_caches("hestia-test-roundtrip-").await.unwrap();
+    // REST: the entry shows up in a prefix list. The REST view lags behind
+    // uploads just like Twirp lookups do, so this must poll too.
+    let listed = wait_for(
+        || async { rest.list_caches("hestia-test-roundtrip-").await.unwrap() },
+        |entries| entries.iter().any(|entry| entry.key == key),
+    )
+    .await;
     assert!(
         listed.iter().any(|entry| entry.key == key),
-        "uploaded entry missing from REST list: {listed:?}"
+        "uploaded entry missing from REST list after {PROPAGATION_TIMEOUT:?}: {listed:?}"
     );
 
     // ...and REST delete removes it for real (deletes propagate eventually,


### PR DESCRIPTION
The build job already builds everything as flake checks and, with dogfooding enabled, pushes the closures to the GHA cache. action-test and token-probe then threw that away: one re-ran a full cargo build via nix, the other recompiled the workspace with `nix develop -c cargo test`.

Both jobs now depend on build and start a dogfood substituter first, so getting the hestia binary and the new gha-real-tests package is pure substitution. The gha_real test binary is packaged via crane and added to the flake checks, which is what makes it land in the cache in the first place.

Token-capture-only mode stays tested in token-probe, and forks without the dogfood variables keep building from source.

The action needed one fix for running twice in a job: a unique install directory per invocation, otherwise the second run trips over the first daemon's binary and log.