### PR TITLE
action: verify release downloads via build attestations instead of sha256

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,7 @@ jobs:
   # binary (this job cannot use the package it is about to build); with
   # the variables unset the dogfood step is skipped.
   #   HESTIA_DOGFOOD          "true"
-  #   HESTIA_DOGFOOD_VERSION  release tag, e.g. "v0.1.0-alpha.1"
-  #   HESTIA_DOGFOOD_SHA256   sha256 of that release's hestia-x86_64-linux
-  #   HESTIA_DOGFOOD_SHA256_AARCH64  same for hestia-aarch64-linux
-  #                           (used by release.yml's arm64 leg)
+  #   HESTIA_DOGFOOD_VERSION  release tag, e.g. "v0.1.0-alpha.4"
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -36,7 +33,6 @@ jobs:
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
-          sha256: ${{ vars.HESTIA_DOGFOOD_SHA256 }}
       - name: Run flake checks
         run: nix flake check --print-build-logs
       # No-op after the flake checks; asserts the closures the dependent
@@ -73,7 +69,6 @@ jobs:
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
-          sha256: ${{ vars.HESTIA_DOGFOOD_SHA256 }}
       # No binary/version input: token-capture-only mode (must stay tested).
       - uses: ./action
       - name: Assert cache tokens are visible to shell steps
@@ -127,7 +122,6 @@ jobs:
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
-          sha256: ${{ vars.HESTIA_DOGFOOD_SHA256 }}
       - name: Build hestia
         run: nix build .# -o hestia-bin
       # Instance under test on its own port/socket, started last: the

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -6,7 +6,7 @@
 #
 # This workflow doubles as the reference for other repositories using
 # hestia: copy it, replace the "Build hestia" step with the action's
-# version/sha256 inputs (see action/README.md), and keep the permissions.
+# version input (see action/README.md), and keep the permissions.
 name: Cache GC
 
 on:
@@ -43,7 +43,6 @@ jobs:
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
-          sha256: ${{ vars.HESTIA_DOGFOOD_SHA256 }}
       - name: Build hestia
         if: vars.HESTIA_DOGFOOD != 'true'
         run: nix build .# -o hestia-bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
-          sha256: ${{ matrix.system == 'aarch64-linux' && vars.HESTIA_DOGFOOD_SHA256_AARCH64 || vars.HESTIA_DOGFOOD_SHA256 }}
       - name: System diagnostics
         run: |
           uname -a
@@ -133,9 +132,9 @@ jobs:
             *-*) prerelease=(--prerelease) ;;
           esac
 
-          # Release notes: usage snippet with the real sha256 values, so the
-          # release is copy-paste usable; --generate-notes appends the
-          # auto-generated changelog below it.
+          # Release notes: copy-paste usage snippet; --generate-notes appends
+          # the changelog below it. The checksums table is for manual
+          # verification only (the action checks the build attestations).
           sha256_x86_64=$(cut -d' ' -f1 hestia-x86_64-linux.sha256)
           sha256_aarch64=$(cut -d' ' -f1 hestia-aarch64-linux.sha256)
           cat > notes.md <<EOF
@@ -147,7 +146,6 @@ jobs:
           - uses: Mic92/hestia/action@${tag}
             with:
               version: ${tag}
-              sha256: ${sha256_x86_64}   # x86_64-linux
           \`\`\`
 
           ## Checksums (SHA-256)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ jobs:
       - uses: Mic92/hestia/action@main
         with:
           version: v0.1.0-alpha.4
-          sha256: <sha256 of the release binary>
       - run: nix build .#
 ```
 

--- a/action/README.md
+++ b/action/README.md
@@ -11,8 +11,9 @@ What it does, in order:
 1. Captures the Actions cache API tokens (`ACTIONS_RUNTIME_TOKEN`,
    `ACTIONS_RESULTS_URL`). These are only visible to JS actions — this is why
    hestia needs an action and cannot be set up from `run:` steps alone.
