### PR TITLE
tests: local drain benchmark against a throttled fake backend

### DIFF
--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -186,6 +186,53 @@ impl PackBuilder {
     }
 }
 
+/// A chunk compressed into its pack frame, ready for
+/// [`PackBuilder::add_compressed`].
+#[derive(Debug)]
+pub struct CompressedChunk {
+    pub hash: ChunkHash,
+    pub frame: Vec<u8>,
+    pub uncompressed_size: u32,
+}
+
+/// Compress chunks in parallel across CPU cores, preserving order.
+///
+/// zstd is the dominant CPU cost of a drain; spreading one path's chunks
+/// over all cores shortens the producer's critical path.
+/// Blocking: call via `spawn_blocking` from async code.
+pub fn compress_chunks(chunks: Vec<Chunk>) -> Result<Vec<CompressedChunk>, Error> {
+    let compress_one = |chunk: &Chunk| -> Result<CompressedChunk, Error> {
+        Ok(CompressedChunk {
+            hash: chunk.hash,
+            frame: zstd::encode_all(chunk.data.as_ref(), ZSTD_LEVEL)?,
+            uncompressed_size: chunk.data.len() as u32,
+        })
+    };
+    let workers = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .min(chunks.len());
+    if workers <= 1 {
+        return chunks.iter().map(compress_one).collect();
+    }
+    // Static partitioning balances well: CDC keeps chunk sizes near the
+    // average, so equal-count slices carry roughly equal work.
+    let per_worker = chunks.len().div_ceil(workers);
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = chunks
+            .chunks(per_worker)
+            .map(|slice| scope.spawn(move || slice.iter().map(compress_one).collect()))
+            .collect();
+        let mut out = Vec::with_capacity(chunks.len());
+        for handle in handles {
+            let frames: Result<Vec<CompressedChunk>, Error> =
+                handle.join().expect("compression worker panicked");
+            out.extend(frames?);
+        }
+        Ok(out)
+    })
+}
+
 /// A finished pack blob ready for upload.
 #[derive(Debug, Clone)]
 pub struct Pack {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::chunker::{self, PackBuilder, chunk_path, nar_hash_from_chunks};
+use crate::chunker::{self, PackBuilder, chunk_path, compress_chunks, nar_hash_from_chunks};
 use crate::gha::Error as GhaError;
 use crate::gha::savemutable::SaveMutable;
 use crate::gha::twirp::{Reservation, TwirpClient};
@@ -186,9 +186,6 @@ pub struct PipelineContext {
 struct PreparedPath {
     hash: PathHash,
     entry: PathEntry,
-    /// This path's chunks that exist in neither the manifest nor an earlier
-    /// prepared path of the same batch.
-    new_chunks: Vec<chunker::Chunk>,
 }
 
 impl PipelineContext {
@@ -304,99 +301,127 @@ impl PipelineContext {
             to_push.push((path, info));
         }
 
-        let mut prepared: Vec<PreparedPath> = Vec::new();
-        // Chunks of earlier prepared paths in this batch (cross-path dedup).
-        let mut batch_chunks: BTreeSet<crate::manifest::ChunkHash> = BTreeSet::new();
-
         stats.load_ms = load_started.elapsed().as_millis() as u64;
 
-        let chunk_started = std::time::Instant::now();
-        for (path, info) in to_push {
-            let chunked = chunk_path(&path).await?;
-            let chunk_map = chunked.chunk_map();
+        // Pipelined chunk → compress → pack → upload: the producer chunks
+        // paths sequentially, compresses their new chunks in parallel
+        // across cores, and seals packs at the target size; sealed packs
+        // flow through a bounded channel to the uploader, so network
+        // transfer overlaps with the CPU work for later paths.
+        let (pack_tx, pack_rx) = tokio::sync::mpsc::channel::<chunker::Pack>(2);
 
-            // Integrity gate: the chunked representation must reproduce the
-            // NAR hash Nix recorded for this path. A mismatch means hestia
-            // would serve corrupt data; never upload it.
-            let (nar_hash, nar_size) = nar_hash_from_chunks(&chunked.tree, &chunk_map).await?;
-            if nar_hash != info.nar_hash || nar_size != info.nar_size {
-                eprintln!(
-                    "hestia: NOT uploading {path}: chunked NAR hash {nar_hash} (size {nar_size}) \
-                     does not match the store's record {} (size {}); \
-                     this indicates a chunker bug or store corruption",
-                    info.nar_hash, info.nar_size
-                );
-                stats.failed_verification += 1;
-                continue;
-            }
+        let producer = async {
+            let mut prepared: Vec<PreparedPath> = Vec::new();
+            // Chunks of earlier prepared paths in this batch (cross-path dedup).
+            let mut batch_chunks: BTreeSet<crate::manifest::ChunkHash> = BTreeSet::new();
+            let mut builder = PackBuilder::new();
 
-            let new_chunks: Vec<chunker::Chunk> = chunked
-                .chunks
-                .into_iter()
-                .filter(|chunk| {
-                    !current.chunks.contains_key(&chunk.hash) && batch_chunks.insert(chunk.hash)
-                })
-                .collect();
+            'paths: for (path, info) in to_push {
+                let chunk_started = std::time::Instant::now();
+                let chunked = chunk_path(&path).await?;
+                let chunk_map = chunked.chunk_map();
 
-            prepared.push(PreparedPath {
-                hash: info.path_hash(),
-                entry: PathEntry {
-                    references: info.references_without_self(),
-                    store_path: info.store_path,
-                    nar_hash,
-                    nar_size,
-                    ca: info.ca,
-                    deriver: info.deriver,
-                    tree: chunked.tree,
-                    last_reachable: 0,
-                    last_pushed: now,
-                },
-                new_chunks,
-            });
-        }
-
-        stats.chunk_ms = chunk_started.elapsed().as_millis() as u64;
-
-        let mut delta = Manifest::new();
-
-        // Pack: seal a pack whenever it reaches the target size, so a large
-        // drain produces several packs that can upload concurrently.
-        let pack_started = std::time::Instant::now();
-        let mut packs: Vec<chunker::Pack> = Vec::new();
-        let mut builder = PackBuilder::new();
-        for path in &prepared {
-            for chunk in &path.new_chunks {
-                builder.add(chunk)?;
-                if builder.compressed_size() >= self.pack_target_size {
-                    packs.push(std::mem::take(&mut builder).finish());
+                // Integrity gate: the chunked representation must reproduce
+                // the NAR hash Nix recorded for this path. A mismatch means
+                // hestia would serve corrupt data; never upload it.
+                let (nar_hash, nar_size) = nar_hash_from_chunks(&chunked.tree, &chunk_map).await?;
+                stats.chunk_ms += chunk_started.elapsed().as_millis() as u64;
+                if nar_hash != info.nar_hash || nar_size != info.nar_size {
+                    eprintln!(
+                        "hestia: NOT uploading {path}: chunked NAR hash {nar_hash} (size \
+                         {nar_size}) does not match the store's record {} (size {}); \
+                         this indicates a chunker bug or store corruption",
+                        info.nar_hash, info.nar_size
+                    );
+                    stats.failed_verification += 1;
+                    continue;
                 }
+
+                let new_chunks: Vec<chunker::Chunk> = chunked
+                    .chunks
+                    .into_iter()
+                    .filter(|chunk| {
+                        !current.chunks.contains_key(&chunk.hash) && batch_chunks.insert(chunk.hash)
+                    })
+                    .collect();
+
+                let mut pack_started = std::time::Instant::now();
+                let frames = tokio::task::spawn_blocking(move || compress_chunks(new_chunks))
+                    .await
+                    .expect("compression task panicked")?;
+                for frame in frames {
+                    builder.add_compressed(frame.hash, &frame.frame, frame.uncompressed_size);
+                    if builder.compressed_size() >= self.pack_target_size {
+                        let pack = std::mem::take(&mut builder).finish();
+                        // Pause the pack timer across the send: a full
+                        // channel blocks on upload backpressure, which must
+                        // not be booked as packing time.
+                        stats.pack_ms += pack_started.elapsed().as_millis() as u64;
+                        if pack_tx.send(pack).await.is_err() {
+                            // Uploader gone: it failed, and try_join below
+                            // reports its error; stop producing.
+                            break 'paths;
+                        }
+                        pack_started = std::time::Instant::now();
+                    }
+                }
+                stats.pack_ms += pack_started.elapsed().as_millis() as u64;
+
+                prepared.push(PreparedPath {
+                    hash: info.path_hash(),
+                    entry: PathEntry {
+                        references: info.references_without_self(),
+                        store_path: info.store_path,
+                        nar_hash,
+                        nar_size,
+                        ca: info.ca,
+                        deriver: info.deriver,
+                        tree: chunked.tree,
+                        last_reachable: 0,
+                        last_pushed: now,
+                    },
+                });
             }
-        }
-        if !builder.is_empty() {
-            packs.push(builder.finish());
-        }
-        stats.new_chunks = packs.iter().map(|pack| pack.chunks.len()).sum();
-        stats.pack_ms = pack_started.elapsed().as_millis() as u64;
+            if !builder.is_empty() {
+                // A send failure means the uploader failed; try_join below
+                // reports its error, the producer's result is discarded.
+                let _ = pack_tx.send(builder.finish()).await;
+            }
+            // pack_tx drops here, ending the consumer's stream.
+            drop(pack_tx);
+            Ok::<_, Error>(prepared)
+        };
 
         let upload_started = std::time::Instant::now();
-        let upload_futures: Vec<_> = packs
-            .iter()
-            .map(|pack| async move {
-                let uploaded = upload_pack(&self.twirp, &self.http, pack).await?;
-                Ok::<_, GhaError>((uploaded, pack.data.len() as u64))
-            })
-            .collect();
-        let uploads: Vec<(bool, u64)> = futures_util::stream::iter(upload_futures)
-            .buffer_unordered(UPLOAD_CONCURRENCY)
-            .try_collect()
-            .await?;
+        let consumer = async {
+            let pack_stream = futures_util::stream::unfold(pack_rx, |mut rx| async move {
+                rx.recv().await.map(|pack| (pack, rx))
+            });
+            pack_stream
+                .map(|pack| async move {
+                    let uploaded = upload_pack(&self.twirp, &self.http, &pack).await?;
+                    Ok::<_, Error>((uploaded, pack))
+                })
+                .buffer_unordered(UPLOAD_CONCURRENCY)
+                .try_collect::<Vec<(bool, chunker::Pack)>>()
+                .await
+        };
+
+        let (prepared, uploads) = tokio::try_join!(producer, consumer)?;
+        // Stage times overlap now: chunk/pack are producer busy times,
+        // upload is the wall time of the whole pipelined section.
         stats.upload_ms = upload_started.elapsed().as_millis() as u64;
-        for (uploaded, size) in uploads {
+
+        let mut delta = Manifest::new();
+        let mut packs: Vec<chunker::Pack> = Vec::new();
+        for (uploaded, pack) in uploads {
             if uploaded {
                 stats.packs_uploaded += 1;
-                stats.bytes_uploaded += size;
+                stats.bytes_uploaded += pack.data.len() as u64;
             }
+            packs.push(pack);
         }
+        stats.new_chunks = packs.iter().map(|pack| pack.chunks.len()).sum();
 
         for pack in &packs {
             for (chunk_hash, location) in pack.locations() {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -79,13 +79,18 @@ pub struct DrainStats {
     /// (everything before chunking starts), in milliseconds.
     #[serde(default)]
     pub load_ms: u64,
-    /// Time spent chunking and verifying new paths, in milliseconds.
+    /// Producer time spent chunking and verifying new paths, in
+    /// milliseconds. Chunk, pack, and upload run pipelined, so these
+    /// stage times overlap and do not sum to the drain duration.
     #[serde(default)]
     pub chunk_ms: u64,
-    /// Time spent compressing chunks into packs, in milliseconds.
+    /// Producer time spent compressing chunks into packs, in milliseconds
+    /// (excludes waiting for upload backpressure).
     #[serde(default)]
     pub pack_ms: u64,
-    /// Time spent uploading packs, in milliseconds.
+    /// Wall time of the pipelined chunk/pack/upload section, in
+    /// milliseconds. Uploads overlap the CPU stages, so this is an upper
+    /// bound on upload time (throughput derived from it is a lower bound).
     #[serde(default)]
     pub upload_ms: u64,
     /// Time spent committing the manifest, in milliseconds.

--- a/tests/drain_bench.rs
+++ b/tests/drain_bench.rs
@@ -1,0 +1,68 @@
+//! Local drain benchmark: pipeline stage breakdown without a CI
+//! round-trip.
+//!
+//! Blob transfers are throttled to Azure-like characteristics (60 ms
+//! latency, 48 MiB/s per stream), and fixtures are incompressible random
+//! data — the compression ratio measured for a NixOS ISO closure.
+//!
+//!     cargo test --release --test drain_bench -- --ignored --nocapture
+//!
+//! Workload size via env: BENCH_MIB (default 512), BENCH_PATHS (default 64).
+
+mod support;
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use hestia::drain::stage_breakdown;
+use hestia::pipeline::now_unix;
+
+use support::common::pipeline_context;
+use support::fake_gha::FakeGha;
+use support::store::ScratchStore;
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+#[tokio::test]
+#[ignore = "benchmark; run explicitly with --ignored --nocapture"]
+async fn drain_bench() {
+    let total_mib = env_usize("BENCH_MIB", 512);
+    let n_paths = env_usize("BENCH_PATHS", 64);
+    let bytes_per_path = total_mib * 1024 * 1024 / n_paths;
+
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+
+    eprintln!(
+        "building workload: {n_paths} paths x {} MiB",
+        bytes_per_path / (1024 * 1024)
+    );
+    let paths: BTreeSet<String> = (0..n_paths)
+        .map(|i| {
+            store
+                .add_fixture_sized(&format!("bench-{i}"), i as u64 + 1, bytes_per_path)
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+
+    let fake = FakeGha::start().await;
+    fake.set_blob_throttle(Duration::from_millis(60), 48 * 1024 * 1024);
+    let http = reqwest::Client::new();
+    let pipeline = pipeline_context(&fake, &http, store.database());
+
+    let started = std::time::Instant::now();
+    let mut stats = pipeline
+        .run(paths, BTreeSet::new(), now_unix())
+        .await
+        .expect("drain failed");
+    stats.elapsed_ms = started.elapsed().as_millis() as u64;
+
+    eprintln!("drain stages: {}", stage_breakdown(&stats));
+}

--- a/tests/support/fake_gha.rs
+++ b/tests/support/fake_gha.rs
@@ -88,6 +88,9 @@ struct Inner {
     /// When set, download lookups pretend the newest matching entry does
     /// not exist yet (simulates the real service's eventual consistency).
     stale_lookups: bool,
+    /// Per-request blob transfer throttle (latency, bytes/s), for local
+    /// benchmarks that emulate Azure transfer characteristics.
+    blob_throttle: Option<(Duration, u64)>,
 }
 
 impl Inner {
@@ -295,6 +298,15 @@ struct SigQuery {
     sig: String,
 }
 
+/// Sleep for the configured throttle: fixed latency plus size/bandwidth.
+async fn apply_throttle(state: &AppState, bytes: u64) {
+    let throttle = state.inner.lock().unwrap().blob_throttle;
+    if let Some((latency, bytes_per_sec)) = throttle {
+        let transfer = Duration::from_secs_f64(bytes as f64 / bytes_per_sec as f64);
+        tokio::time::sleep(latency + transfer).await;
+    }
+}
+
 async fn blob_put(
     State(state): State<AppState>,
     Path(id): Path<u64>,
@@ -302,6 +314,7 @@ async fn blob_put(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
+    apply_throttle(&state, body.len() as u64).await;
     let inner = state.inner.lock().unwrap();
     if !inner.valid_sigs.contains(&query.sig) {
         return (StatusCode::FORBIDDEN, "signature expired").into_response();
@@ -360,53 +373,62 @@ async fn blob_get(
     Query(query): Query<SigQuery>,
     headers: HeaderMap,
 ) -> Response {
-    let mut inner = state.inner.lock().unwrap();
-    if !inner.valid_sigs.contains(&query.sig) {
-        return (StatusCode::FORBIDDEN, "signature expired").into_response();
-    }
-    let Some(position) = inner.entries.iter().position(|e| e.id == id) else {
-        return (StatusCode::NOT_FOUND, "no such blob").into_response();
-    };
-    let path = inner.blob_path(id);
-    let Ok(data) = std::fs::read(&path) else {
-        return (StatusCode::NOT_FOUND, "blob not uploaded").into_response();
-    };
+    // Block scope: the std mutex guard must end before the throttle await
+    // (explicit drop() does not satisfy the async Send analysis).
+    let (status, payload, drop_mid_body) = {
+        let mut inner = state.inner.lock().unwrap();
+        if !inner.valid_sigs.contains(&query.sig) {
+            return (StatusCode::FORBIDDEN, "signature expired").into_response();
+        }
+        let Some(position) = inner.entries.iter().position(|e| e.id == id) else {
+            return (StatusCode::NOT_FOUND, "no such blob").into_response();
+        };
+        let path = inner.blob_path(id);
+        let Ok(data) = std::fs::read(&path) else {
+            return (StatusCode::NOT_FOUND, "blob not uploaded").into_response();
+        };
 
-    // Downloads bump the LRU clock (verified against the real service).
-    let now = inner.tick();
-    inner.entries[position].last_accessed_at = now;
+        // Downloads bump the LRU clock (verified against the real service).
+        let now = inner.tick();
+        inner.entries[position].last_accessed_at = now;
 
-    // Record the download for tests that assert fetch behavior.
-    let request = BlobRequest {
-        key: inner.entries[position].key.clone(),
-        range: headers
+        // Record the download for tests that assert fetch behavior.
+        let request = BlobRequest {
+            key: inner.entries[position].key.clone(),
+            range: headers
+                .get(header::RANGE)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string),
+        };
+        inner.blob_requests.push(request);
+
+        // Connection-drop injection (Azure timeout simulation).
+        let drop_mid_body = if inner.blob_read_failures > 0 {
+            inner.blob_read_failures -= 1;
+            true
+        } else {
+            false
+        };
+
+        match headers
             .get(header::RANGE)
             .and_then(|v| v.to_str().ok())
-            .map(str::to_string),
-    };
-    inner.blob_requests.push(request);
-
-    // Connection-drop injection (Azure timeout simulation).
-    let drop_mid_body = if inner.blob_read_failures > 0 {
-        inner.blob_read_failures -= 1;
-        true
-    } else {
-        false
-    };
-
-    match headers
-        .get(header::RANGE)
-        .and_then(|v| v.to_str().ok())
-        .map(|v| parse_range(v, data.len() as u64))
-    {
-        // Range requested but unsatisfiable.
-        Some(None) => (StatusCode::RANGE_NOT_SATISFIABLE, "bad range").into_response(),
-        Some(Some((start, end))) => {
-            let slice = data[start as usize..=end as usize].to_vec();
-            blob_response(StatusCode::PARTIAL_CONTENT, slice, drop_mid_body)
+            .map(|v| parse_range(v, data.len() as u64))
+        {
+            // Range requested but unsatisfiable.
+            Some(None) => {
+                return (StatusCode::RANGE_NOT_SATISFIABLE, "bad range").into_response();
+            }
+            Some(Some((start, end))) => (
+                StatusCode::PARTIAL_CONTENT,
+                data[start as usize..=end as usize].to_vec(),
+                drop_mid_body,
+            ),
+            None => (StatusCode::OK, data, drop_mid_body),
         }
-        None => blob_response(StatusCode::OK, data, drop_mid_body),
-    }
+    };
+    apply_throttle(&state, payload.len() as u64).await;
+    blob_response(status, payload, drop_mid_body)
 }
 
 // ---------------------------------------------------------------------------
@@ -559,6 +581,7 @@ impl FakeGha {
             creates_until_quota: None,
             blob_read_failures: 0,
             stale_lookups: false,
+            blob_throttle: None,
         }));
         let state = AppState {
             inner: Arc::clone(&inner),
@@ -584,6 +607,9 @@ impl FakeGha {
             )
             .route("/test/fail-blob-reads/{reads}", post(test_fail_blob_reads))
             .route("/test/stale-lookups/{on}", post(test_stale_lookups))
+            // Pack blobs reach the production target size (64 MiB), far
+            // beyond axum's 2 MiB default body limit.
+            .layer(axum::extract::DefaultBodyLimit::max(256 * 1024 * 1024))
             .with_state(state);
 
         let task = tokio::spawn(async move {
@@ -607,6 +633,12 @@ impl FakeGha {
     /// Set the fake's clock (unix seconds). Subsequent operations record
     /// `created_at` / `last_accessed_at` values just after this instant,
     /// which lets GC tests simulate days passing.
+    /// Throttle blob transfers: fixed latency plus `bytes_per_sec`
+    /// bandwidth per request, to emulate Azure for local benchmarks.
+    pub fn set_blob_throttle(&self, latency: Duration, bytes_per_sec: u64) {
+        self.inner.lock().unwrap().blob_throttle = Some((latency, bytes_per_sec));
+    }
+
     pub fn set_clock(&self, unix_seconds: u64) {
         self.inner.lock().unwrap().clock = unix_seconds;
     }

--- a/tests/support/store.rs
+++ b/tests/support/store.rs
@@ -132,6 +132,24 @@ impl ScratchStore {
     /// symlink, empty file) and add it to the store.
     ///
     /// Same `name` + `seed` always produces the same store path.
+    /// Like [`Self::add_fixture`], but with a blob of `bytes` pseudo-random
+    /// bytes; benchmarks use this to build workloads of arbitrary size.
+    pub fn add_fixture_sized(&self, name: &str, seed: u64, bytes: usize) -> PathBuf {
+        let fixture = self.dir.path().join(format!("fixture-{name}"));
+        std::fs::create_dir_all(&fixture).unwrap();
+        let mut blob = Vec::with_capacity(bytes);
+        let mut state = seed | 1;
+        while blob.len() < bytes {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            blob.extend_from_slice(&state.to_le_bytes());
+        }
+        blob.truncate(bytes);
+        std::fs::write(fixture.join("blob"), &blob).unwrap();
+        self.add_path(&fixture)
+    }
+
     pub fn add_fixture(&self, name: &str, seed: u64) -> PathBuf {
         let fixture = self.dir.path().join(format!("fixture-{name}"));
         std::fs::create_dir_all(fixture.join("bin")).unwrap();


### PR DESCRIPTION
Measuring drain performance took a PR and a Perf workflow run per iteration. This adds blob throttling to the fake backend and an ignored bench test:

```
cargo test --release --test drain_bench -- --ignored --nocapture
```

With Azure-like throttling it reproduces the upload underutilization from the ISO run (84 MiB/s vs 81 MiB/s in CI, against a 192 MiB/s budget).