### PR TITLE
gha: retry transient Azure failures in blob transfers

### DIFF
--- a/src/gha/blob.rs
+++ b/src/gha/blob.rs
@@ -9,8 +9,10 @@
 //!
 //! SAS URLs expire. On 401/403 the caller-provided refresh callback is asked
 //! for a fresh URL (a new Twirp round-trip) and the transfer is retried once.
+//! Transient failures (5xx, dropped connections) are retried with backoff.
 
 use std::ops::Range;
+use std::time::Duration;
 
 use bytes::Bytes;
 
@@ -21,6 +23,12 @@ const BLOB_TYPE: &str = "BlockBlob";
 
 /// Azure storage API version header (matches what actions/toolkit sends).
 const API_VERSION: &str = "2020-04-08";
+
+/// Retries for transient failures (503 ServerBusy, dropped connections).
+const TRANSIENT_RETRIES: u32 = 3;
+
+/// First retry delay; doubles per attempt.
+const TRANSIENT_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// Format a half-open byte range as an HTTP `Range` header value
 /// (inclusive on both ends per RFC 9110).
@@ -119,8 +127,10 @@ pub async fn get(
     Ok(body)
 }
 
-/// Like [`put`], but when the SAS URL has expired (401/403), ask `refresh`
-/// for a fresh URL and retry once.
+/// Like [`put`], but recovers from the two failure classes a pre-signed
+/// transfer can hit: expired SAS URLs (401/403, ask `refresh` for a fresh
+/// URL once) and transient failures (5xx, dropped connections; retried
+/// with backoff).
 pub async fn put_with_refresh<F>(
     http: &reqwest::Client,
     url: &str,
@@ -130,17 +140,26 @@ pub async fn put_with_refresh<F>(
 where
     F: AsyncFnOnce() -> Result<String, Error>,
 {
-    match put(http, url, data.clone()).await {
-        Err(Error::Status { status, .. }) if url_expired(status) => {
-            let fresh_url = refresh().await?;
-            put(http, &fresh_url, data).await
+    let mut url = url.to_string();
+    let mut refresh = Some(refresh);
+    let mut transient_left = TRANSIENT_RETRIES;
+    let mut delay = TRANSIENT_RETRY_DELAY;
+    loop {
+        match put(http, &url, data.clone()).await {
+            Err(Error::Status { status, .. }) if url_expired(status) && refresh.is_some() => {
+                url = refresh.take().expect("checked above")().await?;
+            }
+            Err(err) if is_transient(&err) && transient_left > 0 => {
+                transient_left -= 1;
+                tokio::time::sleep(delay).await;
+                delay *= 2;
+            }
+            result => return result,
         }
-        result => result,
     }
 }
 
-/// Like [`get`], but when the SAS URL has expired (401/403), ask `refresh`
-/// for a fresh URL and retry once.
+/// Like [`get`], but with the same recovery as [`put_with_refresh`].
 pub async fn get_with_refresh<F>(
     http: &reqwest::Client,
     url: &str,
@@ -150,12 +169,22 @@ pub async fn get_with_refresh<F>(
 where
     F: AsyncFnOnce() -> Result<String, Error>,
 {
-    match get(http, url, range.clone()).await {
-        Err(Error::Status { status, .. }) if url_expired(status) => {
-            let fresh_url = refresh().await?;
-            get(http, &fresh_url, range).await
+    let mut url = url.to_string();
+    let mut refresh = Some(refresh);
+    let mut transient_left = TRANSIENT_RETRIES;
+    let mut delay = TRANSIENT_RETRY_DELAY;
+    loop {
+        match get(http, &url, range.clone()).await {
+            Err(Error::Status { status, .. }) if url_expired(status) && refresh.is_some() => {
+                url = refresh.take().expect("checked above")().await?;
+            }
+            Err(err) if is_transient(&err) && transient_left > 0 => {
+                transient_left -= 1;
+                tokio::time::sleep(delay).await;
+                delay *= 2;
+            }
+            result => return result,
         }
-        result => result,
     }
 }
 

--- a/tests/gha_blob_robustness.rs
+++ b/tests/gha_blob_robustness.rs
@@ -1,5 +1,5 @@
 //! Regression tests for the Azure blob client (`gha::blob`) against
-//! servers that mishandle `Range` requests.
+//! servers that mishandle `Range` requests or fail transiently.
 //!
 //! `blob::get(url, Some(range))` promises to return exactly the requested
 //! bytes. Callers build chunk extraction on that promise:
@@ -12,13 +12,21 @@
 //!
 //! Both failure modes must surface as clean errors from `blob::get`, never
 //! as silently wrong data.
+//!
+//! Azure also fails transiently (503 ServerBusy, dropped connections). The
+//! `*_with_refresh` transfer functions every production caller uses must
+//! retry those instead of failing the drain or GC run.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use axum::Router;
+use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::IntoResponse;
 use axum::routing::get;
+use bytes::Bytes;
 
 use hestia::gha::blob;
 
@@ -70,6 +78,103 @@ async fn start_server() -> String {
         axum::serve(listener, router).await.unwrap();
     });
     format!("http://{addr}")
+}
+
+/// A server that answers 503 ServerBusy a fixed number of times before
+/// succeeding, the way Azure behaves under load.
+async fn busy_then_ok(
+    State(remaining): State<Arc<AtomicUsize>>,
+    method: axum::http::Method,
+) -> impl IntoResponse {
+    if remaining
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+        .is_ok()
+    {
+        return (StatusCode::SERVICE_UNAVAILABLE, b"ServerBusy".to_vec());
+    }
+    if method == axum::http::Method::PUT {
+        (StatusCode::CREATED, Vec::new())
+    } else {
+        (StatusCode::OK, BLOB.to_vec())
+    }
+}
+
+/// Start a server whose blob endpoint is busy for the first `busy` requests,
+/// returning the request counter.
+async fn start_busy_server(busy: usize) -> (String, Arc<AtomicUsize>) {
+    let remaining = Arc::new(AtomicUsize::new(busy));
+    let router = Router::new()
+        .route("/blob", get(busy_then_ok).put(busy_then_ok))
+        .with_state(remaining.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind stub listener");
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    (format!("http://{addr}"), remaining)
+}
+
+/// Refresh callback that must not be called: 503 is not a URL expiry.
+async fn no_refresh() -> Result<String, hestia::gha::Error> {
+    panic!("refresh must only be called for 401/403, not for transient errors");
+}
+
+#[tokio::test]
+async fn upload_retries_transient_server_errors() {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let (base, _) = start_busy_server(2).await;
+        let http = reqwest::Client::new();
+        let url = format!("{base}/blob");
+
+        blob::put_with_refresh(&http, &url, Bytes::from_static(b"data"), no_refresh)
+            .await
+            .expect("two 503s then success must not fail the upload");
+    })
+    .await
+    .expect("test timed out");
+}
+
+#[tokio::test]
+async fn download_retries_transient_server_errors() {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let (base, _) = start_busy_server(2).await;
+        let http = reqwest::Client::new();
+        let url = format!("{base}/blob");
+
+        let data = blob::get_with_refresh(&http, &url, None, no_refresh)
+            .await
+            .expect("two 503s then success must not fail the download");
+        assert_eq!(data.as_ref(), &BLOB[..]);
+    })
+    .await
+    .expect("test timed out");
+}
+
+#[tokio::test]
+async fn permanent_server_errors_fail_after_bounded_retries() {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let (base, remaining) = start_busy_server(usize::MAX).await;
+        let http = reqwest::Client::new();
+        let url = format!("{base}/blob");
+
+        let err = blob::put_with_refresh(&http, &url, Bytes::from_static(b"data"), no_refresh)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("503"),
+            "error should carry the HTTP status: {err}"
+        );
+        // Bounded: a permanently busy server must not be hammered forever.
+        let requests = usize::MAX - remaining.load(Ordering::SeqCst);
+        assert!(
+            (2..=8).contains(&requests),
+            "expected a small bounded number of attempts, got {requests}"
+        );
+    })
+    .await
+    .expect("test timed out");
 }
 
 #[tokio::test]