-2. Installs the `hestia` binary (from a GitHub release, sha256-verified, or
-   from a path you built yourself).
+2. Installs the `hestia` binary (from a GitHub release, verified against
+   GitHub's build provenance attestations, or from a path you built
+   yourself).
 3. Starts the hestia daemon: a post-build-hook listener plus a local
    substituter (Nix binary cache protocol over HTTP).
 4. Wires both into `nix.conf` (`extra-substituters` with `?trusted=true`,
@@ -35,7 +36,6 @@ jobs:
       - uses: Mic92/hestia/action@main
         with:
           version: v0.1.0-alpha.4
-          sha256: <sha256 of the release binary>
       - run: nix build .#
 ```
 
@@ -65,8 +65,8 @@ themselves (hestia's own integration tests use it).
 | Input | Default | Description |
 |---|---|---|
 | `binary` | — | Path to a pre-built hestia binary. Takes precedence over `version`. |
-| `version` | — | Release tag to download (e.g. `v0.1.0-alpha.1`). Requires `sha256`. |
-| `sha256` | — | Expected SHA-256 of the downloaded binary. Downloads are refused without it. |
+| `version` | — | Release tag to download (e.g. `v0.1.0-alpha.4`). The download is verified against GitHub's build attestations. |
+| `github-token` | `${{ github.token }}` | Token for the attestation API lookup. |
 | `listen` | `127.0.0.1:37515` | Substituter listen address. |
 | `socket` | `/tmp/hestia/hook.sock` | Post-build-hook unix socket path. |
 | `drain-timeout` | `300` | Seconds the post-job step waits for the final upload. |

--- a/action/action.yml
+++ b/action/action.yml
@@ -20,15 +20,16 @@ inputs:
   version:
     description: >
       Hestia release tag to download from GitHub releases
-      (e.g. "v0.1.0-alpha.1"). Requires `sha256`.
+      (e.g. "v0.1.0-alpha.4"). The downloaded binary is verified against
+      GitHub's build provenance attestations before it runs.
     required: false
     default: ""
-  sha256:
+  github-token:
     description: >
-      Expected SHA-256 hex digest of the downloaded release binary. Required
-      together with `version`; unverified downloads are refused.
+      Token for the attestation API lookup that verifies downloaded release
+      binaries.
     required: false
-    default: ""
+    default: ${{ github.token }}
   listen:
     description: Address the substituter HTTP server listens on.
     required: false

--- a/action/main.js
+++ b/action/main.js
@@ -66,6 +66,54 @@ function captureTokens() {
   console.log('hestia-cache: cache tokens captured and exported');
 }
 
+/**
+ * Verify a downloaded release binary against GitHub's attestation API.
+ *
+ * The lookup is scoped to `repo` and keyed by content digest, so a match
+ * proves the binary was built by that repository's release workflow. The
+ * Sigstore signature is not checked (that needs a full Sigstore client);
+ * the trust anchor is the GitHub API over TLS, the same anchor the release
+ * download relies on.
+ */
+async function verifyAttestation(repo, assetName, digest, token) {
+  const url = `https://api.github.com/repos/${repo}/attestations/sha256:${digest}`;
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    fail(`attestation lookup failed: HTTP ${response.status} for ${url}`);
+  }
+  const attestations = (await response.json()).attestations || [];
+  if (attestations.length === 0) {
+    fail(
+      `no build attestation found for ${assetName} (sha256:${digest}) in ${repo}; ` +
+        'refusing to run an unverified binary'
+    );
+  }
+
+  // The API does not always inline the bundle (sometimes there is only a
+  // compressed bundle_url), so logging the building workflow is best effort.
+  let builtBy = '';
+  for (const attestation of attestations) {
+    try {
+      const statement = JSON.parse(
+        Buffer.from(attestation.bundle.dsseEnvelope.payload, 'base64').toString('utf8')
+      );
+      const workflow = statement.predicate.buildDefinition.externalParameters.workflow;
+      builtBy = `, built by ${workflow.repository}/${workflow.path}@${workflow.ref}`;
+      break;
+    } catch {
+      // No inline bundle; the digest lookup above already verified.
+    }
+  }
+  console.log(`hestia-cache: attestation verified for ${assetName} (sha256:${digest})${builtBy}`);
+}
+
 /** Install the hestia binary into installDir; returns its path. */
 async function installBinary(installDir) {
   const target = path.join(installDir, 'hestia');
@@ -76,25 +124,20 @@ async function installBinary(installDir) {
     console.log(`hestia-cache: installing from local binary ${binary}`);
     fs.copyFileSync(binary, target);
   } else {
-    const expectedSha256 = getInput('sha256').toLowerCase();
-    if (!expectedSha256) {
-      fail("the 'sha256' input is required when installing a release (unverified downloads are refused)");
-    }
     const arch = { x64: 'x86_64', arm64: 'aarch64' }[process.arch] || process.arch;
     // GITHUB_ACTION_REPOSITORY points at the repo this action was loaded
     // from, so forks automatically download their own releases.
     const repo = process.env.GITHUB_ACTION_REPOSITORY || 'Mic92/hestia';
-    const url = `https://github.com/${repo}/releases/download/${version}/hestia-${arch}-linux`;
+    const assetName = `hestia-${arch}-linux`;
+    const url = `https://github.com/${repo}/releases/download/${version}/${assetName}`;
     console.log(`hestia-cache: downloading ${url}`);
     const response = await fetch(url, { redirect: 'follow' });
     if (!response.ok) {
       fail(`download failed: HTTP ${response.status} for ${url}`);
     }
     const data = Buffer.from(await response.arrayBuffer());
-    const actualSha256 = crypto.createHash('sha256').update(data).digest('hex');
-    if (actualSha256 !== expectedSha256) {
-      fail(`sha256 mismatch for ${url}: expected ${expectedSha256}, got ${actualSha256}`);
-    }
+    const digest = crypto.createHash('sha256').update(data).digest('hex');
+    await verifyAttestation(repo, assetName, digest, getInput('github-token'));
     fs.writeFileSync(target, data);
   }
   fs.chmodSync(target, 0o755);

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -91,20 +91,12 @@ if [[ -z $run_id ]]; then
 fi
 gh run watch "$run_id" --exit-status
 
-# Point CI dogfooding at the new release.
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
-gh release download "$tag" --pattern '*.sha256' --dir "$tmpdir"
-sha256_x86_64=$(cut -d' ' -f1 "$tmpdir/hestia-x86_64-linux.sha256")
-sha256_aarch64=$(cut -d' ' -f1 "$tmpdir/hestia-aarch64-linux.sha256")
+# Point CI dogfooding at the new release. Downloads are verified via build
+# attestations, so only the version variable is needed.
 gh variable set HESTIA_DOGFOOD_VERSION --body "$tag"
-gh variable set HESTIA_DOGFOOD_SHA256 --body "$sha256_x86_64"
-gh variable set HESTIA_DOGFOOD_SHA256_AARCH64 --body "$sha256_aarch64"
 
 echo
 echo "released ${tag}:"
 gh release view "$tag" --json url --jq .url
 echo "dogfood variables updated:"
 echo "  HESTIA_DOGFOOD_VERSION=${tag}"
-echo "  HESTIA_DOGFOOD_SHA256=${sha256_x86_64}"
-echo "  HESTIA_DOGFOOD_SHA256_AARCH64=${sha256_aarch64}"


### PR DESCRIPTION
Replaces the sha256 input with verification against GitHub's attestation API. The lookup is scoped to the action's repository and keyed by content digest, so it only succeeds for binaries built by the repository's own release workflow (attested since v0.1.0-alpha.4, #19).

Workflows that set `sha256:` need to drop it. The new `github-token` input (default `github.token`) authenticates the lookup.

Also drops the HESTIA_DOGFOOD_SHA256* variables from the CI, GC, and release workflows and from the release script.

Tested against the real API: inline bundle (astral-sh/uv), bundle behind a compressed URL (cli/cli), unknown digest (rejected).