### PR TITLE
add macOS (aarch64-darwin) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,15 @@ jobs:
   # the variables unset the dogfood step is skipped.
   #   HESTIA_DOGFOOD          "true"
   #   HESTIA_DOGFOOD_VERSION  release tag, e.g. "v0.1.0-alpha.4"
+  #
+  # macOS jobs do not dogfood yet: no release ships darwin binaries. Drop
+  # the runner.os conditions once one does.
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
     permissions:
       # GHA cache writes when dogfooding is enabled.
       actions: write
@@ -29,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
       - name: Start hestia cache (dogfood)
-        if: vars.HESTIA_DOGFOOD == 'true'
+        if: vars.HESTIA_DOGFOOD == 'true' && runner.os == 'Linux'
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
@@ -131,7 +138,11 @@ jobs:
   # (locally built binary), nix.conf wiring, daemon readiness, post-build-hook
   # capture, manifest commit, and substitution back out of the cache.
   action-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
     # The build job pushes the package closure to the cache.
     needs: build
     permissions:
@@ -143,7 +154,7 @@ jobs:
       # Dogfood substituter, so the nix build below substitutes instead of
       # compiling (forks without the variables build from source).
       - name: Start hestia cache (dogfood)
-        if: vars.HESTIA_DOGFOOD == 'true'
+        if: vars.HESTIA_DOGFOOD == 'true' && runner.os == 'Linux'
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
@@ -186,9 +197,11 @@ jobs:
           curl -fsS "http://$HESTIA_LISTEN/$hash.narinfo"
 
           # Nix itself is the oracle: copy the path out of hestia into a
-          # fresh store.
+          # fresh store. Not /tmp: on macOS it is a symlink, which nix
+          # rejects for store parents.
+          fresh_store="$RUNNER_TEMP/fresh-store"
           nix copy --no-check-sigs \
             --from "http://$HESTIA_LISTEN" \
-            --to /tmp/fresh-store \
+            --to "$fresh_store" \
             "$path"
-          test -e "/tmp/fresh-store$path"
+          test -e "$fresh_store$path"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
             system: x86_64-linux
           - runner: ubuntu-24.04-arm
             system: aarch64-linux
+          - runner: macos-latest
+            system: aarch64-darwin
     runs-on: ${{ matrix.runner }}
     permissions:
       # GHA cache writes when dogfooding is enabled.
@@ -51,13 +53,10 @@ jobs:
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
-      - name: Build static binary
+      - name: Build release binary
         run: nix build .#
       - name: Prepare release asset
-        run: |
-          set -euo pipefail
-          install -m755 result/bin/hestia "hestia-${{ matrix.system }}"
-          sha256sum "hestia-${{ matrix.system }}" | tee "hestia-${{ matrix.system }}.sha256"
+        run: install -m755 result/bin/hestia "hestia-${{ matrix.system }}"
       # Publish build provenance so the hestia-cache action can verify
       # downloaded binaries against GitHub's attestation API instead of
       # requiring users to pin a sha256.
@@ -68,9 +67,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: hestia-${{ matrix.system }}
-          path: |
-            hestia-${{ matrix.system }}
-            hestia-${{ matrix.system }}.sha256
+          path: hestia-${{ matrix.system }}
           if-no-files-found: error
 
   release:
@@ -98,10 +95,8 @@ jobs:
           esac
 
           # Draft release: usage snippet + auto-generated changelog, pruned
-          # by hand before publishing. The checksums table is for manual
-          # verification (the action checks build attestations).
-          sha256_x86_64=$(cut -d' ' -f1 hestia-x86_64-linux.sha256)
-          sha256_aarch64=$(cut -d' ' -f1 hestia-aarch64-linux.sha256)
+          # by hand before publishing. Binaries are verified via build
+          # attestations (gh attestation verify), so no checksums.
           cat > notes.md <<EOF
           This is alpha software. The cache format and behavior can change
           between releases; a format change means the cache starts out empty
