### PR TITLE
action: rewrite README in a plainer voice

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -3,23 +3,24 @@
 > ⚠️ **Alpha software**: APIs, cache format, and behavior may change without
 > notice. Not yet recommended for production CI.
 
-GitHub Action that turns the GitHub Actions cache into a Nix binary cache,
-powered by [hestia](https://github.com/Mic92/hestia).
+This action runs [hestia](https://github.com/Mic92/hestia) inside your job,
+turning the GitHub Actions cache into a Nix binary cache.
 
-What it does, in order:
+When the job starts, the action:
 
 1. Captures the Actions cache API tokens (`ACTIONS_RUNTIME_TOKEN`,
-   `ACTIONS_RESULTS_URL`). These are only visible to JS actions — this is why
-   hestia needs an action and cannot be set up from `run:` steps alone.
-2. Installs the `hestia` binary (from a GitHub release, verified against
-   GitHub's build provenance attestations, or from a path you built
-   yourself).
+   `ACTIONS_RESULTS_URL`). They are only visible to JS actions, which is why
+   hestia needs an action at all and cannot be set up from `run:` steps.
+2. Installs the `hestia` binary, either from a GitHub release (verified
+   against GitHub's build attestations) or from a path you built yourself.
 3. Starts the hestia daemon: a post-build-hook listener plus a local
-   substituter (Nix binary cache protocol over HTTP).
+   substituter speaking the Nix binary cache protocol over HTTP.
 4. Wires both into `nix.conf` (`extra-substituters` with `?trusted=true`,
    `post-build-hook`) and restarts the nix-daemon if there is one.
-5. **Post-job**: drains the daemon — chunks, packs, and uploads everything
-   that was built, then commits the manifest to the GHA cache.
+
+When the job ends, a post step drains the daemon: everything that was built
+is chunked, packed, and uploaded, and the manifest is committed to the GHA
+cache.
 
 ## Usage
 
@@ -39,13 +40,12 @@ jobs:
       - run: nix build .#
 ```
 
-Subsequent runs substitute everything the first run built from the GHA cache
-instead of rebuilding it.
+Later runs substitute what earlier runs built instead of rebuilding it.
 
 ### Using a locally built binary
 
-If you build hestia yourself (e.g. while hacking on it, or to avoid trusting
-release binaries), pass a path instead:
+If you build hestia yourself, while hacking on it or because you do not want
+to trust release binaries, pass a path instead:
 
 ```yaml
       - run: nix build github:Mic92/hestia -o hestia-bin
@@ -57,8 +57,8 @@ release binaries), pass a path instead:
 ### Token capture only
 
 With neither `version` nor `binary` set, the action only exports the cache
-API tokens and starts nothing. This exists for setups that run hestia
-themselves (hestia's own integration tests use it).
+API tokens and starts nothing. This mode is for setups that run hestia
+themselves; hestia's own integration tests use it.
 
 ## Inputs
 
@@ -76,10 +76,11 @@ themselves (hestia's own integration tests use it).
 
 ## Garbage collection
 
-The cache needs a periodic GC run on the default branch (PR-scoped caches die
-with their branch, but the default branch scope grows forever otherwise). See
-[`.github/workflows/gc.yml`](../.github/workflows/gc.yml) in the hestia
-repository for a ready-to-copy workflow.
+The cache needs a periodic GC run on the default branch: PR-scoped caches die
+with their branch, but the default branch scope grows forever unless
+something prunes it. Copy
+[`.github/workflows/gc.yml`](../.github/workflows/gc.yml) from the hestia
+repository as a starting point.
 
 ## Permissions
 


### PR DESCRIPTION
Same treatment the top-level README got: describe what the action
does as a maintainer would, without bold-led list items and marketing
phrasing.
