### PR TITLE
ci: fix perf recording pitfalls in profile.sh

### DIFF
--- a/bin/profile.sh
+++ b/bin/profile.sh
@@ -19,15 +19,27 @@ start() {
     echo "recording already running (pid $(cat "$perf_pid_file"))" >&2
     exit 1
   fi
-  sudo perf record -F 199 --call-graph dwarf,16384 -a -o "$perf_data" &
-  echo $! >"$perf_pid_file"
-  # Let perf finish setting up before the caller starts the workload.
+  sudo perf record -F 99 --call-graph dwarf -a -o "$perf_data" &
+  local pid=$!
+  # Let perf finish setting up before the caller starts the workload, and
+  # catch immediate failures (bad options, missing permissions) here
+  # instead of as a confusing kill error in stop.
   sleep 1
-  echo "recording started (pid $(cat "$perf_pid_file"))" >&2
+  if ! sudo kill -0 "$pid" 2>/dev/null; then
+    wait "$pid" || true
+    echo "perf record exited immediately; see its output above" >&2
+    exit 1
+  fi
+  echo "$pid" >"$perf_pid_file"
+  echo "recording started (pid $pid)" >&2
 }
 
 stop() {
   local output="${1:?usage: $0 stop <output.svg>}"
+  if [[ ! -e $perf_pid_file ]]; then
+    echo "no recording is running (start one with: $0 start)" >&2
+    exit 1
+  fi
   local pid
   pid=$(cat "$perf_pid_file")
 
@@ -39,10 +51,12 @@ stop() {
 
   local title
   title=$(basename "$output" .svg)
-  perf script -i "$perf_data" >"$perf_data.txt"
-  inferno-collapse-perf <"$perf_data.txt" |
+  # Stream perf script into the collapser: its text output is many times
+  # the size of perf.data and must not land on disk.
+  perf script -i "$perf_data" |
+    inferno-collapse-perf |
     inferno-flamegraph --title "$title" >"$output"
-  rm -f "$perf_data" "$perf_data.txt"
+  rm -f "$perf_data"
   echo "flamegraph written to $output" >&2
 }
 


### PR DESCRIPTION
Three problems found in review after the workflow merged:

* perf script output landed in a file before being collapsed. For a
  system-wide DWARF recording it is many times the size of perf.data
  (gigabytes for a one-minute drain) and can fill the runner disk.
  Stream it through the collapser instead.

* start() reported success even when perf record exited immediately
  (bad option, missing permission), leaving a pidfile pointing at
  nothing; stop then failed with an unrelated kill error. Check that
  perf is still alive before writing the pidfile.

* stop without a running recording crashed on a missing pidfile
  instead of saying what is wrong.

Also drops the sampling rate from 199 Hz to 99 Hz and the DWARF stack
dump from 16 KiB to the 8 KiB default: half the data, still plenty for
drains that run for seconds.