@@ -114,13 +109,6 @@ jobs:
             with:
               version: ${tag}
           \`\`\`
-
-          ## Checksums (SHA-256)
-
-          | Asset | Digest |
-          |---|---|
-          | hestia-x86_64-linux | \`${sha256_x86_64}\` |
-          | hestia-aarch64-linux | \`${sha256_aarch64}\` |
           EOF
 
           gh release create "$tag" \

--- a/action/README.md
+++ b/action/README.md
@@ -15,8 +15,10 @@ When the job starts, the action:
    against GitHub's build attestations) or from a path you built yourself.
 3. Starts the hestia daemon: a post-build-hook listener plus a local
    substituter speaking the Nix binary cache protocol over HTTP.
-4. Wires both into `nix.conf` (`extra-substituters` with `?trusted=true`,
-   `post-build-hook`) and restarts the nix-daemon if there is one.
+4. Wires both into a private `nix.conf` (`extra-substituters` with
+   `?trusted=true`, `post-build-hook`) registered via `NIX_USER_CONF_FILES`.
+   No nix-daemon restart; on multi-user installs the runner user must be in
+   `trusted-users` for the hook to fire (GitHub-hosted runners are).
 
 When the job ends, a post step drains the daemon: everything that was built
 is chunked, packed, and uploaded, and the manifest is committed to the GHA

--- a/action/main.js
+++ b/action/main.js
@@ -12,6 +12,7 @@
 
 const crypto = require('crypto');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawn, spawnSync } = require('child_process');
 
@@ -43,14 +44,6 @@ function saveState(name, value) {
 function fail(message) {
   console.error(`::error::${message}`);
   process.exit(1);
-}
-
-/** Run a command, streaming output; throws on non-zero exit. */
-function run(command, args) {
-  const result = spawnSync(command, args, { stdio: 'inherit' });
-  if (result.status !== 0) {
-    throw new Error(`${command} ${args.join(' ')} exited with ${result.status}`);
-  }
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -135,10 +128,13 @@ async function installBinary(installDir) {
     fs.copyFileSync(binary, target);
   } else {
     const arch = { x64: 'x86_64', arm64: 'aarch64' }[process.arch] || process.arch;
+    if (process.platform !== 'linux' && process.platform !== 'darwin') {
+      fail(`unsupported platform: ${process.platform}`);
+    }
     // GITHUB_ACTION_REPOSITORY points at the repo this action was loaded
     // from, so forks automatically download their own releases.
     const repo = process.env.GITHUB_ACTION_REPOSITORY || 'Mic92/hestia';
-    const assetName = `hestia-${arch}-linux`;
+    const assetName = `hestia-${arch}-${process.platform}`;
     const url = `https://github.com/${repo}/releases/download/${version}/${assetName}`;
     console.log(`hestia-cache: downloading ${url}`);
     const response = await fetch(url, { redirect: 'follow' });
