### PR TITLE
drain: time pipeline stages, print speed in summary and stages in daemon log

### DIFF
--- a/src/drain.rs
+++ b/src/drain.rs
@@ -38,6 +38,11 @@ fn human_bytes(bytes: u64) -> String {
     format!("{value:.1} {unit}")
 }
 
+/// `0.5s`, `57.3s`.
+fn seconds(ms: u64) -> String {
+    format!("{:.1}s", ms as f64 / 1000.0)
+}
+
 /// Human-readable one-line summary of what a drain accomplished.
 pub fn summarize(stats: &DrainStats) -> String {
     let mut parts = vec![format!("pushed {}", count(stats.pushed, "path"))];
@@ -55,12 +60,15 @@ pub fn summarize(stats: &DrainStats) -> String {
     }
     let mut summary = parts.join(", ");
     if stats.packs_uploaded > 0 {
-        summary.push_str(&format!(
-            " ({}, {} in {})",
-            count(stats.new_chunks, "chunk"),
-            human_bytes(stats.bytes_uploaded),
-            count(stats.packs_uploaded, "pack"),
-        ));
+        let mut inner = human_bytes(stats.bytes_uploaded);
+        if stats.elapsed_ms > 0 {
+            inner.push_str(&format!(
+                " in {}, {}/s",
+                seconds(stats.elapsed_ms),
+                human_bytes(throughput(stats.bytes_uploaded, stats.elapsed_ms))
+            ));
+        }
+        summary.push_str(&format!(" ({inner})"));
     }
     if stats.manifest_version > 0 {
         summary.push_str(&format!("; manifest m#{}", stats.manifest_version));
@@ -68,6 +76,32 @@ pub fn summarize(stats: &DrainStats) -> String {
         summary.push_str("; nothing to commit");
     }
     summary
+}
+
+/// Bytes per second. `ms` is clamped to 1 to avoid dividing by zero.
+fn throughput(bytes: u64, ms: u64) -> u64 {
+    (bytes as f64 / (ms.max(1) as f64 / 1000.0)) as u64
+}
+
+/// Per-stage timing breakdown of a drain, for the daemon log.
+pub fn stage_breakdown(stats: &DrainStats) -> String {
+    let mut stages = vec![format!("chunk {}", seconds(stats.chunk_ms))];
+    if stats.packs_uploaded > 0 {
+        stages.push(format!(
+            "pack {} ({}, {})",
+            seconds(stats.pack_ms),
+            count(stats.new_chunks, "chunk"),
+            count(stats.packs_uploaded, "pack"),
+        ));
+        stages.push(format!(
+            "upload {} ({}/s)",
+            seconds(stats.upload_ms),
+            human_bytes(throughput(stats.bytes_uploaded, stats.upload_ms))
+        ));
+    }
+    stages.push(format!("commit {}", seconds(stats.commit_ms)));
+    stages.push(format!("total {}", seconds(stats.elapsed_ms)));
+    stages.join(", ")
 }
 
 pub async fn run(args: &DrainArgs) -> ExitCode {
@@ -116,12 +150,38 @@ mod tests {
             packs_uploaded: 1,
             bytes_uploaded: 456_789,
             manifest_version: 7,
+            chunk_ms: 1_200,
+            pack_ms: 500,
+            upload_ms: 200,
+            commit_ms: 100,
+            elapsed_ms: 2_000,
         };
-        let summary = summarize(&stats);
         assert_eq!(
-            summary,
+            summarize(&stats),
             "pushed 4 paths, 3 already cached, 2 upstream-signed, 1 invalid \
-             (123 chunks, 446.1 KiB in 1 pack); manifest m#7"
+             (446.1 KiB in 2.0s, 223.0 KiB/s); manifest m#7"
+        );
+        assert_eq!(
+            stage_breakdown(&stats),
+            "chunk 1.2s, pack 0.5s (123 chunks, 1 pack), upload 0.2s (2.2 MiB/s), \
+             commit 0.1s, total 2.0s"
+        );
+    }
+
+    #[test]
+    fn deduplicated_drain_has_no_upload_in_summary_or_breakdown() {
+        let stats = DrainStats {
+            pushed: 2,
+            manifest_version: 3,
+            chunk_ms: 400,
+            commit_ms: 100,
+            elapsed_ms: 600,
+            ..DrainStats::default()
+        };
+        assert_eq!(summarize(&stats), "pushed 2 paths; manifest m#3");
+        assert_eq!(
+            stage_breakdown(&stats),
+            "chunk 0.4s, commit 0.1s, total 0.6s"
         );
     }
 
@@ -131,13 +191,23 @@ mod tests {
             pushed: 1,
             new_chunks: 1,
             packs_uploaded: 1,
-            bytes_uploaded: 100,
+            bytes_uploaded: 1_048_576,
             manifest_version: 1,
+            chunk_ms: 300,
+            pack_ms: 100,
+            upload_ms: 500,
+            commit_ms: 100,
+            elapsed_ms: 1_000,
             ..DrainStats::default()
         };
         assert_eq!(
             summarize(&stats),
-            "pushed 1 path (1 chunk, 100 B in 1 pack); manifest m#1"
+            "pushed 1 path (1.0 MiB in 1.0s, 1.0 MiB/s); manifest m#1"
+        );
+        assert_eq!(
+            stage_breakdown(&stats),
+            "chunk 0.3s, pack 0.1s (1 chunk, 1 pack), upload 0.5s (2.0 MiB/s), \
+             commit 0.1s, total 1.0s"
         );
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -297,6 +297,7 @@ impl PipelineContext {
         // Chunks of earlier prepared paths in this batch (cross-path dedup).
         let mut batch_chunks: BTreeSet<crate::manifest::ChunkHash> = BTreeSet::new();
 
+        let chunk_started = std::time::Instant::now();
         for (path, info) in to_push {
             let chunked = chunk_path(&path).await?;
             let chunk_map = chunked.chunk_map();
@@ -341,8 +342,11 @@ impl PipelineContext {
             });
         }
 
+        stats.chunk_ms = chunk_started.elapsed().as_millis() as u64;
+
         let mut delta = Manifest::new();
 
+        let pack_started = std::time::Instant::now();
         let mut builder = PackBuilder::new();
         for path in &prepared {
             for chunk in &path.new_chunks {
@@ -353,8 +357,11 @@ impl PipelineContext {
         if !builder.is_empty() {
             let pack = builder.finish();
             stats.new_chunks = pack.chunks.len();
+            stats.pack_ms = pack_started.elapsed().as_millis() as u64;
 
+            let upload_started = std::time::Instant::now();
             let uploaded = upload_pack(&self.twirp, &self.http, &pack).await?;
+            stats.upload_ms = upload_started.elapsed().as_millis() as u64;
             if uploaded {
                 stats.packs_uploaded += 1;
                 stats.bytes_uploaded += pack.data.len() as u64;
@@ -394,6 +401,7 @@ impl PipelineContext {
 
         // The merge closure keeps the manifest it encoded so the committed
         // version can be published without re-loading it from the cache.
+        let commit_started = std::time::Instant::now();
         let mut committed: Option<Manifest> = None;
         let version = self
             .save_mutable()
@@ -419,6 +427,7 @@ impl PipelineContext {
                 Ok(encoded)
             })
             .await?;
+        stats.commit_ms = commit_started.elapsed().as_millis() as u64;
         stats.manifest_version = version;
 
         // Publish exactly what was committed (includes concurrent writers'

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -75,6 +75,21 @@ pub struct DrainStats {
     /// needed committing.
     #[serde(default)]
     pub manifest_version: u64,
+    /// Time spent chunking and verifying new paths, in milliseconds.
+    #[serde(default)]
+    pub chunk_ms: u64,
+    /// Time spent compressing chunks into packs, in milliseconds.
+    #[serde(default)]
+    pub pack_ms: u64,
+    /// Time spent uploading packs, in milliseconds.
+    #[serde(default)]
+    pub upload_ms: u64,
+    /// Time spent committing the manifest, in milliseconds.
+    #[serde(default)]
+    pub commit_ms: u64,
+    /// Wall-clock duration of the whole drain, in milliseconds.
+    #[serde(default)]
+    pub elapsed_ms: u64,
 }
 
 /// One response line from the daemon.

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -101,8 +101,16 @@ impl DaemonState {
         let paths = std::mem::take(&mut *self.buffered.lock().expect("buffer lock poisoned"));
         let accessed = self.access_log.snapshot();
 
+        let started = Instant::now();
         match self.pipeline.run(paths.clone(), accessed, now_unix()).await {
-            Ok(stats) => {
+            Ok(mut stats) => {
+                stats.elapsed_ms = started.elapsed().as_millis() as u64;
+                if stats.pushed > 0 {
+                    eprintln!(
+                        "hestia serve: drain stages: {}",
+                        crate::drain::stage_breakdown(&stats)
+                    );
+                }
                 self.touch();
                 // The pipeline publishes the committed manifest into the
                 // shared ManifestStore itself (read-your-writes; reloading


### PR DESCRIPTION
Drain client output stays short:
```
pushed 615 paths (1.0 GiB in 57.3s, 17.9 MiB/s); manifest m#1
```

Full per-stage breakdown lands in the daemon log:
```
hestia serve: drain stages: chunk 40.1s, pack 8.2s (55086 chunks, 1 pack), upload 7.3s (140.3 MiB/s), commit 1.2s, total 57.3s
```

Stages: chunk (NAR read + FastCDC + hash verification), pack (zstd), upload (network only, real throughput), commit (SaveMutable write).

Baseline measurement before parallelizing the pipeline — chunk/pack/upload currently run sequentially on one core.