### PR TITLE
Cache the full closure by default, make the upstream filter opt-in

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -24,8 +24,10 @@ superseded by this plan).
   touch fully-live packs, delete garbage via GitHub REST API.
 - `hestia-action` — **required** GitHub Action wrapper (see Auth below;
   shell steps cannot see the cache tokens).
-- Only locally-built paths are stored. Anything signed by cache.nixos.org (or
-  other configured upstreams) is filtered out.
+- By default the full runtime closure of built paths is stored, including
+  upstream-served dependencies (Decision 30). The opt-in upstream cache
+  filter (`--upstream-cache-filter`, attic naming) restores the old
+  locally-built-only behavior; `--no-closure` disables closure expansion.
 
 Storage model on the GHA cache:
 
@@ -138,7 +140,8 @@ hestia serve                       (one process per CI job)
 │     /{hash}.narinfo    → manifest lookup → build_narinfo() → record access
 │     /nar/{hash}.nar    → chunks → NarEvents → NarByteStream → stream
 └── on drain (action post-step) or idle-exit:
-      paths → store-db query_path_info → filter upstream-signed
+      paths → closure expansion → store-db query_path_info
+      → filter upstream-signed (opt-in)
       → NarDumper events → FastCDC chunks (skip known) + nar_hash
         recomputed from the chunked representation (integrity gate)
       → pack new chunks → Twirp reserve → Azure PUT → finalize
@@ -798,6 +801,19 @@ continues from / interleaves with the Open Questions section above.
     tests run there (only the two system-store oracle tests skip, covered
     by the action-test job). The static release build stays on
     buildRustPackage (nix/package.nix).
+30. **Closure expansion by default; the upstream filter is opt-in**
+    (post-Phase 6 feature). The original design stored only locally-built
+    paths and filtered upstream-signed ones. Two problems: substituted
+    dependencies never trigger the post-build-hook, so every fresh runner
+    re-downloaded them from cache.nixos.org; and the filter never matched
+    anything in practice (freshly built paths carry no signatures — the
+    "skipping" came from the hook-only architecture, not the filter).
+    Drains now expand hooked paths to their runtime closure (store-db
+    references walk) and cache everything: for small projects the whole
+    nixpkgs closure fits the 10 GB quota easily, and the co-located GHA
+    cache beats upstream round-trips. Flags follow attic conventions:
+    `--upstream-cache-filter` (opt-in skip), `--upstream-cache-key-name`
+    (repeatable), `--no-closure` (hooked paths only).
 
 ## Mistakes Fixed from Earlier Draft
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ nix build ◀─cached paths── hestia ◀─download─ GitHub Actions cache
 
 Nix reports every path it builds to the daemon, and asks it for paths before
 building them — to Nix it looks like a regular binary cache. At the end of
-the job, new build results are split into content-defined chunks, packed
+the job, new build results and their runtime dependencies (the full closure,
+nixpkgs packages included) are split into content-defined chunks, packed
 into a few large blobs, and uploaded. Chunks already in the cache are never
 uploaded again, and every download is hash-verified before Nix gets to see
 it. Corrupt or evicted cache data simply means a rebuild — never wrong build
@@ -122,7 +123,9 @@ The action covers the common case. Direct CLI use:
 | `--idle-exit <SECONDS>` | — | Drain and exit after this much inactivity (fallback for setups without post steps). |
 | `--branch <NAME>` | `$GITHUB_REF_NAME`, else `local` | Branch part of the manifest root key. |
 | `--system <SYSTEM>` | detected | Nix system part of the root key (e.g. `x86_64-linux`). |
-| `--upstream-key <KEY_NAME>` | `cache.nixos.org-1` | Trusted upstream signature names; paths signed by these are never uploaded. Repeatable. |
+| `--upstream-cache-filter` | off | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
+| `--upstream-cache-key-name <KEY_NAME>` | `cache.nixos.org-1` | Key names treated as upstream caches by the filter. Repeatable. |
+| `--no-closure` | off | Cache built paths only, without their runtime closure. |
 | `--db-path <PATH>` | `/nix/var/nix/db/db.sqlite` | Nix store database to read path metadata from. |
 
 ### `hestia hook` — post-build-hook client

