### PR TITLE
action: auto-resolve latest release when version is omitted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,11 @@ jobs:
         uses: ./action
         with:
           version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
-      # No binary/version input: token-capture-only mode (must stay tested).
+      # Explicitly empty binary/version: token-capture-only mode (must
+      # stay tested). version defaults to "latest" when omitted.
       - uses: ./action
+        with:
+          version: ""
       - name: Assert cache tokens are visible to shell steps
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
       - uses: Mic92/hestia/action@main
-        with:
-          version: v0.1.0-alpha.9
       - run: nix build .#
 ```
 

--- a/action/README.md
+++ b/action/README.md
@@ -37,8 +37,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
       - uses: Mic92/hestia/action@main
-        with:
-          version: v0.1.0-alpha.9
       - run: nix build .#
 ```
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -20,10 +20,11 @@ inputs:
   version:
     description: >
       Hestia release tag to download from GitHub releases
-      (e.g. "v0.1.0-alpha.4"). The downloaded binary is verified against
-      GitHub's build provenance attestations before it runs.
+      (e.g. "v0.1.0-alpha.4"), or "latest" to auto-resolve the newest
+      release.  The downloaded binary is verified against GitHub's build
+      provenance attestations before it runs.
     required: false
-    default: ""
+    default: "latest"
   github-token:
     description: >
       Token for the attestation API lookup that verifies downloaded release
@@ -64,8 +65,8 @@ inputs:
     required: false
     default: "false"
 
-# If neither `binary` nor `version` is set, the action only captures and
-# exports the cache tokens (ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL).
+# If both `binary` and `version` are explicitly empty, the action only
+# captures and exports the cache tokens (ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL).
 # That mode exists for setups that run hestia themselves -- for example
 # hestia's own integration tests against the real cache API.
 

--- a/action/main.js
+++ b/action/main.js
@@ -117,16 +117,44 @@ async function verifyAttestation(repo, assetName, digest, token) {
   console.log(`hestia-cache: attestation verified for ${assetName} (sha256:${digest})${builtBy}`);
 }
 
+/**
+ * Resolve "latest" to the actual tag name of the newest GitHub release.
+ * Falls back to the GitHub API for the repository this action was loaded
+ * from, so forks resolve their own releases.
+ */
+async function resolveVersion(version) {
+  if (version !== 'latest') return version;
+  const repo = process.env.GITHUB_ACTION_REPOSITORY || 'Mic92/hestia';
+  // /releases/latest skips prereleases, so list recent releases and pick
+  // the first published (non-draft) entry.
+  const url = `https://api.github.com/repos/${repo}/releases?per_page=10`;
+  const headers = { Accept: 'application/vnd.github+json' };
+  const token = getInput('github-token');
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    fail(`failed to resolve latest release: HTTP ${response.status} from ${url}`);
+  }
+  const releases = (await response.json()).filter((r) => !r.draft);
+  if (!releases.length) {
+    fail(`no published releases found for ${repo}`);
+  }
+  const tag = releases[0].tag_name;
+  console.log(`hestia-cache: resolved 'latest' to ${tag}`);
+  return tag;
+}
+
 /** Install the hestia binary into installDir; returns its path. */
 async function installBinary(installDir) {
   const target = path.join(installDir, 'hestia');
   const binary = getInput('binary');
-  const version = getInput('version');
+  let version = getInput('version');
 
   if (binary) {
     console.log(`hestia-cache: installing from local binary ${binary}`);
     fs.copyFileSync(binary, target);
   } else {
+    version = await resolveVersion(version);
     const arch = { x64: 'x86_64', arm64: 'aarch64' }[process.arch] || process.arch;
     if (process.platform !== 'linux' && process.platform !== 'darwin') {
       fail(`unsupported platform: ${process.platform}`);

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -49,13 +49,10 @@ fi
 # packages read it via importTOML); cargo syncs Cargo.lock.
 sed -i -e "0,/^version = \".*\"\$/s//version = \"${version}\"/" Cargo.toml
 nix develop --command cargo update --package hestia
-# Release examples in the documentation reference the latest tag.
-sed -i -e "s/version: v[0-9][^\"' ]*/version: ${tag}/" README.md action/README.md
-
 branch="release-${version}"
 git branch -D "$branch" 2>/dev/null || true
 git checkout -b "$branch"
-git add Cargo.toml Cargo.lock README.md action/README.md
+git add Cargo.toml Cargo.lock
 git commit -m "release: bump version to ${version}"
 git push --force-with-lease origin "$branch"
 


### PR DESCRIPTION
Users tracking alpha releases had to bump the `version` input on every release. Now the action defaults to `latest` and resolves it to the newest published release tag (including prereleases) via the GitHub API at install time. Pinning a specific tag still works.

Also removes the version-bumping sed for README/action docs from the release script since the examples no longer hardcode a tag.