### PR TITLE
pipeline: split drains into multiple packs, upload them concurrently

### DIFF
--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -168,6 +168,11 @@ impl PackBuilder {
         self.chunks.is_empty()
     }
 
+    /// Compressed bytes buffered so far.
+    pub fn compressed_size(&self) -> u64 {
+        self.buffer.len() as u64
+    }
+
     /// Finalize: the pack hash is the SHA-256 of the complete blob, which
     /// makes packs content-addressed (`pack-{hash}` cache keys).
     pub fn finish(self) -> Pack {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -28,9 +28,16 @@ use crate::pathinfo::{Error as PathInfoError, Lookup, PathInfo, StoreDatabase};
 use crate::protocol::DrainStats;
 use crate::substituter::ManifestStore;
 use crate::upstream::UpstreamFilter;
+use futures_util::{StreamExt as _, TryStreamExt as _};
 
 /// SaveMutable family prefix for the manifest ("m" → keys `m#1`, `m#2`, …).
 pub const MANIFEST_PREFIX: &str = "m";
+
+/// Compressed bytes per pack before a new pack is started.
+pub const PACK_TARGET_SIZE: u64 = 64 * 1024 * 1024;
+
+/// How many packs upload concurrently during a drain.
+const UPLOAD_CONCURRENCY: usize = 4;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -162,6 +169,9 @@ pub struct PipelineContext {
     /// SaveMutable family prefix (always [`MANIFEST_PREFIX`] in production;
     /// tests use distinct prefixes to isolate scenarios).
     pub manifest_prefix: String,
+    /// Compressed bytes per pack ([`PACK_TARGET_SIZE`] in production; tests
+    /// use small values to exercise pack splitting).
+    pub pack_target_size: u64,
     /// Where committed manifests are published for the substituter.
     ///
     /// Read-your-writes: the cache service's lookups are eventually
@@ -349,27 +359,46 @@ impl PipelineContext {
 
         let mut delta = Manifest::new();
 
+        // Pack: seal a pack whenever it reaches the target size, so a large
+        // drain produces several packs that can upload concurrently.
         let pack_started = std::time::Instant::now();
+        let mut packs: Vec<chunker::Pack> = Vec::new();
         let mut builder = PackBuilder::new();
         for path in &prepared {
             for chunk in &path.new_chunks {
                 builder.add(chunk)?;
+                if builder.compressed_size() >= self.pack_target_size {
+                    packs.push(std::mem::take(&mut builder).finish());
+                }
+            }
+        }
+        if !builder.is_empty() {
+            packs.push(builder.finish());
+        }
+        stats.new_chunks = packs.iter().map(|pack| pack.chunks.len()).sum();
+        stats.pack_ms = pack_started.elapsed().as_millis() as u64;
+
+        let upload_started = std::time::Instant::now();
+        let upload_futures: Vec<_> = packs
+            .iter()
+            .map(|pack| async move {
+                let uploaded = upload_pack(&self.twirp, &self.http, pack).await?;
+                Ok::<_, GhaError>((uploaded, pack.data.len() as u64))
+            })
+            .collect();
+        let uploads: Vec<(bool, u64)> = futures_util::stream::iter(upload_futures)
+            .buffer_unordered(UPLOAD_CONCURRENCY)
+            .try_collect()
+            .await?;
+        stats.upload_ms = upload_started.elapsed().as_millis() as u64;
+        for (uploaded, size) in uploads {
+            if uploaded {
+                stats.packs_uploaded += 1;
+                stats.bytes_uploaded += size;
             }
         }
 
-        if !builder.is_empty() {
-            let pack = builder.finish();
-            stats.new_chunks = pack.chunks.len();
-            stats.pack_ms = pack_started.elapsed().as_millis() as u64;
-
-            let upload_started = std::time::Instant::now();
-            let uploaded = upload_pack(&self.twirp, &self.http, &pack).await?;
-            stats.upload_ms = upload_started.elapsed().as_millis() as u64;
-            if uploaded {
-                stats.packs_uploaded += 1;
-                stats.bytes_uploaded += pack.data.len() as u64;
-            }
-
+        for pack in &packs {
             for (chunk_hash, location) in pack.locations() {
                 delta.chunks.insert(chunk_hash, location);
             }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -365,6 +365,7 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         expand_closure: !args.no_closure,
         root_key: pipeline::root_key(&branch, &system),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
+        pack_target_size: pipeline::PACK_TARGET_SIZE,
         // Replaced by Daemon::bind with the daemon's shared ManifestStore.
         publish: None,
     };

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -436,3 +436,40 @@ async fn identical_content_across_paths_shares_chunks() {
     assert_eq!(manifest.paths.len(), 2);
     assert_all_chunks_locatable(&manifest);
 }
+
+#[tokio::test]
+async fn small_pack_target_splits_a_drain_into_multiple_packs() {
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+    // ~600 KB of pseudo-random data -> several FastCDC chunks.
+    let fixture = store.add_fixture("multipack", 7);
+
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let ctx = PipelineContext {
+        // Every chunk exceeds the target, so every chunk seals its own pack.
+        pack_target_size: 1,
+        ..context(&fake, &http, store.database())
+    };
+
+    let stats = ctx
+        .run(to_path_set(&[&fixture]), BTreeSet::new(), now_unix())
+        .await
+        .expect("pipeline run failed");
+
+    assert_eq!(stats.pushed, 1);
+    assert!(
+        stats.packs_uploaded >= 2,
+        "expected multiple packs, got {}",
+        stats.packs_uploaded
+    );
+    assert_eq!(stats.packs_uploaded, pack_count(&fake, &http).await);
+
+    // Every chunk must remain locatable across the pack split.
+    let (_, manifest) = committed_manifest(&fake, &http)
+        .await
+        .expect("manifest committed");
+    assert_eq!(manifest.packs.len(), stats.packs_uploaded);
+    assert_all_chunks_locatable(&manifest);
+}

--- a/tests/support/common.rs
+++ b/tests/support/common.rs
@@ -11,7 +11,7 @@ use hestia::gha::savemutable::SaveMutable;
 use hestia::gha::twirp::{Reservation, TwirpClient};
 use hestia::manifest::{FileSystemObject, Manifest, PathHash};
 use hestia::pathinfo::StoreDatabase;
-use hestia::pipeline::{MANIFEST_PREFIX, PipelineContext};
+use hestia::pipeline::{MANIFEST_PREFIX, PACK_TARGET_SIZE, PipelineContext};
 use hestia::upstream::UpstreamFilter;
 
 use super::fake_gha::FakeGha;
@@ -45,6 +45,7 @@ pub fn pipeline_context_with(
         expand_closure: true,
         root_key: TEST_ROOT_KEY.to_string(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
+        pack_target_size: PACK_TARGET_SIZE,
         publish: None,
     }
 }


### PR DESCRIPTION
Profiling (perf workflow run 26847630463, 117 paths / 200 MiB) shows upload as the largest drain stage: 4.5s at 44 MiB/s over a single sequential PUT.

This seals a pack every 64 MiB of compressed data and uploads up to four packs concurrently. Content-addressed pack keys keep dedup semantics unchanged.

Tested with a pipeline e2e test that forces a tiny pack target so one drain produces many packs.