--- a/action/README.md
+++ b/action/README.md
@@ -70,6 +70,9 @@ themselves (hestia's own integration tests use it).
 | `listen` | `127.0.0.1:37515` | Substituter listen address. |
 | `socket` | `/tmp/hestia/hook.sock` | Post-build-hook unix socket path. |
 | `drain-timeout` | `300` | Seconds the post-job step waits for the final upload. |
+| `upstream-cache-filter` | `false` | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
+| `upstream-cache-key-names` | `cache.nixos.org-1` | Space-separated key names treated as upstream caches by the filter. |
+| `no-closure` | `false` | Cache built paths only, without their runtime closure. |
 
 ## Garbage collection
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -43,6 +43,25 @@ inputs:
       (chunking, pack upload, manifest commit).
     required: false
     default: "300"
+  upstream-cache-filter:
+    description: >
+      Skip paths signed by an upstream cache (cache.nixos.org by default)
+      instead of caching them. Saves GHA cache quota for projects with big
+      nixpkgs closures.
+    required: false
+    default: "false"
+  upstream-cache-key-names:
+    description: >
+      Space-separated signing key names treated as upstream caches by
+      `upstream-cache-filter`.
+    required: false
+    default: ""
+  no-closure:
+    description: >
+      Cache built paths only, without their runtime closure (dependencies
+      stay on upstream caches).
+    required: false
+    default: "false"
 
 # If neither `binary` nor `version` is set, the action only captures and
 # exports the cache tokens (ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL).

--- a/action/main.js
+++ b/action/main.js
@@ -171,10 +171,30 @@ function restartNixDaemon() {
   }
 }
 
