### PR TITLE
release: create releases as drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,9 +132,9 @@ jobs:
             *-*) prerelease=(--prerelease) ;;
           esac
 
-          # Release notes: copy-paste usage snippet; --generate-notes appends
-          # the changelog below it. The checksums table is for manual
-          # verification only (the action checks the build attestations).
+          # Draft release: usage snippet + auto-generated changelog, pruned
+          # by hand before publishing. The checksums table is for manual
+          # verification (the action checks build attestations).
           sha256_x86_64=$(cut -d' ' -f1 hestia-x86_64-linux.sha256)
           sha256_aarch64=$(cut -d' ' -f1 hestia-aarch64-linux.sha256)
           cat > notes.md <<EOF
@@ -163,5 +163,6 @@ jobs:
             --title "$tag" \
             --notes-file notes.md \
             --generate-notes \
+            --draft \
             "${prerelease[@]}" \
             hestia-*

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -91,6 +91,15 @@ if [[ -z $run_id ]]; then
 fi
 gh run watch "$run_id" --exit-status
 
+# Dogfooding needs a published release; draft assets are not downloadable.
+echo
+echo "draft release created:"
+gh release view "$tag" --json url --jq .url
+echo "edit the notes and publish it; waiting..."
+while [[ "$(gh release view "$tag" --json isDraft --jq .isDraft)" == "true" ]]; do
+  sleep 10
+done
+
 # Point CI dogfooding at the new release. Downloads are verified via build
 # attestations, so only the version variable is needed.
 gh variable set HESTIA_DOGFOOD_VERSION --body "$tag"


### PR DESCRIPTION
Releases now start as drafts: curate the auto-generated changelog, then publish. The release script waits for publication before updating the dogfood variable (draft assets can't be downloaded).