### PR TITLE
release: do not dogfood on macOS until darwin binaries exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,10 @@ jobs:
       # fast, seed main's scope once by running this workflow via
       # workflow_dispatch (dry run on main) after the nixpkgs pin or the
       # toolchain changes.
+      # macOS is not dogfooded yet: no published release ships darwin
+      # binaries. Drop the runner.os gate after the next release.
       - name: Start hestia cache (dogfood)
-        if: vars.HESTIA_DOGFOOD == 'true'
+        if: vars.HESTIA_DOGFOOD == 'true' && runner.os == 'Linux'
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}


### PR DESCRIPTION
release.yml's dogfood step ran on the darwin matrix entry too and tried to download `hestia-aarch64-darwin` from alpha.6 (404, no darwin binaries yet). Same gate the CI workflow uses; drop after alpha.8 ships darwin binaries.