+/**
+ * Extra `hestia serve` flags from optional inputs. Only emitted when set,
+ * so older release binaries (which lack these flags) keep working with the
+ * default inputs.
+ */
+function serveFlags() {
+  const flags = [];
+  if (getInput('upstream-cache-filter') === 'true') {
+    flags.push('--upstream-cache-filter');
+  }
+  for (const name of getInput('upstream-cache-key-names').split(/\s+/).filter(Boolean)) {
+    flags.push('--upstream-cache-key-name', name);
+  }
+  if (getInput('no-closure') === 'true') {
+    flags.push('--no-closure');
+  }
+  return flags;
+}
+
 /** Start `hestia serve` detached so it outlives this action step. */
 function startDaemon(hestiaBin, listen, socket, logFile) {
   const log = fs.openSync(logFile, 'a');
-  const daemon = spawn(hestiaBin, ['serve', '--listen', listen, '--socket', socket], {
+  const args = ['serve', '--listen', listen, '--socket', socket, ...serveFlags()];
+  const daemon = spawn(hestiaBin, args, {
     detached: true,
     stdio: ['ignore', log, log],
     env: process.env, // carries ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,10 +50,23 @@ pub struct ServeArgs {
     #[arg(long)]
     pub system: Option<String>,
 
-    /// Trusted upstream signature key names; paths signed by any of these
-    /// are never uploaded. Repeatable [default: cache.nixos.org-1].
-    #[arg(long = "upstream-key", value_name = "KEY_NAME")]
-    pub upstream_keys: Vec<String>,
+    /// Skip paths signed by an upstream cache (see
+    /// --upstream-cache-key-name) instead of caching them.
+    #[arg(long)]
+    pub upstream_cache_filter: bool,
+
+    /// Signing key names treated as upstream caches by
+    /// --upstream-cache-filter. Repeatable.
+    #[arg(
+        long = "upstream-cache-key-name",
+        value_name = "KEY_NAME",
+        default_value = "cache.nixos.org-1"
+    )]
+    pub upstream_cache_key_names: Vec<String>,
+
+    /// Push built paths only; do not expand them to their runtime closure.
+    #[arg(long)]
+    pub no_closure: bool,
 
     /// Nix store database to read path metadata from.
     #[arg(long, default_value = "/nix/var/nix/db/db.sqlite")]
@@ -125,7 +138,9 @@ mod tests {
 
         assert_eq!(args.branch, None);
         assert_eq!(args.system, None);
-        assert!(args.upstream_keys.is_empty());
+        assert!(!args.upstream_cache_filter);
+        assert!(!args.no_closure);
+        assert_eq!(args.upstream_cache_key_names, vec!["cache.nixos.org-1"]);
         assert_eq!(args.db_path, PathBuf::from("/nix/var/nix/db/db.sqlite"));
 
         let cli = parse(&[
@@ -141,10 +156,12 @@ mod tests {
             "main",
             "--system",
             "riscv64-linux",
-            "--upstream-key",
+            "--upstream-cache-filter",
+            "--upstream-cache-key-name",
             "cache.nixos.org-1",
-            "--upstream-key",
+            "--upstream-cache-key-name",
             "company-cache-1",
+            "--no-closure",
             "--db-path",
             "/custom/db.sqlite",
         ]);
@@ -156,8 +173,10 @@ mod tests {
         assert_eq!(args.idle_exit, Some(120));
         assert_eq!(args.branch.as_deref(), Some("main"));
         assert_eq!(args.system.as_deref(), Some("riscv64-linux"));
+        assert!(args.upstream_cache_filter);
+        assert!(args.no_closure);
         assert_eq!(
-            args.upstream_keys,
+            args.upstream_cache_key_names,
             vec![
                 "cache.nixos.org-1".to_string(),
                 "company-cache-1".to_string()

--- a/src/pathinfo.rs
+++ b/src/pathinfo.rs
@@ -12,6 +12,7 @@
 //! `nix-store --store 'local?store=…' --add` is queryable without spawning
 //! a daemon process.
 
+use std::collections::{BTreeSet, VecDeque};
 use std::path::{Path, PathBuf};
 
 use harmonia_store_db::StoreDb;
@@ -181,6 +182,43 @@ impl StoreDatabase {
                 Ok((path, lookup))
             })
             .collect()
+    }
+
+    /// Look up `roots` and everything they transitively reference (their
+    /// runtime closure), over a single database connection.
+    ///
+    /// Per-path problems are reported as [`Lookup`] variants, exactly like
+    /// [`Self::query_batch`].
+    pub fn query_closure(
+        &self,
+        roots: impl IntoIterator<Item = String>,
+    ) -> Result<Vec<(String, Lookup)>, Error> {
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        let mut queue: VecDeque<String> = VecDeque::new();
+        for root in roots {
+            if seen.insert(root.clone()) {
+                queue.push_back(root);
+            }
+        }
+        if queue.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let db = self.open()?;
+        let mut results = Vec::new();
+        while let Some(path) = queue.pop_front() {
+            let lookup = self.lookup_one(&db, &path)?;
+            if let Lookup::Found(info) = &lookup {
+                for reference in &info.references {
+                    let reference_path = format!("{}/{reference}", self.store_dir);
+                    if seen.insert(reference_path.clone()) {
+                        queue.push_back(reference_path);
+                    }
+                }
+            }
+            results.push((path, lookup));
+        }
+        Ok(results)
     }
 
     fn lookup_one(&self, db: &StoreDb, store_path: &str) -> Result<Lookup, Error> {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2,9 +2,11 @@
 //!
 //! Runs on drain (action post-step or idle-exit). Steps:
 //!
-//! 1. Query path info from the store database for every buffered path.
-//! 2. Filter: invalid paths, upstream-signed paths, paths already in the
-//!    manifest (those get their `last_pushed` clock bumped instead).
+//! 1. Query path info from the store database for every buffered path,
+//!    expanded to its runtime closure unless disabled.
+//! 2. Filter: invalid paths, upstream-signed paths (when the upstream
+//!    cache filter is enabled), paths already in the manifest (those get
+//!    their `last_pushed` clock bumped instead).
 //! 3. Chunk each new path (FastCDC over NAR events) and verify the chunked
 //!    representation reproduces the NAR hash recorded by Nix.
 //! 4. Pack new chunks, upload the pack (Twirp reserve → Azure PUT →
@@ -164,6 +166,10 @@ pub struct PipelineContext {
     pub http: reqwest::Client,
     pub store: StoreDatabase,
     pub upstream: UpstreamFilter,
+    /// Expand hooked paths to their runtime closure before pushing.
+    /// Substituted dependencies never trigger the post-build-hook, so
+    /// without expansion they are never cached.
+    pub expand_closure: bool,
     /// Manifest root key, e.g. `main-x86_64-linux`.
     pub root_key: String,
     /// SaveMutable family prefix (always [`MANIFEST_PREFIX`] in production;
@@ -247,9 +253,16 @@ impl PipelineContext {
 
         // Blocking sqlite I/O happens off the async runtime.
         let store = self.store.clone();
-        let lookups = tokio::task::spawn_blocking(move || store.query_batch(paths))
-            .await
-            .expect("store database query task panicked")?;
+        let expand_closure = self.expand_closure;
+        let lookups = tokio::task::spawn_blocking(move || {
+            if expand_closure {
+                store.query_closure(paths)
+            } else {
+                store.query_batch(paths)
+            }
+        })
+        .await
+        .expect("store database query task panicked")?;
 
         let mut root_paths: BTreeSet<PathHash> = accessed;
         // Existing entries whose last_pushed clock gets bumped (dedup-skips).

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -332,10 +332,12 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    let upstream = if args.upstream_keys.is_empty() {
-        UpstreamFilter::default()
+    // The filter is opt-in: by default everything is cached, upstream-served
+    // paths included. An empty filter skips nothing.
+    let upstream = if args.upstream_cache_filter {
+        UpstreamFilter::new(args.upstream_cache_key_names.iter().cloned())
     } else {
-        UpstreamFilter::new(args.upstream_keys.iter().cloned())
+        UpstreamFilter::new(Vec::new())
     };
 
     let branch = args
@@ -352,6 +354,7 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         http: http.clone(),
         store,
         upstream,
+        expand_closure: !args.no_closure,
         root_key: pipeline::root_key(&branch, &system),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         // Replaced by Daemon::bind with the daemon's shared ManifestStore.

--- a/tests/failure_modes.rs
+++ b/tests/failure_modes.rs
@@ -40,6 +40,7 @@ fn context(fake: &FakeGha, http: &reqwest::Client, store: &ScratchStore) -> Pipe
         http: http.clone(),
         store: store.database(),
         upstream: UpstreamFilter::default(),
+        expand_closure: true,
         root_key: TEST_ROOT_KEY.to_string(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         publish: None,

--- a/tests/pathinfo_real.rs
+++ b/tests/pathinfo_real.rs
@@ -83,6 +83,62 @@ fn scratch_store_references_are_recorded() {
 }
 
 #[test]
+fn scratch_store_closure_query_walks_references() {
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+    let (top, dep) = store.add_paths_with_reference("closure");
+    let standalone = store.add_fixture("standalone", 7);
+    let database = store.database();
+
+    // The closure of `top` is {top, dep}.
+    let results = database
+        .query_closure([top.to_str().unwrap().to_string()])
+        .expect("closure query failed");
+    let found: Vec<&str> = results
+        .iter()
+        .filter(|(_, lookup)| matches!(lookup, Lookup::Found(_)))
+        .map(|(path, _)| path.as_str())
+        .collect();
+    assert_eq!(results.len(), 2);
+    assert!(found.contains(&top.to_str().unwrap()));
+    assert!(found.contains(&dep.to_str().unwrap()));
+
+    // A path without references is its own closure.
+    let results = database
+        .query_closure([standalone.to_str().unwrap().to_string()])
+        .expect("closure query failed");
+    assert_eq!(results.len(), 1);
+
+    // Duplicate roots are deduplicated; unknown paths are reported, not fatal.
+    let unknown = format!(
+        "{}/00000000000000000000000000000000-missing",
+        database.store_dir()
+    );
+    let results = database
+        .query_closure([
+            top.to_str().unwrap().to_string(),
+            top.to_str().unwrap().to_string(),
+            unknown.clone(),
+        ])
+        .expect("closure query failed");
+    assert_eq!(results.len(), 3, "top + dep + unknown");
+    assert!(
+        results
+            .iter()
+            .any(|(path, lookup)| *path == unknown && matches!(lookup, Lookup::Unknown))
+    );
+
+    // Empty input needs no database at all.
+    assert!(
+        database
+            .query_closure(Vec::new())
+            .expect("empty query")
+            .is_empty()
+    );
+}
+
+#[test]
 fn scratch_store_fake_upstream_signature_is_filtered() {
     // Hermetic version of the upstream-filter requirement: sign a path with
     // a key named exactly like the cache.nixos.org key and verify the

--- a/tests/pipeline_consistency.rs
+++ b/tests/pipeline_consistency.rs
@@ -38,6 +38,7 @@ fn context(twirp: TwirpClient, http: &reqwest::Client, store: StoreDatabase) -> 
         http: http.clone(),
         store,
         upstream: UpstreamFilter::default(),
+        expand_closure: true,
         root_key: TEST_ROOT_KEY.to_string(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         publish: None,

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -29,6 +29,7 @@ fn context(fake: &FakeGha, http: &reqwest::Client, store: StoreDatabase) -> Pipe
         // would skip cache.nixos.org-signed paths) lets them through --
         // exactly like locally built paths in production.
         upstream: UpstreamFilter::default(),
+        expand_closure: true,
         root_key: TEST_ROOT_KEY.to_string(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         publish: None,
@@ -174,6 +175,98 @@ async fn pushes_paths_end_to_end() {
 
     // Exactly one pack blob landed in the (fake) GHA cache.
     assert_eq!(pack_count(&fake, &http).await, 1);
+}
+
+#[tokio::test]
+async fn closure_expansion_pushes_dependencies() {
+    // Hooking only `top` must push `dep` too: dependencies never trigger
+    // the post-build-hook themselves.
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+    let (top, dep) = store.add_paths_with_reference("closure");
+
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let ctx = context(&fake, &http, store.database());
+
+    let now = now_unix();
+    let stats = ctx
+        .run(to_path_set(&[&top]), BTreeSet::new(), now)
+        .await
+        .expect("pipeline run failed");
+
+    assert_eq!(stats.paths_received, 1, "only top was hooked");
+    assert_eq!(stats.pushed, 2, "top and its dependency must be pushed");
+
+    let (_, manifest) = committed_manifest(&ctx).await.expect("manifest committed");
+    assert!(manifest.paths.contains_key(&path_hash_of(&top)));
+    assert!(
+        manifest.paths.contains_key(&path_hash_of(&dep)),
+        "dependency must be cached even though it was never hooked"
+    );
+    assert_all_chunks_locatable(&manifest);
+
+    let root = &manifest.roots[TEST_ROOT_KEY];
+    assert!(root.paths.contains(&path_hash_of(&top)));
+    assert!(root.paths.contains(&path_hash_of(&dep)));
+}
+
+#[tokio::test]
+async fn no_closure_pushes_only_hooked_paths() {
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+    let (top, dep) = store.add_paths_with_reference("no-closure");
+
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let ctx = PipelineContext {
+        expand_closure: false,
+        ..context(&fake, &http, store.database())
+    };
+
+    let stats = ctx
+        .run(to_path_set(&[&top]), BTreeSet::new(), now_unix())
+        .await
+        .expect("pipeline run failed");
+
+    assert_eq!(stats.pushed, 1, "only the hooked path must be pushed");
+
+    let (_, manifest) = committed_manifest(&ctx).await.expect("manifest committed");
+    assert!(manifest.paths.contains_key(&path_hash_of(&top)));
+    assert!(
+        !manifest.paths.contains_key(&path_hash_of(&dep)),
+        "dependency must not be pushed with --no-closure"
+    );
+}
+
+#[tokio::test]
+async fn disabled_upstream_filter_caches_signed_paths() {
+    // Production default: no filter, upstream-signed paths are cached too.
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+    let signed = store.add_fixture("signed-cached", 41);
+    store.sign_path(&signed, "cache.nixos.org-1");
+
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let ctx = PipelineContext {
+        upstream: UpstreamFilter::new(Vec::new()),
+        ..context(&fake, &http, store.database())
+    };
+
+    let stats = ctx
+        .run(to_path_set(&[&signed]), BTreeSet::new(), now_unix())
+        .await
+        .expect("pipeline run failed");
+
+    assert_eq!(stats.skipped_upstream, 0);
+    assert_eq!(stats.pushed, 1, "signed path must be cached");
+
+    let (_, manifest) = committed_manifest(&ctx).await.expect("manifest committed");
+    assert!(manifest.paths.contains_key(&path_hash_of(&signed)));
 }
 
 #[tokio::test]

--- a/tests/serve_daemon.rs
+++ b/tests/serve_daemon.rs
@@ -36,6 +36,7 @@ fn pipeline_context(
         http: http.clone(),
         store,
         upstream: UpstreamFilter::default(),
+        expand_closure: true,
         root_key: TEST_ROOT_KEY.to_string(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         publish: None,

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -44,6 +44,7 @@ fn pipeline_context(
         http: http.clone(),
         store,
         upstream: UpstreamFilter::default(),
+        expand_closure: true,
         root_key: TEST_ROOT_KEY.to_string(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         publish: None,


### PR DESCRIPTION
Until now only locally-built paths landed in the GHA cache: substituted dependencies never trigger the post-build-hook, so every fresh runner pulled the whole nixpkgs closure from cache.nixos.org again. The upstream-signature filter also never matched anything in practice - built paths carry no signatures.

Drains now expand hooked paths to their runtime closure and cache everything by default. For small projects the closure fits the 10 GB quota easily, and the co-located GHA cache is faster than upstream round-trips. Projects that need the quota can opt into the upstream filter.

Flags follow attic naming: `--upstream-cache-filter`, `--upstream-cache-key-name`, `--no-closure`. The action exposes them as inputs and only passes flags when set, so the released binary keeps working.