### PR TITLE
docs: lead with action inputs, move CLI flags to docs/cli.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You will also want a daily GC workflow on the default branch to stay within
 the cache quota; copy [`.github/workflows/gc.yml`](.github/workflows/gc.yml)
 for that.
 
-See [`action/README.md`](action/README.md) for all action inputs.
+See [Configuration](#configuration) for all action inputs.
 
 ## Comparison
 
@@ -101,62 +101,27 @@ Roots are how hestia decides what is still alive. They are unrelated to
 GitHub's own cache access scoping (who may read or write entries, see
 [Security](#security)), which applies on top.
 
-## Configuration reference
+## Configuration
 
-The action takes care of all of this; the tables below are only relevant if
-you run the CLI yourself.
+All inputs are optional; the defaults work for the quick start above.
 
-### `hestia serve` — per-job daemon
-
-| Flag | Default | Description |
+| Input | Default | Description |
 |---|---|---|
-| `--socket <PATH>` | `/tmp/hestia/hook.sock` | Unix socket for the post-build-hook listener. |
-| `--listen <ADDR>` | `127.0.0.1:37515` | Substituter HTTP address. |
-| `--idle-exit <SECONDS>` | — | Drain and exit after this much inactivity (fallback for setups without post steps). |
-| `--branch <NAME>` | `$GITHUB_REF_NAME`, else `local` | Branch part of the manifest root key. |
-| `--system <SYSTEM>` | detected | Nix system part of the root key (e.g. `x86_64-linux`). |
-| `--upstream-cache-filter` | off | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
-| `--upstream-cache-key-name <KEY_NAME>` | `cache.nixos.org-1` | Key names treated as upstream caches by the filter. Repeatable. |
-| `--no-closure` | off | Cache built paths only, without their runtime closure. |
-| `--db-path <PATH>` | `/nix/var/nix/db/db.sqlite` | Nix store database to read path metadata from. |
+| `binary` | — | Path to a pre-built hestia binary. Takes precedence over `version`. |
+| `version` | latest release | Release tag to download (e.g. `v0.1.0-alpha.10`). The download is verified against GitHub's build attestations. |
+| `github-token` | `${{ github.token }}` | Token for the attestation API lookup. |
+| `listen` | `127.0.0.1:37515` | Substituter listen address. |
+| `socket` | `/tmp/hestia/hook.sock` | Post-build-hook unix socket path. |
+| `drain-timeout` | `300` | Seconds the post-job step waits for the final upload. |
+| `upstream-cache-filter` | `false` | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
+| `upstream-cache-key-names` | `cache.nixos.org-1` | Space-separated key names treated as upstream caches by the filter. |
+| `no-closure` | `false` | Cache built paths only, without their runtime closure. |
 
-### `hestia hook` — post-build-hook client
+The GC workflow takes one input: `dry-run` (plan only, delete nothing); see
+[`.github/workflows/gc.yml`](.github/workflows/gc.yml).
 
-| Flag | Default | Description |
-|---|---|---|
-| `--socket <PATH>` | `/tmp/hestia/hook.sock` | Daemon socket. |
-| `[PATH]...` | `$OUT_PATHS` | Store paths to register. |
-
-Always exits 0 (a failing post-build-hook would fail the build).
-
-### `hestia drain` — upload + commit
-
-| Flag | Default | Description |
-|---|---|---|
-| `--socket <PATH>` | `/tmp/hestia/hook.sock` | Daemon socket. |
-| `--timeout <SECONDS>` | `300` | Maximum time to wait for the upload. |
-
-### `hestia gc` — garbage collection (cron, default branch)
-
-| Flag | Default | Description |
-|---|---|---|
-| `--dry-run` | off | Plan only; delete nothing. |
-| `--grace <DAYS>` | `3` | Unreachable paths are kept this long. |
-| `--push-ttl <DAYS>` | `14` | Recently pushed paths are kept, reachable or not. |
-| `--root-ttl <DAYS>` | `14` | Roots (branch+system pins) expire after this. |
-| `--touch-age <DAYS>` | `4` | Idle packs get an LRU touch after this. |
-
-### Environment variables
-
-| Variable | Used by | Description |
-|---|---|---|
-| `ACTIONS_RUNTIME_TOKEN` | serve, gc | GHA cache API token. Only visible to JS actions; the hestia action exports it. |
-| `ACTIONS_RESULTS_URL` | serve, gc | GHA cache API base URL. Exported by the action. |
-| `GITHUB_TOKEN` | gc | GitHub REST API token (`actions: write`) for listing/deleting cache entries. |
-| `GITHUB_REPOSITORY` | gc | `owner/repo`, set automatically in workflows. |
-| `GITHUB_API_URL` | gc | REST API base URL (override for GHES). |
-| `GITHUB_REF_NAME` | serve | Default for `--branch`. |
-| `OUT_PATHS` | hook | Set by Nix when invoking the post-build-hook. |
+Running the `hestia` binary yourself instead of using the action? See the
+[CLI reference](docs/cli.md).
 
 ## Security
 

--- a/action/README.md
+++ b/action/README.md
@@ -65,7 +65,7 @@ themselves; hestia's own integration tests use it.
 | Input | Default | Description |
 |---|---|---|
 | `binary` | — | Path to a pre-built hestia binary. Takes precedence over `version`. |
-| `version` | — | Release tag to download (e.g. `v0.1.0-alpha.4`). The download is verified against GitHub's build attestations. |
+| `version` | latest release | Release tag to download (e.g. `v0.1.0-alpha.10`). The download is verified against GitHub's build attestations. |
 | `github-token` | `${{ github.token }}` | Token for the attestation API lookup. |
 | `listen` | `127.0.0.1:37515` | Substituter listen address. |
 | `socket` | `/tmp/hestia/hook.sock` | Post-build-hook unix socket path. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,57 @@
+# CLI reference
+
+The action takes care of all of this; these flags are only relevant if you
+run the `hestia` binary yourself (e.g. token-capture-only mode, self-hosted
+setups, or hacking on hestia).
+
+## `hestia serve` — per-job daemon
+
+| Flag | Default | Description |
+|---|---|---|
+| `--socket <PATH>` | `/tmp/hestia/hook.sock` | Unix socket for the post-build-hook listener. |
+| `--listen <ADDR>` | `127.0.0.1:37515` | Substituter HTTP address. |
+| `--idle-exit <SECONDS>` | — | Drain and exit after this much inactivity (fallback for setups without post steps). |
+| `--branch <NAME>` | `$GITHUB_REF_NAME`, else `local` | Branch part of the manifest root key. |
+| `--system <SYSTEM>` | detected | Nix system part of the root key (e.g. `x86_64-linux`). |
+| `--upstream-cache-filter` | off | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
+| `--upstream-cache-key-name <KEY_NAME>` | `cache.nixos.org-1` | Key names treated as upstream caches by the filter. Repeatable. |
+| `--no-closure` | off | Cache built paths only, without their runtime closure. |
+| `--db-path <PATH>` | `/nix/var/nix/db/db.sqlite` | Nix store database to read path metadata from. |
+
+## `hestia hook` — post-build-hook client
+
+| Flag | Default | Description |
+|---|---|---|
+| `--socket <PATH>` | `/tmp/hestia/hook.sock` | Daemon socket. |
+| `[PATH]...` | `$OUT_PATHS` | Store paths to register. |
+
+Always exits 0 (a failing post-build-hook would fail the build).
+
+## `hestia drain` — upload + commit
+
+| Flag | Default | Description |
+|---|---|---|
+| `--socket <PATH>` | `/tmp/hestia/hook.sock` | Daemon socket. |
+| `--timeout <SECONDS>` | `300` | Maximum time to wait for the upload. |
+
+## `hestia gc` — garbage collection (cron, default branch)
+
+| Flag | Default | Description |
+|---|---|---|
+| `--dry-run` | off | Plan only; delete nothing. |
+| `--grace <DAYS>` | `3` | Unreachable paths are kept this long. |
+| `--push-ttl <DAYS>` | `14` | Recently pushed paths are kept, reachable or not. |
+| `--root-ttl <DAYS>` | `14` | Roots (branch+system pins) expire after this. |
+| `--touch-age <DAYS>` | `4` | Idle packs get an LRU touch after this. |
+
+## Environment variables
+
+| Variable | Used by | Description |
+|---|---|---|
+| `ACTIONS_RUNTIME_TOKEN` | serve, gc | GHA cache API token. Only visible to JS actions; the hestia action exports it. |
+| `ACTIONS_RESULTS_URL` | serve, gc | GHA cache API base URL. Exported by the action. |
+| `GITHUB_TOKEN` | gc | GitHub REST API token (`actions: write`) for listing/deleting cache entries. |
+| `GITHUB_REPOSITORY` | gc | `owner/repo`, set automatically in workflows. |
+| `GITHUB_API_URL` | gc | REST API base URL (override for GHES). |
+| `GITHUB_REF_NAME` | serve | Default for `--branch`. |
+| `OUT_PATHS` | hook | Set by Nix when invoking the post-build-hook. |

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -22,7 +22,7 @@ fn count(n: usize, noun: &str) -> String {
 }
 
 /// `512 B`, `1.5 KiB`, `64.6 MiB`, `2.1 GiB`.
-fn human_bytes(bytes: u64) -> String {
+pub fn human_bytes(bytes: u64) -> String {
     if bytes < 1024 {
         return format!("{bytes} B");
     }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -31,6 +31,7 @@ use crate::chunker::{
     self, PackBuilder, coalesce_adjacent, extract_chunk, flatten_tree, pack_cache_key,
 };
 use crate::cli::GcArgs;
+use crate::drain::human_bytes;
 use crate::gha::rest::{CacheEntry, RestClient};
 use crate::gha::savemutable::SaveMutable;
 use crate::gha::twirp::{DownloadUrl, TwirpClient};
@@ -210,7 +211,7 @@ impl GcPlan {
         // Repacks copy compressed frames verbatim, so upload == download.
         format!(
             "evicted {} pack(s); heal {} path(s); drop {} root(s) + {} path(s); \
-             repack {} job(s) ({} chunk(s), {} B down, {} B up); \
+             repack {} job(s) ({} chunk(s), {} copied); \
              touch {} pack(s); delete {} pack(s) + {} orphan(s)",
             self.evicted_packs.len(),
             self.heal_paths.len(),
@@ -221,8 +222,7 @@ impl GcPlan {
                 .iter()
                 .map(|job| job.copies.len())
                 .sum::<usize>(),
-            self.download_bytes(),
-            self.download_bytes(),
+            human_bytes(self.download_bytes()),
             self.touch_packs.len(),
             self.delete_packs.len(),
             self.orphan_keys.len(),
@@ -639,12 +639,12 @@ pub struct GcReport {
 impl GcReport {
     pub fn summary(&self) -> String {
         format!(
-            "uploaded {} pack(s) ({} B down, {} B up); touched {} pack(s); \
+            "uploaded {} pack(s) ({} down, {} up); touched {} pack(s); \
              deleted {} pack(s), {} orphan(s), {} old manifest version(s); \
              manifest version: {}",
             self.packs_uploaded,
-            self.bytes_downloaded,
-            self.bytes_uploaded,
+            human_bytes(self.bytes_downloaded),
+            human_bytes(self.bytes_uploaded),
             self.packs_touched,
             self.packs_deleted,
             self.orphans_deleted,


### PR DESCRIPTION
Most users configure hestia through the action, but the README documented CLI flags and only linked to the action inputs. Inverted: README now carries the action input table (plus the GC workflow's `dry-run` input); CLI flags and environment variables move to [docs/cli.md](docs/cli.md). Also updates the stale `version` default in action/README.md (now resolves the latest release).