--- a/tests/gha_real.rs
+++ b/tests/gha_real.rs
@@ -81,9 +81,11 @@ async fn real_blob_round_trip_range_read_and_delete() {
     let Reservation::Created { upload_url } = twirp.create_cache_entry(&key).await.unwrap() else {
         panic!("fresh unique key reported as already existing");
     };
-    blob::put(&http, &upload_url, Bytes::from(data.clone()))
-        .await
-        .unwrap();
+    blob::put_with_refresh(&http, &upload_url, Bytes::from(data.clone()), async || {
+        Ok(upload_url.clone())
+    })
+    .await
+    .unwrap();
     twirp
         .finalize_upload(&key, data.len() as u64)
         .await
@@ -106,7 +108,9 @@ async fn real_blob_round_trip_range_read_and_delete() {
         panic!("just-finalized entry not found after {PROPAGATION_TIMEOUT:?}");
     };
     assert_eq!(matched_key, key);
-    let downloaded = blob::get(&http, &url, None).await.unwrap();
+    let downloaded = blob::get_with_refresh(&http, &url, None, async || Ok(url.clone()))
+        .await
+        .unwrap();
     assert_eq!(
         downloaded.as_ref(),
         data.as_slice(),
@@ -114,11 +118,15 @@ async fn real_blob_round_trip_range_read_and_delete() {
     );
 
     // Range read (chunk access pattern).
-    let chunk = blob::get(&http, &url, Some(1000..2000)).await.unwrap();
+    let chunk = blob::get_with_refresh(&http, &url, Some(1000..2000), async || Ok(url.clone()))
+        .await
+        .unwrap();
     assert_eq!(chunk.as_ref(), &data[1000..2000], "range read differs");
 
     // 1-byte read (GC LRU touch).
-    let touch = blob::get(&http, &url, Some(0..1)).await.unwrap();
+    let touch = blob::get_with_refresh(&http, &url, Some(0..1), async || Ok(url.clone()))
+        .await
+        .unwrap();
     assert_eq!(touch.len(), 1);
 
     // REST: the entry shows up in a prefix list. The REST view lags behind
@@ -176,9 +184,14 @@ async fn real_miss_and_restore_key_prefix() {
         else {
             panic!("fresh key {key} already exists");
         };
-        blob::put(&http, &upload_url, Bytes::from(payload.clone()))
-            .await
-            .unwrap();
+        blob::put_with_refresh(
+            &http,
+            &upload_url,
+            Bytes::from(payload.clone()),
+            async || Ok(upload_url.clone()),
+        )
+        .await
+        .unwrap();
         twirp
             .finalize_upload(&key, payload.len() as u64)
             .await
@@ -205,7 +218,9 @@ async fn real_miss_and_restore_key_prefix() {
         panic!("prefix restore lookup missed after {PROPAGATION_TIMEOUT:?}");
     };
     assert_eq!(matched_key, expected_key, "newest entry must win");
-    let data = blob::get(&http, &url, None).await.unwrap();
+    let data = blob::get_with_refresh(&http, &url, None, async || Ok(url.clone()))
+        .await
+        .unwrap();
     assert_eq!(data.as_ref(), b"payload v2");
 
     // Cleanup.


### PR DESCRIPTION
Azure intermittently answers 503 ServerBusy; CI hit this in the real-API tests. Uploads had no retry at all, so a busy Azure failed the whole drain - only the substituter's download path retried transient errors.

`put_with_refresh`/`get_with_refresh` (what all production callers use) now retry 5xx and dropped connections with backoff, on top of the existing 401/403 URL refresh. The real-API tests use them instead of the raw single-shot transfers.