### PR TITLE
gha: handle GitHub rate limits in the REST client

### DIFF
--- a/src/gha/rest.rs
+++ b/src/gha/rest.rs
@@ -11,7 +11,11 @@
 //!
 //! The workflow needs `permissions: actions: write` for deletion.
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use serde::Deserialize;
+use tokio::time::Instant;
 
 use crate::gha::Error;
 
@@ -23,6 +27,17 @@ pub const ENV_GITHUB_REPOSITORY: &str = "GITHUB_REPOSITORY";
 pub const ENV_GITHUB_API_URL: &str = "GITHUB_API_URL";
 
 const PER_PAGE: u32 = 100;
+
+/// GitHub asks for at least one second between mutating requests:
+/// <https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api>
+const MUTATION_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Wait before retrying a rate-limited request that carried no Retry-After
+/// header (GitHub documents "at least one minute").
+const RATE_LIMIT_FALLBACK_WAIT: Duration = Duration::from_secs(60);
+
+/// Give up after this many rate-limited responses for a single request.
+const RATE_LIMIT_MAX_ATTEMPTS: u32 = 5;
 
 /// Build the caches collection URL for a repository.
 fn caches_url(api_url: &str, repo: &str) -> String {
@@ -162,6 +177,11 @@ pub struct RestClient {
     api_url: String,
     repo: String,
     token: String,
+    mutation_interval: Duration,
+    rate_limit_fallback_wait: Duration,
+    /// When the last mutating request was sent. Shared across clones so
+    /// pacing holds globally, not per handle.
+    last_mutation: Arc<tokio::sync::Mutex<Option<Instant>>>,
 }
 
 impl RestClient {
@@ -176,7 +196,21 @@ impl RestClient {
             api_url: api_url.into(),
             repo: repo.into(),
             token: token.into(),
+            mutation_interval: MUTATION_INTERVAL,
+            rate_limit_fallback_wait: RATE_LIMIT_FALLBACK_WAIT,
+            last_mutation: Arc::new(tokio::sync::Mutex::new(None)),
         }
+    }
+
+    /// Override the request pacing (tests use short intervals).
+    pub fn with_pacing(
+        mut self,
+        mutation_interval: Duration,
+        rate_limit_fallback_wait: Duration,
+    ) -> Self {
+        self.mutation_interval = mutation_interval;
+        self.rate_limit_fallback_wait = rate_limit_fallback_wait;
+        self
     }
 
     /// Build a client from `GITHUB_TOKEN` / `GITHUB_REPOSITORY`
@@ -213,19 +247,62 @@ impl RestClient {
             .header(reqwest::header::USER_AGENT, "hestia")
     }
 
-    async fn check<T: serde::de::DeserializeOwned>(
+    /// Hold back a mutating request until `mutation_interval` has passed
+    /// since the previous one.
+    async fn pace_mutation(&self) {
+        let mut last = self.last_mutation.lock().await;
+        if let Some(at) = *last {
+            tokio::time::sleep_until(at + self.mutation_interval).await;
+        }
+        *last = Some(Instant::now());
+    }
+
+    /// Send a request and decode the response, waiting and retrying when
+    /// GitHub rate-limits it. `mutating` requests are additionally paced.
+    ///
+    /// Rate limits answer 403 or 429; a Retry-After header or a "rate
+    /// limit" message distinguishes them from a real permission error.
+    async fn send<T: serde::de::DeserializeOwned>(
+        &self,
         url: &str,
-        response: reqwest::Response,
+        request: reqwest::RequestBuilder,
+        mutating: bool,
     ) -> Result<T, Error> {
-        let status = response.status();
-        if status.is_success() {
-            Ok(response.json().await?)
-        } else {
-            Err(Error::Status {
-                status: status.as_u16(),
-                url: url.to_string(),
-                body: response.text().await.unwrap_or_default(),
-            })
+        let mut attempts = 0;
+        loop {
+            if mutating {
+                self.pace_mutation().await;
+            }
+            let response = request
+                .try_clone()
+                .expect("cache API requests have no streaming body")
+                .send()
+                .await?;
+            let status = response.status();
+            if status.is_success() {
+                return Ok(response.json().await?);
+            }
+
+            let retry_after = response
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(Duration::from_secs);
+            let body = response.text().await.unwrap_or_default();
+
+            let rate_limited = (status == reqwest::StatusCode::FORBIDDEN
+                || status == reqwest::StatusCode::TOO_MANY_REQUESTS)
+                && (retry_after.is_some() || body.to_lowercase().contains("rate limit"));
+            attempts += 1;
+            if !rate_limited || attempts >= RATE_LIMIT_MAX_ATTEMPTS {
+                return Err(Error::Status {
+                    status: status.as_u16(),
+                    url: url.to_string(),
+                    body,
+                });
+            }
+            tokio::time::sleep(retry_after.unwrap_or(self.rate_limit_fallback_wait)).await;
         }
     }
 
@@ -252,8 +329,7 @@ impl RestClient {
             if !key_prefix.is_empty() {
                 request = request.query(&[("key", key_prefix)]);
             }
-            let response = request.send().await?;
-            let list: CacheList = Self::check(&url, response).await?;
+            let list: CacheList = self.send(&url, request, false).await?;
             // Termination must not depend on `total_count` ever becoming
             // consistent with the returned pages: an empty page means there
             // is nothing more to fetch, whatever the server claims.
@@ -273,17 +349,15 @@ impl RestClient {
     /// error and returns an empty list (GC idempotence).
     pub async fn delete_by_key(&self, key: &str) -> Result<Vec<CacheEntry>, Error> {
         let url = self.caches_url();
-        let response = self
+        let request = self
             .request(reqwest::Method::DELETE, &url)
-            .query(&[("key", key)])
-            .send()
-            .await?;
-        // GitHub returns 404 when nothing matched the key.
-        if response.status() == reqwest::StatusCode::NOT_FOUND {
-            return Ok(Vec::new());
+            .query(&[("key", key)]);
+        match self.send(&url, request, true).await {
+            Ok(CacheList { actions_caches, .. }) => Ok(actions_caches),
+            // GitHub returns 404 when nothing matched the key.
+            Err(Error::Status { status: 404, .. }) => Ok(Vec::new()),
+            Err(err) => Err(err),
         }
-        let list: CacheList = Self::check(&url, response).await?;
-        Ok(list.actions_caches)
     }
 }
 

--- a/tests/gha_rest_robustness.rs
+++ b/tests/gha_rest_robustness.rs
@@ -9,14 +9,18 @@
 //!   and duplicates entries.
 //! * `total_count` is server-controlled data; pagination termination must
 //!   not depend on it ever being consistent with the returned pages.
+//! * Mutating requests trip GitHub's secondary rate limit when sent
+//!   back-to-back (GC deletes dozens of entries in one sweep). The client
+//!   must pace them and retry rate-limited responses.
 
 use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::Router;
 use axum::extract::{Query, State};
-use axum::response::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json, Response};
 use axum::routing::get;
 use serde_json::json;
 
@@ -150,6 +154,165 @@ async fn start_github_like(entries: Vec<Entry>, concurrent_downloads: bool) -> S
         .route("/repos/{owner}/{repo}/actions/caches", get(list_handler))
         .with_state(state);
     start_server(router).await
+}
+
+/// A cache endpoint that rate-limits the first `rate_limited_requests`
+/// calls the way GitHub's secondary rate limit does (403 + Retry-After +
+/// a "secondary rate limit" message), and records when each request
+/// arrived.
+struct RateLimitedServer {
+    rate_limited_requests: usize,
+    requests: Vec<Instant>,
+}
+
+impl RateLimitedServer {
+    /// Returns the rate-limit response if this request should be limited.
+    fn admit(&mut self) -> Option<Response> {
+        self.requests.push(Instant::now());
+        if self.requests.len() > self.rate_limited_requests {
+            return None;
+        }
+        Some(
+            (
+                StatusCode::FORBIDDEN,
+                [("retry-after", "1")],
+                Json(json!({
+                    "message": "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+                    "documentation_url": "https://docs.github.com/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits",
+                })),
+            )
+                .into_response(),
+        )
+    }
+}
+
+fn single_entry_listing(key: &str) -> Json<serde_json::Value> {
+    Json(json!({
+        "total_count": 1,
+        "actions_caches": [{
+            "id": 1,
+            "ref": "refs/heads/main",
+            "key": key,
+            "version": "v",
+            "created_at": format_timestamp(1_000),
+            "last_accessed_at": format_timestamp(1_000),
+            "size_in_bytes": 1,
+        }],
+    }))
+}
+
+async fn rate_limited_delete_handler(
+    State(state): State<Arc<Mutex<RateLimitedServer>>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Response {
+    if let Some(limited) = state.lock().unwrap().admit() {
+        return limited;
+    }
+    let key = params.get("key").cloned().unwrap_or_default();
+    single_entry_listing(&key).into_response()
+}
+
+async fn rate_limited_list_handler(State(state): State<Arc<Mutex<RateLimitedServer>>>) -> Response {
+    if let Some(limited) = state.lock().unwrap().admit() {
+        return limited;
+    }
+    single_entry_listing("pack-listed").into_response()
+}
+
+async fn start_rate_limited_server(
+    rate_limited_requests: usize,
+) -> (String, Arc<Mutex<RateLimitedServer>>) {
+    let state = Arc::new(Mutex::new(RateLimitedServer {
+        rate_limited_requests,
+        requests: Vec::new(),
+    }));
+    let router = Router::new()
+        .route(
+            "/repos/{owner}/{repo}/actions/caches",
+            get(rate_limited_list_handler).delete(rate_limited_delete_handler),
+        )
+        .with_state(state.clone());
+    (start_server(router).await, state)
+}
+
+#[tokio::test]
+async fn delete_retries_after_secondary_rate_limit() {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let (url, state) = start_rate_limited_server(1).await;
+        let rest = RestClient::new(reqwest::Client::new(), &url, "fake/repo", "fake-token")
+            .with_pacing(Duration::ZERO, Duration::from_millis(100));
+
+        // GitHub answered the first DELETE with a secondary rate limit
+        // error; the client must wait and retry instead of failing GC.
+        let deleted = rest.delete_by_key("pack-rate-limited").await.unwrap();
+        assert_eq!(deleted.len(), 1);
+        assert_eq!(state.lock().unwrap().requests.len(), 2);
+    })
+    .await
+    .expect("test timed out");
+}
+
+#[tokio::test]
+async fn list_retries_after_secondary_rate_limit() {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let (url, state) = start_rate_limited_server(1).await;
+        let rest = RestClient::new(reqwest::Client::new(), &url, "fake/repo", "fake-token")
+            .with_pacing(Duration::ZERO, Duration::from_millis(100));
+
+        // Reads hit the same secondary rate limit as writes when GC pages
+        // through a large cache; they must retry too.
+        let listed = rest.list_caches("pack-").await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(state.lock().unwrap().requests.len(), 2);
+    })
+    .await
+    .expect("test timed out");
+}
+
+#[tokio::test]
+async fn rate_limiting_that_never_lifts_is_an_error_not_a_hang() {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let (url, _state) = start_rate_limited_server(usize::MAX).await;
+        let rest = RestClient::new(reqwest::Client::new(), &url, "fake/repo", "fake-token")
+            .with_pacing(Duration::ZERO, Duration::from_millis(10));
+
+        let err = rest.delete_by_key("pack-never").await.unwrap_err();
+        assert!(
+            err.to_string().contains("403"),
+            "error should carry the HTTP status: {err}"
+        );
+    })
+    .await
+    .expect("test timed out");
+}
+
+#[tokio::test]
+async fn mutating_requests_are_paced() {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let (url, state) = start_rate_limited_server(0).await;
+        let interval = Duration::from_millis(300);
+        let rest = RestClient::new(reqwest::Client::new(), &url, "fake/repo", "fake-token")
+            .with_pacing(interval, Duration::from_secs(1));
+
+        for i in 0..3 {
+            rest.delete_by_key(&format!("pack-{i}")).await.unwrap();
+        }
+
+        // Three deletes, two enforced gaps. Checking the gap between
+        // consecutive server-side arrivals (not total elapsed time) so a
+        // slow first request cannot mask missing pacing.
+        let requests = state.lock().unwrap().requests.clone();
+        assert_eq!(requests.len(), 3);
+        for pair in requests.windows(2) {
+            let gap = pair[1] - pair[0];
+            assert!(
+                gap >= interval - Duration::from_millis(50),
+                "deletes arrived {gap:?} apart, expected at least {interval:?}"
+            );
+        }
+    })
+    .await
+    .expect("test timed out");
 }
 
 #[tokio::test]

