### PR TITLE
drain: time the load stage so the breakdown adds up

### DIFF
--- a/src/drain.rs
+++ b/src/drain.rs
@@ -85,7 +85,10 @@ fn throughput(bytes: u64, ms: u64) -> u64 {
 
 /// Per-stage timing breakdown of a drain, for the daemon log.
 pub fn stage_breakdown(stats: &DrainStats) -> String {
-    let mut stages = vec![format!("chunk {}", seconds(stats.chunk_ms))];
+    let mut stages = vec![
+        format!("load {}", seconds(stats.load_ms)),
+        format!("chunk {}", seconds(stats.chunk_ms)),
+    ];
     if stats.packs_uploaded > 0 {
         stages.push(format!(
             "pack {} ({}, {})",
@@ -150,7 +153,8 @@ mod tests {
             packs_uploaded: 1,
             bytes_uploaded: 456_789,
             manifest_version: 7,
-            chunk_ms: 1_200,
+            load_ms: 200,
+            chunk_ms: 1_000,
             pack_ms: 500,
             upload_ms: 200,
             commit_ms: 100,
@@ -163,8 +167,8 @@ mod tests {
         );
         assert_eq!(
             stage_breakdown(&stats),
-            "chunk 1.2s, pack 0.5s (123 chunks, 1 pack), upload 0.2s (2.2 MiB/s), \
-             commit 0.1s, total 2.0s"
+            "load 0.2s, chunk 1.0s, pack 0.5s (123 chunks, 1 pack), \
+             upload 0.2s (2.2 MiB/s), commit 0.1s, total 2.0s"
         );
     }
 
@@ -173,6 +177,7 @@ mod tests {
         let stats = DrainStats {
             pushed: 2,
             manifest_version: 3,
+            load_ms: 100,
             chunk_ms: 400,
             commit_ms: 100,
             elapsed_ms: 600,
@@ -181,7 +186,7 @@ mod tests {
         assert_eq!(summarize(&stats), "pushed 2 paths; manifest m#3");
         assert_eq!(
             stage_breakdown(&stats),
-            "chunk 0.4s, commit 0.1s, total 0.6s"
+            "load 0.1s, chunk 0.4s, commit 0.1s, total 0.6s"
         );
     }
 
@@ -206,7 +211,7 @@ mod tests {
         );
         assert_eq!(
             stage_breakdown(&stats),
-            "chunk 0.3s, pack 0.1s (1 chunk, 1 pack), upload 0.5s (2.0 MiB/s), \
+            "load 0.0s, chunk 0.3s, pack 0.1s (1 chunk, 1 pack), upload 0.5s (2.0 MiB/s), \
              commit 0.1s, total 1.0s"
         );
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -221,6 +221,7 @@ impl PipelineContext {
             return Ok(stats);
         }
 
+        let load_started = std::time::Instant::now();
         let (loaded_version, loaded) = self.load_manifest_versioned().await?;
 
         // Read-your-writes (PLAN.md Decision 28): cache lookups may lag
@@ -296,6 +297,8 @@ impl PipelineContext {
         let mut prepared: Vec<PreparedPath> = Vec::new();
         // Chunks of earlier prepared paths in this batch (cross-path dedup).
         let mut batch_chunks: BTreeSet<crate::manifest::ChunkHash> = BTreeSet::new();
+
+        stats.load_ms = load_started.elapsed().as_millis() as u64;
 
         let chunk_started = std::time::Instant::now();
         for (path, info) in to_push {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -75,6 +75,10 @@ pub struct DrainStats {
     /// needed committing.
     #[serde(default)]
     pub manifest_version: u64,
+    /// Time spent loading the manifest and querying the local store
+    /// (everything before chunking starts), in milliseconds.
+    #[serde(default)]
+    pub load_ms: u64,
     /// Time spent chunking and verifying new paths, in milliseconds.
     #[serde(default)]
     pub chunk_ms: u64,


### PR DESCRIPTION
The stage breakdown left a gap: chunk + commit did not sum to the
total (e.g. 'chunk 0.0s, commit 1.5s, total 2.3s' hides 0.8s). The
missing time is everything before chunking starts: loading the
manifest from the cache, merging it with the published version, and
the local store closure query. Time it as its own 'load' stage:

  drain stages: load 0.8s, chunk 0.0s, commit 1.5s, total 2.3s
