### PR TITLE
action: print the daemon log in the post step, scope state per invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
       # jobs substitute are complete and pushed.
       - name: Assert package closures are complete
         run: nix build .# .#gha-real-tests --no-link
-      - name: Show daemon log
-        if: ${{ always() && vars.HESTIA_DOGFOOD == 'true' }}
-        run: cat "$HESTIA_SERVE_LOG"
 
   # Phase 0 milestone: prove that the action wrapper makes the GHA cache
   # tokens visible to shell steps and that the results endpoint is reachable.
@@ -167,6 +164,3 @@ jobs:
             --to /tmp/fresh-store \
             "$path"
           test -e "/tmp/fresh-store$path"
-      - name: Show daemon log
-        if: always()
-        run: cat "$HESTIA_SERVE_LOG"

--- a/action/main.js
+++ b/action/main.js
@@ -30,6 +30,16 @@ function getInput(name) {
   return (process.env[`INPUT_${name.toUpperCase()}`] || '').trim();
 }
 
+/**
+ * Save a value for this invocation's post step (the runner exposes it there
+ * as STATE_<name>). Unlike exported environment variables, state is not
+ * shared between invocations: a job that runs this action twice gets two
+ * post steps, each draining its own daemon.
+ */
+function saveState(name, value) {
+  fs.appendFileSync(process.env.GITHUB_STATE, `${name}=${value}\n`);
+}
+
 function fail(message) {
   console.error(`::error::${message}`);
   process.exit(1);
@@ -297,13 +307,20 @@ async function main() {
   startDaemon(hestiaBin, listen, socket, logFile);
   await waitForReadiness(listen, logFile);
 
-  // State for later steps and the drain post-step.
+  // Environment variables for the user's later shell steps. When the action
+  // runs more than once in a job, these point at the latest daemon.
   exportVariable('HESTIA_BIN', hestiaBin);
   exportVariable('HESTIA_SOCKET', socket);
   exportVariable('HESTIA_LISTEN', listen);
   exportVariable('HESTIA_DRAIN_TIMEOUT', getInput('drain-timeout') || '300');
   exportVariable('HESTIA_SERVE_LOG', logFile);
   fs.appendFileSync(process.env.GITHUB_PATH, `${installDir}\n`);
+
+  // State for this invocation's own post step.
+  saveState('bin', hestiaBin);
+  saveState('socket', socket);
+  saveState('serveLog', logFile);
+  saveState('drainTimeout', getInput('drain-timeout') || '300');
 }
 
 main().catch((error) => {

--- a/action/post.js
+++ b/action/post.js
@@ -10,28 +10,43 @@
 const fs = require('fs');
 const { spawnSync } = require('child_process');
 
+/** Read a value the main step saved with saveState(). */
+function getState(name) {
+  return (process.env[`STATE_${name}`] || '').trim();
+}
+
 function main() {
-  const binary = process.env.HESTIA_BIN || '';
+  const binary = getState('bin');
   if (!binary) {
     console.log('hestia-cache: no daemon was started in this job; nothing to drain');
     return 0;
   }
 
-  const socket = process.env.HESTIA_SOCKET || '/tmp/hestia/hook.sock';
-  const timeout = process.env.HESTIA_DRAIN_TIMEOUT || '300';
+  const socket = getState('socket');
+  const timeout = getState('drainTimeout') || '300';
 
   console.log('hestia-cache: draining (uploading built paths, committing the manifest)');
   const drain = spawnSync(binary, ['drain', '--socket', socket, '--timeout', timeout], {
     stdio: 'inherit',
   });
 
-  if (drain.status !== 0) {
-    // Show the daemon log: the drain summary alone rarely explains failures.
-    const log = process.env.HESTIA_SERVE_LOG || '';
-    if (log && fs.existsSync(log)) {
-      console.log('--- hestia serve log ---');
-      console.log(fs.readFileSync(log, 'utf8'));
+  // The daemon log carries what the drain summary does not: per-stage drain
+  // timings, substituter hits, and error details. Collapsed on success so it
+  // does not bury the summary; printed plainly on failure.
+  const log = getState('serveLog');
+  if (log && fs.existsSync(log)) {
+    if (drain.status === 0) {
+      console.log('::group::hestia daemon log');
+    } else {
+      console.log('--- hestia daemon log ---');
     }
+    console.log(fs.readFileSync(log, 'utf8'));
+    if (drain.status === 0) {
+      console.log('::endgroup::');
+    }
+  }
+
+  if (drain.status !== 0) {
     console.error('::error::hestia drain failed; the paths built by this job were not cached');
   }
   return drain.status === null ? 1 : drain.status;


### PR DESCRIPTION
The per-stage drain timings only exist in the daemon log, which was
discarded unless a workflow added its own 'Show daemon log' step (and
the release workflow never did). The post step now prints the log
itself, collapsed in a log group on success and plainly on failure.

Doing this exposed a second problem: the post step located its daemon
through exported HESTIA_* environment variables, which are shared
across invocations. In a job that runs the action twice (like CI's
action-test job), both post steps drained whichever daemon was started
last. Pass bin/socket/log/timeout through GITHUB_STATE instead, which
the runner scopes to each invocation. The HESTIA_* variables stay
exported for the user's own shell steps.

The 'Show daemon log' steps in ci.yml are redundant now and removed.