--- a/tests/support/fake_gha.rs
+++ b/tests/support/fake_gha.rs
@@ -30,6 +30,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use axum::Router;
 use axum::body::Bytes;
@@ -615,7 +616,8 @@ impl FakeGha {
         TwirpClient::new(http.clone(), &self.base_url, "fake-runtime-token")
     }
 
-    /// REST client pointed at this fake.
+    /// REST client pointed at this fake. The fake never rate-limits, so
+    /// request pacing is disabled to keep tests fast.
     pub fn rest(&self, http: &reqwest::Client) -> RestClient {
         RestClient::new(
             http.clone(),
@@ -623,6 +625,7 @@ impl FakeGha {
             &self.repo,
             "fake-github-token",
         )
+        .with_pacing(Duration::ZERO, Duration::from_millis(50))
     }
 
     /// Simulate LRU eviction of `key` (entry and blob disappear).


### PR DESCRIPTION
The nightly GC run fails with HTTP 403. It is not a permissions problem: deleting dozens of cache entries back-to-back trips GitHub's [secondary rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#about-secondary-rate-limits).

Per GitHub's [best practices](https://docs.github.com/en/rest/guides/best-practices-for-using-the-rest-api): mutating requests are paced at one per second, and rate-limited responses (403/429 with Retry-After or a rate limit message) are retried after the requested wait instead of failing GC. Both reads and writes retry; only writes are paced.