### PR TITLE
release: publish build provenance attestations for release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
       # GHA cache writes when dogfooding is enabled.
       actions: write
       contents: read
+      # Build provenance attestations for the release binaries.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
@@ -91,6 +94,13 @@ jobs:
           set -euo pipefail
           install -m755 result/bin/hestia "hestia-${{ matrix.system }}"
           sha256sum "hestia-${{ matrix.system }}" | tee "hestia-${{ matrix.system }}.sha256"
+      # Publish build provenance so the hestia-cache action can verify
+      # downloaded binaries against GitHub's attestation API instead of
+      # requiring users to pin a sha256.
+      - uses: actions/attest-build-provenance@v4
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          subject-path: hestia-${{ matrix.system }}
       - uses: actions/upload-artifact@v7
         with:
           name: hestia-${{ matrix.system }}


### PR DESCRIPTION
Users currently have to pin the sha256 of the release binary in the
hestia-cache action because there is no other way to verify what they
download. Attest the binaries with actions/attest-build-provenance so
the action can verify downloads against GitHub's attestation API
instead; the sha256 input becomes unnecessary in a follow-up.

Dry runs (workflow_dispatch) skip the attestation step: they build
binaries that are never released.
