### PR TITLE
release: bump version to 0.1.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hestia"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hestia"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2024"
 license = "MIT"
 description = "Nix binary cache backed by the GitHub Actions cache (v2 API)"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,7 +7,7 @@
 }:
 rustPlatform.buildRustPackage {
   pname = "hestia";
-  version = "0.1.0-alpha.1";
+  version = "0.1.0-alpha.2";
 
   src = lib.fileset.toSource {
     root = ../.;


### PR DESCRIPTION
Version bump for the next alpha release. Changes since v0.1.0-alpha.1:

- full-closure caching by default with an opt-in upstream cache filter (attic-style flags)
- the action supports multiple instances per job
- humanized drain summary
- CI now substitutes prebuilt closures instead of rebuilding

I'll tag v0.1.0-alpha.2 once this lands.