### PR TITLE
ci: add on-demand daemon profiling workflow

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,66 @@
+# Daemon profiling on demand: build hestia with debug info, push a synthetic
+# workload through the daemon and substitute it back out, record both with
+# perf, and upload the flamegraphs as a workflow artifact.
+name: Perf
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  flamegraph:
+    runs-on: ubuntu-latest
+    permissions:
+      # The profiled daemon writes to the GHA cache.
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: NixOS/nix-installer-action@main
+      - name: Build hestia with debug info
+        # The nix package strips debug info; perf needs it for DWARF
+        # unwinding and symbol names.
+        run: nix develop --command env CARGO_PROFILE_RELEASE_DEBUG=2 cargo build --release
+      - name: Start hestia cache
+        uses: ./action
+        with:
+          binary: target/release/hestia
+      - name: Install perf
+        run: |
+          set -euo pipefail
+          sudo apt-get update -q
+          sudo apt-get install -qy linux-tools-common "linux-tools-$(uname -r)" ||
+            sudo apt-get install -qy linux-tools-common linux-tools-generic
+          # Allow profiling other processes and resolving kernel symbols.
+          sudo sysctl kernel.perf_event_paranoid=-1 kernel.kptr_restrict=0
+          perf --version
+      - name: Build synthetic workload
+        env:
+          PERF_WORKLOAD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: nix build --impure --file nix/perf-workload.nix -o ./workload
+      # Push direction: chunking, packing, uploading, manifest commit.
+      - name: Profile the drain
+        run: |
+          bin/profile.sh start
+          "$HESTIA_BIN" drain --socket "$HESTIA_SOCKET" --timeout 600
+          nix shell --inputs-from . nixpkgs#inferno \
+            --command bin/profile.sh stop drain-flamegraph.svg
+      # Serve direction: pack range reads, chunk decompression, NAR
+      # reassembly. The fresh store forces real substitution of the path
+      # the drain just uploaded.
+      - name: Profile substitution of the same path
+        run: |
+          bin/profile.sh start
+          nix copy --no-check-sigs \
+            --from "http://$HESTIA_LISTEN" \
+            --to /tmp/fresh-store \
+            "$(readlink -f ./workload)"
+          nix shell --inputs-from . nixpkgs#inferno \
+            --command bin/profile.sh stop substitute-flamegraph.svg
+      - uses: actions/upload-artifact@v7
+        with:
+          name: flamegraphs
+          path: "*-flamegraph.svg"
+          if-no-files-found: error

--- a/bin/profile.sh
+++ b/bin/profile.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Record the whole system with perf between `start` and `stop`, then render
+# a flamegraph.
+#
+#   profile.sh start                 begin recording
+#   profile.sh stop <output.svg>     end recording, render the flamegraph
+#
+# System-wide recording captures the hestia daemon, the command driving it,
+# and kernel time; the flamegraph groups stacks by process. `stop` needs
+# perf and the inferno tools on PATH.
+
+set -euo pipefail
+
+perf_data=/tmp/hestia-perf.data
+perf_pid_file=/tmp/hestia-perf.pid
+
+start() {
+  if [[ -e $perf_pid_file ]]; then
+    echo "recording already running (pid $(cat "$perf_pid_file"))" >&2
+    exit 1
+  fi
+  sudo perf record -F 199 --call-graph dwarf,16384 -a -o "$perf_data" &
+  echo $! >"$perf_pid_file"
+  # Let perf finish setting up before the caller starts the workload.
+  sleep 1
+  echo "recording started (pid $(cat "$perf_pid_file"))" >&2
+}
+
+stop() {
+  local output="${1:?usage: $0 stop <output.svg>}"
+  local pid
+  pid=$(cat "$perf_pid_file")
+
+  # SIGINT makes perf flush its buffers and exit cleanly.
+  sudo kill -INT "$pid"
+  tail --pid="$pid" -f /dev/null
+  rm -f "$perf_pid_file"
+  sudo chown "$(id -u)" "$perf_data"
+
+  local title
+  title=$(basename "$output" .svg)
+  perf script -i "$perf_data" >"$perf_data.txt"
+  inferno-collapse-perf <"$perf_data.txt" |
+    inferno-flamegraph --title "$title" >"$output"
+  rm -f "$perf_data" "$perf_data.txt"
+  echo "flamegraph written to $output" >&2
+}
+
+case "${1:-}" in
+  start) start ;;
+  stop)
+    shift
+    stop "$@"
+    ;;
+  *)
+    echo "usage: $0 start | stop <output.svg>" >&2
+    exit 1
+    ;;
+esac

--- a/nix/perf-workload.nix
+++ b/nix/perf-workload.nix
@@ -1,0 +1,29 @@
+# Synthetic workload for the Perf workflow (perf.yml): what the profiled
+# drain chunks, packs, and uploads.
+#
+# 64 x 4 MiB random files (incompressible) plus 1000 small text files,
+# ~256 MiB. PERF_WORKLOAD_ID keeps the derivation unique per run, so its
+# chunks never deduplicate against earlier runs.
+#
+# Impure: reads PERF_WORKLOAD_ID and builtins.currentSystem, and fetches
+# the nixpkgs revision pinned in flake.lock.
+let
+  lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+  node = lock.nodes.nixpkgs.locked;
+  nixpkgs = fetchTarball {
+    url = "${node.url}/archive/${node.rev}.tar.gz";
+    sha256 = node.narHash;
+  };
+  pkgs = import nixpkgs { system = builtins.currentSystem; };
+  workloadId = builtins.getEnv "PERF_WORKLOAD_ID";
+in
+assert workloadId != "";
+pkgs.runCommand "perf-workload-${workloadId}" { } ''
+  mkdir -p $out/random $out/text
+  for i in $(seq 1 64); do
+    head -c 4194304 /dev/urandom > $out/random/$i
+  done
+  for i in $(seq 1 1000); do
+    seq 1 500 > $out/text/$i
+  done
+''


### PR DESCRIPTION
Builds hestia with debug info, pushes a run-unique ~256 MiB workload through the daemon, substitutes it back out into a fresh store, and records both directions with perf. Two flamegraphs land in the workflow artifact:

- `drain-flamegraph.svg`: chunking, packing, uploading, manifest commit
- `substitute-flamegraph.svg`: pack range reads, chunk decompression, NAR reassembly (daemon and nix side by side)

Dispatch only. GitHub only allows dispatching workflows that exist on the default branch, so the first real test happens after merge.