### PR TITLE
drain: humanize the summary line

### DIFF
--- a/src/drain.rs
+++ b/src/drain.rs
@@ -12,9 +12,35 @@ use std::time::Duration;
 use crate::cli::DrainArgs;
 use crate::protocol::{self, DrainStats, Request};
 
+/// `1 path`, `5 paths`.
+fn count(n: usize, noun: &str) -> String {
+    if n == 1 {
+        format!("1 {noun}")
+    } else {
+        format!("{n} {noun}s")
+    }
+}
+
+/// `512 B`, `1.5 KiB`, `64.6 MiB`, `2.1 GiB`.
+fn human_bytes(bytes: u64) -> String {
+    if bytes < 1024 {
+        return format!("{bytes} B");
+    }
+    let mut value = bytes as f64;
+    let mut unit = "B";
+    for next in ["KiB", "MiB", "GiB", "TiB"] {
+        value /= 1024.0;
+        unit = next;
+        if value < 1024.0 {
+            break;
+        }
+    }
+    format!("{value:.1} {unit}")
+}
+
 /// Human-readable one-line summary of what a drain accomplished.
 pub fn summarize(stats: &DrainStats) -> String {
-    let mut parts = vec![format!("{} path(s) pushed", stats.pushed)];
+    let mut parts = vec![format!("pushed {}", count(stats.pushed, "path"))];
     if stats.skipped_existing > 0 {
         parts.push(format!("{} already cached", stats.skipped_existing));
     }
@@ -30,12 +56,14 @@ pub fn summarize(stats: &DrainStats) -> String {
     let mut summary = parts.join(", ");
     if stats.packs_uploaded > 0 {
         summary.push_str(&format!(
-            "; uploaded {} pack(s), {} chunk(s), {} bytes",
-            stats.packs_uploaded, stats.new_chunks, stats.bytes_uploaded
+            " ({}, {} in {})",
+            count(stats.new_chunks, "chunk"),
+            human_bytes(stats.bytes_uploaded),
+            count(stats.packs_uploaded, "pack"),
         ));
     }
     if stats.manifest_version > 0 {
-        summary.push_str(&format!("; manifest version m#{}", stats.manifest_version));
+        summary.push_str(&format!("; manifest m#{}", stats.manifest_version));
     } else {
         summary.push_str("; nothing to commit");
     }
@@ -86,24 +114,50 @@ mod tests {
             failed_verification: 0,
             new_chunks: 123,
             packs_uploaded: 1,
-            bytes_uploaded: 456789,
+            bytes_uploaded: 456_789,
             manifest_version: 7,
         };
         let summary = summarize(&stats);
-        assert!(summary.contains("4 path(s) pushed"), "{summary}");
-        assert!(summary.contains("3 already cached"), "{summary}");
-        assert!(summary.contains("2 upstream-signed"), "{summary}");
-        assert!(summary.contains("1 invalid"), "{summary}");
-        assert!(summary.contains("1 pack(s)"), "{summary}");
-        assert!(summary.contains("m#7"), "{summary}");
-        assert!(!summary.contains("FAILED VERIFICATION"), "{summary}");
+        assert_eq!(
+            summary,
+            "pushed 4 paths, 3 already cached, 2 upstream-signed, 1 invalid \
+             (123 chunks, 446.1 KiB in 1 pack); manifest m#7"
+        );
+    }
+
+    #[test]
+    fn singular_counts_have_no_plural_s() {
+        let stats = DrainStats {
+            pushed: 1,
+            new_chunks: 1,
+            packs_uploaded: 1,
+            bytes_uploaded: 100,
+            manifest_version: 1,
+            ..DrainStats::default()
+        };
+        assert_eq!(
+            summarize(&stats),
+            "pushed 1 path (1 chunk, 100 B in 1 pack); manifest m#1"
+        );
     }
 
     #[test]
     fn empty_drain_summary_says_nothing_to_commit() {
-        let summary = summarize(&DrainStats::default());
-        assert!(summary.contains("0 path(s) pushed"), "{summary}");
-        assert!(summary.contains("nothing to commit"), "{summary}");
+        assert_eq!(
+            summarize(&DrainStats::default()),
+            "pushed 0 paths; nothing to commit"
+        );
+    }
+
+    #[test]
+    fn human_bytes_units() {
+        assert_eq!(human_bytes(0), "0 B");
+        assert_eq!(human_bytes(1023), "1023 B");
+        assert_eq!(human_bytes(1024), "1.0 KiB");
+        assert_eq!(human_bytes(456_789), "446.1 KiB");
+        assert_eq!(human_bytes(67_694_023), "64.6 MiB");
+        assert_eq!(human_bytes(3_000_000_000), "2.8 GiB");
+        assert_eq!(human_bytes(5_000_000_000_000), "4.5 TiB");
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -437,9 +437,8 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
     match result {
         Ok(stats) => {
             eprintln!(
-                "hestia serve: final drain pushed {} path(s), {} pack(s), {} bytes \
-                 (manifest version {})",
-                stats.pushed, stats.packs_uploaded, stats.bytes_uploaded, stats.manifest_version
+                "hestia serve: final drain: {}",
+                crate::drain::summarize(&stats)
             );
             ExitCode::SUCCESS
         }

--- a/tests/serve_daemon.rs
+++ b/tests/serve_daemon.rs
@@ -455,7 +455,7 @@ async fn drain_cli_binary_reports_stats_and_exits_zero() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("1 path(s) pushed"),
+        stderr.contains("pushed 1 path ("),
         "summary must mention the pushed path, got: {stderr}"
     );
 


### PR DESCRIPTION
Before:

    hestia drain: 5 path(s) pushed; uploaded 1 pack(s), 987 chunk(s), 67694023 bytes; manifest version m#46

After:

    hestia drain: pushed 5 paths (987 chunks, 64.6 MiB in 1 pack); manifest m#46

Proper plurals, IEC units, and `hestia serve` reuses the same formatter for its final-drain line instead of rolling its own.