### PR TITLE
gc: split repack output at the pack target size

### DIFF
--- a/src/gc.rs
+++ b/src/gc.rs
@@ -74,7 +74,7 @@ pub struct GcPolicy {
     pub touch_age: u64,
     /// Packs whose live-byte ratio falls below this get repacked.
     pub min_liveness: f64,
-    /// Volatile (tier-0) packs above this count get consolidated into one.
+    /// Volatile (tier-0) packs above this count get consolidated.
     pub max_volatile_packs: usize,
     /// Chunks surviving this many repacks are promoted to the stable tier.
     pub stable_threshold: u32,
@@ -82,6 +82,8 @@ pub struct GcPolicy {
     /// a concurrent push may have uploaded them without having committed its
     /// manifest yet.
     pub min_age: u64,
+    /// Repack output packs are sealed at this compressed size.
+    pub pack_target_size: u64,
 }
 
 impl Default for GcPolicy {
@@ -95,6 +97,7 @@ impl Default for GcPolicy {
             max_volatile_packs: 4,
             stable_threshold: 2,
             min_age: SECS_PER_HOUR,
+            pack_target_size: crate::pipeline::PACK_TARGET_SIZE,
         }
     }
 }
@@ -794,38 +797,58 @@ impl GcContext {
                         if builder.add_compressed(copy.chunk, frame, decompressed.len() as u32) {
                             survived.insert(copy.chunk, copy.from.repacks_survived + 1);
                         }
+                        // A consolidation job can span many source packs;
+                        // seal at the target size instead of producing one
+                        // giant pack.
+                        if builder.compressed_size() >= self.policy.pack_target_size {
+                            let full = std::mem::replace(&mut builder, PackBuilder::new());
+                            self.upload_repacked(full, job.tier, plan.now, &survived, &mut output)
+                                .await?;
+                        }
                     }
                 }
                 sources_read.insert(source);
             }
 
-            if builder.is_empty() {
-                continue;
-            }
-            let pack = builder.finish();
-            upload_pack(&self.twirp, &self.http, &pack).await?;
-            output.uploaded += pack.data.len() as u64;
-            output.packs.insert(
-                pack.hash,
-                PackInfo {
-                    size: pack.data.len() as u64,
-                    created: plan.now,
-                    tier: job.tier,
-                },
-            );
-            for (chunk, location) in pack.locations() {
-                output.locations.insert(
-                    chunk,
-                    ChunkLocation {
-                        repacks_survived: survived[&chunk],
-                        ..location
-                    },
-                );
+            if !builder.is_empty() {
+                self.upload_repacked(builder, job.tier, plan.now, &survived, &mut output)
+                    .await?;
             }
             output.replaced.extend(sources_read);
         }
 
         Ok(output)
+    }
+
+    async fn upload_repacked(
+        &self,
+        builder: PackBuilder,
+        tier: u8,
+        now: u64,
+        survived: &BTreeMap<ChunkHash, u32>,
+        output: &mut RepackOutput,
+    ) -> Result<(), Error> {
+        let pack = builder.finish();
+        upload_pack(&self.twirp, &self.http, &pack).await?;
+        output.uploaded += pack.data.len() as u64;
+        output.packs.insert(
+            pack.hash,
+            PackInfo {
+                size: pack.data.len() as u64,
+                created: now,
+                tier,
+            },
+        );
+        for (chunk, location) in pack.locations() {
+            output.locations.insert(
+                chunk,
+                ChunkLocation {
+                    repacks_survived: survived[&chunk],
+                    ..location
+                },
+            );
+        }
+        Ok(())
     }
 
     /// Execute step 2 of 6: 1-byte Range reads to reset the LRU clock of

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -107,6 +107,57 @@ async fn dry_run_plans_but_changes_nothing() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
+async fn repack_splits_output_at_pack_target_size() {
+    timed(async {
+        let fake = FakeGha::start().await;
+        let http = client();
+        let sim = SimCache::new(&fake, &http);
+
+        // Six volatile packs of ~40 KB each, all live. Odd seeds:
+        // test_data does `seed | 1`, so consecutive seeds collide.
+        fake.set_clock(T0);
+        let paths: Vec<SimPath> = (0..6)
+            .map(|i| SimPath::new(&format!("lib-{i}"), 2 * i + 1, 40_000))
+            .collect();
+        for path in &paths {
+            sim.push("main", std::slice::from_ref(path), &paths, T0)
+                .await;
+        }
+        assert_eq!(sim.manifest().await.packs.len(), 6);
+
+        // Consolidation must not produce one giant pack: ~240 KB of live
+        // chunks against a 100 KB target splits into multiple packs.
+        let t1 = T0 + DAY;
+        fake.set_clock(t1);
+        let policy = GcPolicy {
+            max_volatile_packs: 2,
+            pack_target_size: 100_000,
+            ..GcPolicy::default()
+        };
+        let report = sim.gc(policy).run(false, t1).await.expect("gc run failed");
+
+        assert!(
+            report.packs_uploaded >= 2,
+            "240 KB of repacked chunks must split at the 100 KB target \
+             (uploaded {} pack(s))",
+            report.packs_uploaded
+        );
+        let manifest = sim.manifest().await;
+        for (pack, info) in &manifest.packs {
+            assert!(
+                info.size < 150_000,
+                "pack {pack} is {} bytes, beyond target + one chunk",
+                info.size
+            );
+        }
+        for path in &paths {
+            assert!(manifest.paths.contains_key(&path.path_hash()));
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn repack_copies_live_chunks_and_deletes_old_pack_after_commit() {
     timed(async {
         let fake = FakeGha::start().await;


### PR DESCRIPTION
Yesterday's GC run consolidated 44 packs into a single 2.85 GB pack: repack jobs used one PackBuilder for the whole job. That buffers the entire pack in memory, makes one hot chunk pin 2.85 GB in the LRU, and forces the next repack to re-download everything. Seal repack output at the same target size the drain pipeline uses (new `GcPolicy::pack_target_size`).