### PR TITLE
ci: dogfood on macOS too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
       - name: Start hestia cache (dogfood)
-        if: vars.HESTIA_DOGFOOD == 'true' && runner.os == 'Linux'
+        if: vars.HESTIA_DOGFOOD == 'true'
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
@@ -154,7 +154,7 @@ jobs:
       # Dogfood substituter, so the nix build below substitutes instead of
       # compiling (forks without the variables build from source).
       - name: Start hestia cache (dogfood)
-        if: vars.HESTIA_DOGFOOD == 'true' && runner.os == 'Linux'
+        if: vars.HESTIA_DOGFOOD == 'true'
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,8 @@ jobs:
       # fast, seed main's scope once by running this workflow via
       # workflow_dispatch (dry run on main) after the nixpkgs pin or the
       # toolchain changes.
-      # macOS is not dogfooded yet: no published release ships darwin
-      # binaries. Drop the runner.os gate after the next release.
       - name: Start hestia cache (dogfood)
-        if: vars.HESTIA_DOGFOOD == 'true' && runner.os == 'Linux'
+        if: vars.HESTIA_DOGFOOD == 'true'
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}


### PR DESCRIPTION
alpha.8 ships hestia-aarch64-darwin, so the macOS matrix entries can consume the cache like the Linux ones.