### PR TITLE
ci: run a GC dry run on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+  # Read-only GC with the PR-built binary against the real cache. The
+  # nightly gc.yml run uses the released binary, so without this job GC
+  # bugs would only show up after a release.
+  gc-dry-run:
+    runs-on: ubuntu-latest
+    # The build job pushes the package closure to the cache.
+    needs: build
+    permissions:
+      # REST cache listing; a dry run never deletes.
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: NixOS/nix-installer-action@main
+      # Substituter for the nix build below; also exports the cache tokens
+      # GC needs to read manifests.
+      - name: Start hestia cache (dogfood)
+        if: vars.HESTIA_DOGFOOD == 'true'
+        uses: ./action
+        with:
+          version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
+      # Token-capture-only mode when dogfooding is off (forks).
+      - uses: ./action
+        if: vars.HESTIA_DOGFOOD != 'true'
+      - name: Build hestia
+        run: nix build .# -o hestia-bin
+      - name: Run GC (dry run)
+        run: ./hestia-bin/bin/hestia gc --dry-run
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
   # End-to-end test of the hestia-cache action on a real runner: install
   # (locally built binary), nix.conf wiring, daemon readiness, post-build-hook
   # capture, manifest commit, and substitution back out of the cache.


### PR DESCRIPTION
GC only runs nightly, with the released binary, so GC bugs show up after a release instead of in the PR that introduces them. The alpha.5 manifest decode bug broke nightly GC for two days.

This adds a CI job that runs `hestia gc --dry-run` with the PR-built binary against the real cache. Deletes still happen only in the nightly run.