@@ -177,50 +173,57 @@ function writeHookShim(installDir, hestiaBin, socket) {
  *                      come from hestia, everything else from upstream.
  * - fallback = true -> if a cached path disappears mid-job (LRU eviction),
  *                      Nix rebuilds instead of failing.
+ *
+ * The settings live in a private nix.conf registered via
+ * NIX_USER_CONF_FILES, not in /etc/nix/nix.conf: needs no sudo and no
+ * nix-daemon restart (restarting needs systemd or launchd, which
+ * self-hosted runners may not have). With a multi-user install, nix
+ * forwards settings from trusted users to the daemon, so the
+ * post-build-hook still fires; GitHub-hosted runners put the runner user
+ * in trusted-users.
  */
-function configureNix(listen, hookShim) {
-  const snippet =
-    '\n# --- added by the hestia-cache action ---\n' +
-    `extra-substituters = http://${listen}?trusted=true&priority=30\n` +
-    `post-build-hook = ${hookShim}\n` +
-    'fallback = true\n';
+function configureNix(installDir, listen, hookShim) {
+  const conf = path.join(installDir, 'nix.conf');
+  fs.writeFileSync(
+    conf,
+    '# written by the hestia-cache action\n' +
+      `extra-substituters = http://${listen}?trusted=true&priority=30\n` +
+      `post-build-hook = ${hookShim}\n` +
+      'fallback = true\n'
+  );
 
-  const systemConf = '/etc/nix/nix.conf';
-  if (fs.existsSync(systemConf)) {
-    // Multi-user install (GitHub-hosted runners): the nix-daemon reads
-    // /etc/nix/nix.conf and must be restarted to pick up the hook.
-    appendPrivileged(systemConf, snippet);
-    restartNixDaemon();
-  } else {
-    // Single-user install: per-user configuration is enough.
-    const userConfDir = path.join(process.env.HOME || '/root', '.config', 'nix');
-    fs.mkdirSync(userConfDir, { recursive: true });
-    fs.appendFileSync(path.join(userConfDir, 'nix.conf'), snippet);
-  }
+  // Prepend to the search path so existing user configuration stays active.
+  const home = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  const dirs = (process.env.XDG_CONFIG_DIRS || '/etc/xdg').split(':');
+  const defaults = [home, ...dirs].map((dir) => path.join(dir, 'nix', 'nix.conf')).join(':');
+  const existing = process.env.NIX_USER_CONF_FILES || defaults;
+  exportVariable('NIX_USER_CONF_FILES', `${conf}:${existing}`);
+
+  warnIfHookCannotFire();
 }
 
-/** Append to a root-owned file: direct write if permitted, sudo tee otherwise. */
-function appendPrivileged(file, content) {
+/**
+ * The post-build-hook only fires when nix accepts it from this user:
+ * single-user installs (writable store) or members of trusted-users.
+ */
+function warnIfHookCannotFire() {
   try {
-    fs.appendFileSync(file, content);
-    return;
+    fs.accessSync('/nix/store', fs.constants.W_OK);
+    return; // single-user install: no daemon involved
   } catch {
-    // Not writable by this user; fall through to sudo.
+    // Multi-user: the daemon only honors the hook for trusted users.
   }
-  const tee = spawnSync('sudo', ['tee', '-a', file], {
-    input: content,
-    stdio: ['pipe', 'ignore', 'inherit'],
-  });
-  if (tee.status !== 0) {
-    fail(`cannot write ${file} (tried direct write and sudo tee)`);
+  const show = spawnSync('nix', ['config', 'show', 'trusted-users'], { encoding: 'utf8' });
+  if (show.status !== 0) {
+    return; // cannot determine; stay quiet
   }
-}
-
-function restartNixDaemon() {
-  const isActive = spawnSync('systemctl', ['is-active', '--quiet', 'nix-daemon']);
-  if (isActive.status === 0) {
-    console.log('hestia-cache: restarting nix-daemon to pick up nix.conf changes');
-    run('sudo', ['systemctl', 'restart', 'nix-daemon']);
+  const trusted = show.stdout.trim().split(/\s+/);
+  const user = os.userInfo().username;
+  if (!trusted.includes(user) && !trusted.includes('*')) {
+    console.log(
+      `::warning::hestia-cache: ${user} is not in nix trusted-users; ` +
+        'the post-build-hook cannot fire and built paths will not be cached'
+    );
   }
 }
 
@@ -303,7 +306,7 @@ async function main() {
 
   const hestiaBin = await installBinary(installDir);
   const hookShim = writeHookShim(installDir, hestiaBin, socket);
-  configureNix(listen, hookShim);
+  configureNix(installDir, listen, hookShim);
   startDaemon(hestiaBin, listen, socket, logFile);
   await waitForReadiness(listen, logFile);
 

--- a/nix/crane.nix
+++ b/nix/crane.nix
@@ -49,6 +49,22 @@ in
     // {
       inherit cargoArtifacts;
       doCheck = false;
+      # Release binaries must run outside the nix store. Linux is static
+      # (musl); darwin must only link system libraries.
+      postInstall = lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
+        # Rust std links libiconv, and nixpkgs' rustc resolves it to the
+        # nix store copy. Swap in the system one (shipped with macOS).
+        # The fixup phase re-signs the binary afterwards.
+        nix_libiconv=$(otool -L "$out/bin/hestia" | awk '/\/nix\/store\/.*libiconv/{print $1}')
+        if [ -n "$nix_libiconv" ]; then
+          install_name_tool -change "$nix_libiconv" /usr/lib/libiconv.2.dylib "$out/bin/hestia"
+        fi
+
+        if otool -L "$out/bin/hestia" | tail -n +2 | grep /nix/store; then
+          echo "error: hestia links against nix store paths" >&2
+          exit 1
+        fi
+      '';
       meta = {
         description = "Nix binary cache backed by the GitHub Actions cache (v2 API)";
         homepage = "https://github.com/Mic92/hestia";


### PR DESCRIPTION
CI builds and tests on macos-latest, the action downloads darwin release binaries, and releases ship hestia-aarch64-darwin. x86 macs stay unsupported.

macOS has no static linking, so darwin binaries stay dynamic. A build check asserts they only link system libraries, otherwise they could not run outside the nix store. Rust std links libiconv from the nix store; the build rewrites that to the system copy.

The action no longer appends to /etc/nix/nix.conf and restarts the nix-daemon. The restart needs systemd or launchctl - on macOS it silently never happened, so the post-build-hook never fired, and self-hosted runners without systemd would have the same problem. Instead, settings go into a private nix.conf registered via NIX_USER_CONF_FILES (same approach as the niks3 action); nix forwards them to the daemon for trusted users, and untrusted users get a warning.

The macOS CI jobs skip dogfooding until a release ships darwin binaries; the runner.os conditions come out after that.

Also drops the checksums table from release notes: attestations cover verification, and macOS runners have no sha256sum.