### PR TITLE
release: bump version to 0.1.0-alpha.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hestia"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hestia"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 edition = "2024"
 license = "MIT"
 description = "Nix binary cache backed by the GitHub Actions cache (v2 API)"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
       - uses: NixOS/nix-installer-action@main
       - uses: Mic92/hestia/action@main
         with:
-          version: v0.1.0-alpha.5
+          version: v0.1.0-alpha.6
       - run: nix build .#
 ```
 

--- a/action/README.md
+++ b/action/README.md
@@ -36,7 +36,7 @@ jobs:
       - uses: NixOS/nix-installer-action@main
       - uses: Mic92/hestia/action@main
         with:
-          version: v0.1.0-alpha.5
+          version: v0.1.0-alpha.6
       - run: nix build .#
 ```
 


### PR DESCRIPTION
Version bump for v0.1.0-alpha.6. Tag will be pushed once this lands.