### PR TITLE
Fix bugs found in a full-codebase review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -4,6 +4,7 @@ on:
 jobs:
   auto-merge-dependency-updates:
     runs-on: ubuntu-slim
+    if: github.actor == 'dependabot[bot]'
     permissions:
       contents: write
       pull-requests: write
@@ -11,4 +12,4 @@ jobs:
       group: "auto-merge:${{ github.head_ref }}"
       cancel-in-progress: true
     steps:
-      - uses: Mic92/auto-merge@main
+      - uses: Mic92/auto-merge@e1f544e0f9a0128013e1c37c6d70fd32c2cf0f32 # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,12 @@ permissions:
 jobs:
   # Formatting, clippy, tests, and the package build, all as flake checks.
   #
-  # Also the dogfood job: with the repository variables below set, these
-  # derivations are cached through hestia itself, so cache breakage shows
-  # up as slow or failing CI. The daemon is bootstrapped from a released
-  # binary (this job cannot use the package it is about to build); with
-  # the variables unset the dogfood step is skipped.
-  #   HESTIA_DOGFOOD          "true"
-  #   HESTIA_DOGFOOD_VERSION  release tag, e.g. "v0.1.0-alpha.4"
-  #
-  # macOS jobs do not dogfood yet: no release ships darwin binaries. Drop
-  # the runner.os conditions once one does.
+  # Also the dogfood job: with the HESTIA_DOGFOOD repository variable set
+  # to "true", these derivations are cached through hestia itself (the
+  # latest published release), so cache breakage shows up as slow or
+  # failing CI. The daemon is bootstrapped from a released binary (this
+  # job cannot use the package it is about to build); with the variable
+  # unset the dogfood step is skipped.
   build:
     strategy:
       fail-fast: false
@@ -38,8 +34,6 @@ jobs:
       - name: Start hestia cache (dogfood)
         if: vars.HESTIA_DOGFOOD == 'true'
         uses: ./action
-        with:
-          version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
       - name: Run flake checks
         run: nix flake check --print-build-logs
       # No-op after the flake checks; asserts the closures the dependent
@@ -68,8 +62,6 @@ jobs:
       - name: Start hestia cache (dogfood)
         if: vars.HESTIA_DOGFOOD == 'true'
         uses: ./action
-        with:
-          version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
       # Explicitly empty binary/version: token-capture-only mode (must
       # stay tested). version defaults to "latest" when omitted.
       - uses: ./action
@@ -125,11 +117,13 @@ jobs:
       - name: Start hestia cache (dogfood)
         if: vars.HESTIA_DOGFOOD == 'true'
         uses: ./action
-        with:
-          version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
-      # Token-capture-only mode when dogfooding is off (forks).
+      # Token-capture-only mode when dogfooding is off (forks). Explicitly
+      # empty version: it defaults to "latest" when omitted, which would
+      # start an unwanted daemon.
       - uses: ./action
         if: vars.HESTIA_DOGFOOD != 'true'
+        with:
+          version: ""
       - name: Build hestia
         run: nix build .# -o hestia-bin
       - name: Run GC (dry run)
@@ -159,8 +153,6 @@ jobs:
       - name: Start hestia cache (dogfood)
         if: vars.HESTIA_DOGFOOD == 'true'
         uses: ./action
-        with:
-          version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
       - name: Build hestia
         run: nix build .# -o hestia-bin
       # Instance under test on its own port/socket, started last: the

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -9,6 +9,13 @@
 # version input (see action/README.md), and keep the permissions.
 name: Cache GC
 
+# GC handles concurrent pushes, but not a concurrent GC: a second run's
+# repack reads race the first run's post-commit pack deletes. Queue manual
+# runs behind the nightly one instead of overlapping it.
+concurrency:
+  group: hestia-gc
+  cancel-in-progress: false
+
 on:
   schedule:
     # Daily, off-peak (UTC).

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -41,20 +41,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
-      # With dogfood variables set, run GC with the released binary: no nix
-      # build, the nightly job takes seconds. Without them, build from
-      # source and use the action in token-capture-only mode (GC needs the
-      # cache API tokens, not the daemon).
+      # With HESTIA_DOGFOOD set, run GC with the latest released binary:
+      # no nix build, the nightly job takes seconds. Without it, build
+      # from source and use the action in token-capture-only mode (GC
+      # needs the cache API tokens, not the daemon).
       - name: Install hestia (released binary)
         if: vars.HESTIA_DOGFOOD == 'true'
         uses: ./action
-        with:
-          version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
       - name: Build hestia
         if: vars.HESTIA_DOGFOOD != 'true'
         run: nix build .# -o hestia-bin
       - uses: ./action
         if: vars.HESTIA_DOGFOOD != 'true'
+        with:
+          # Explicitly empty: token-capture-only mode (version defaults to
+          # "latest" when omitted, which would start an unwanted daemon).
+          version: ""
       - name: Run garbage collection
         run: |
           "${HESTIA_BIN:-./hestia-bin/bin/hestia}" gc \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 # Release pipeline: tag push -> static binaries -> GitHub release.
 #
-# The binaries are statically linked (musl): the hestia-cache action
-# downloads and runs them on stock runners, where dynamically linked
-# nix-built binaries would not work (their library paths point into
-# /nix/store).
+# The binaries must run on stock runners without nix: Linux binaries are
+# statically linked (musl); darwin binaries link only system libraries
+# (nix-built dynamic binaries would point into /nix/store).
 name: Release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,6 @@ jobs:
       - name: Start hestia cache (dogfood)
         if: vars.HESTIA_DOGFOOD == 'true'
         uses: ./action
-        with:
-          version: ${{ vars.HESTIA_DOGFOOD_VERSION }}
       - name: Build release binary
         run: nix build .#
       - name: Prepare release asset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.11.0",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,7 @@ dependencies = [
  "harmonia-utils-hash",
  "harmonia-utils-io",
  "harmonia-utils-signature",
+ "libc",
  "proptest",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ tokio = { version = "1", features = [
   "fs",
 ] }
 
+# Accept-loop errno classification (unix sockets are unix-only anyway)
+libc = "0.2"
+
 # Serialization (manifest = CBOR + zstd)
 serde = { version = "1", features = ["derive"] }
 ciborium = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ serde_json = "1"
 sha2 = "0.11"
 
 # Harmonia crates (not on crates.io; pinned to a specific rev)
-# Dropped after Phase 2/3 scope decisions (re-add when needed):
+# Harmonia crates intentionally not used (re-add when needed):
 #   harmonia-store-remote        -> path info comes from direct store
 #                                    database reads (harmonia-store-db),
 #                                    which works without a running daemon

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ tokio = { version = "1", features = [
   "time",
   "sync",
   "io-util",
-  "process",
-  "fs",
 ] }
 
 # Accept-loop errno classification (unix sockets are unix-only anyway)
@@ -58,9 +56,6 @@ bytes = "1"
 # JSON bodies for the Twirp / REST / Azure APIs
 serde_json = "1"
 
-# Cache version namespace (sha256 of a constant, optionally salted)
-sha2 = "0.11"
-
 # Harmonia crates (not on crates.io; pinned to a specific rev)
 # Harmonia crates intentionally not used (re-add when needed):
 #   harmonia-store-remote        -> path info comes from direct store
@@ -78,6 +73,8 @@ harmonia-utils-io = { git = "https://github.com/nix-community/harmonia", rev = "
 harmonia-utils-signature = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }
 
 [dev-dependencies]
+# Integration tests spawn the hestia binary and nix tooling
+tokio = { version = "1", features = ["process"] }
 # Property-based tests for manifest merge laws
 proptest = "1"
 # Blob storage directory for the fake GHA backend

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ rebuilt.
 ```console
 $ nix develop -c cargo test          # unit + integration tests (fake GHA backend)
 $ nix develop -c cargo clippy --all-targets -- -D warnings
-$ nix fmt                            # treefmt (rustfmt, nixfmt, prettier, ...)
+$ nix fmt                            # treefmt (rustfmt, nixfmt, taplo, ...)
 $ nix flake check                    # everything CI runs: fmt, clippy, tests, build
 $ nix build .#                       # the hestia binary (static musl on Linux)
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: write          # GHA cache writes
     steps:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
@@ -41,9 +40,13 @@ jobs:
 Everything built in your workflow gets cached; later runs (and PRs) pull
 from the cache instead of rebuilding.
 
+Build jobs need no extra permissions: cache uploads authenticate with the
+runner-injected `ACTIONS_RUNTIME_TOKEN`, which the `permissions:` block
+does not scope.
+
 You will also want a daily GC workflow on the default branch to stay within
 the cache quota; copy [`.github/workflows/gc.yml`](.github/workflows/gc.yml)
-for that.
+for that (its REST cache deletes are what need `actions: write`).
 
 See [Configuration](#configuration) for all action inputs.
 

--- a/action/README.md
+++ b/action/README.md
@@ -56,9 +56,18 @@ to trust release binaries, pass a path instead:
 
 ### Token capture only
 
-With neither `version` nor `binary` set, the action only exports the cache
-API tokens and starts nothing. This mode is for setups that run hestia
-themselves; hestia's own integration tests use it.
+With both `version` and `binary` explicitly set to empty strings, the
+action only exports the cache API tokens and starts nothing (`version`
+defaults to `latest` when omitted, so a bare invocation starts a daemon):
+
+```yaml
+      - uses: Mic92/hestia/action@main
+        with:
+          version: ""
+```
+
+This mode is for setups that run hestia themselves; hestia's own
+integration tests use it.
 
 ## Inputs
 

--- a/action/README.md
+++ b/action/README.md
@@ -67,8 +67,8 @@ themselves; hestia's own integration tests use it.
 | `binary` | — | Path to a pre-built hestia binary. Takes precedence over `version`. |
 | `version` | latest release | Release tag to download (e.g. `v0.1.0-alpha.10`). The download is verified against GitHub's build attestations. |
 | `github-token` | `${{ github.token }}` | Token for the attestation API lookup. |
-| `listen` | `127.0.0.1:37515` | Substituter listen address. |
-| `socket` | `/tmp/hestia/hook.sock` | Post-build-hook unix socket path. |
+| `listen` | free port per invocation | Substituter listen address. |
+| `socket` | per-invocation temp path | Post-build-hook unix socket path. |
 | `drain-timeout` | `300` | Seconds the post-job step waits for the final upload. |
 | `upstream-cache-filter` | `false` | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
 | `upstream-cache-key-names` | `cache.nixos.org-1` | Space-separated key names treated as upstream caches by the filter. |

--- a/action/action.yml
+++ b/action/action.yml
@@ -32,13 +32,18 @@ inputs:
     required: false
     default: ${{ github.token }}
   listen:
-    description: Address the substituter HTTP server listens on.
+    description: >
+      Address the substituter HTTP server listens on. Defaults to 127.0.0.1
+      with a free port picked per invocation, so the action can run more
+      than once in a job without the daemons colliding.
     required: false
-    default: "127.0.0.1:37515"
+    default: ""
   socket:
-    description: Unix socket path for the post-build-hook listener.
+    description: >
+      Unix socket path for the post-build-hook listener. Defaults to a
+      per-invocation path under the runner's temp directory.
     required: false
-    default: "/tmp/hestia/hook.sock"
+    default: ""
   drain-timeout:
     description: >
       Maximum number of seconds the post-job step waits for the final upload

--- a/action/main.js
+++ b/action/main.js
@@ -14,6 +14,7 @@ const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const net = require('net');
 const { spawn, spawnSync } = require('child_process');
 
 // ---------------------------------------------------------------------------
@@ -61,6 +62,18 @@ function fail(message) {
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Ask the kernel for a free TCP port on the loopback interface. */
+function pickFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Setup steps
@@ -327,11 +340,21 @@ function startDaemon(hestiaBin, listen, socket, logFile) {
   daemon.on('error', (err) => fail(`failed to start hestia daemon: ${err}`));
   daemon.unref();
   console.log(`hestia-cache: daemon started (pid ${daemon.pid}, log ${logFile})`);
+  return daemon.pid;
 }
 
 /** Poll /nix-cache-info until the substituter answers (max ~30s). */
-async function waitForReadiness(listen, logFile) {
+async function waitForReadiness(listen, logFile, pid) {
   for (let attempt = 0; attempt < 60; attempt++) {
+    // A dead daemon must fail here even if another process answers on the
+    // same address (e.g. a daemon leaked by an earlier job).
+    try {
+      process.kill(pid, 0);
+    } catch {
+      console.error('--- hestia serve log ---');
+      console.error(fs.readFileSync(logFile, 'utf8'));
+      fail(`hestia daemon (pid ${pid}) exited during startup`);
+    }
     try {
       const response = await fetch(`http://${listen}/nix-cache-info`);
       if (response.ok) {
@@ -365,8 +388,6 @@ async function main() {
     return;
   }
 
-  const listen = getInput('listen') || '127.0.0.1:37515';
-  const socket = getInput('socket') || '/tmp/hestia/hook.sock';
   // Unique per invocation: a job can run this action more than once, and a
   // shared directory would overwrite the first daemon's binary and log.
   const tempDir = process.env.RUNNER_TEMP || '/tmp';
@@ -374,11 +395,17 @@ async function main() {
   const installDir = fs.mkdtempSync(path.join(tempDir, 'hestia-cache-'));
   const logFile = path.join(installDir, 'serve.log');
 
+  // Like installDir, the defaults are unique per invocation: a fixed
+  // address/socket would make a second invocation unlink the first
+  // daemon's hook socket and die on the TCP bind conflict.
+  const listen = getInput('listen') || `127.0.0.1:${await pickFreePort()}`;
+  const socket = getInput('socket') || path.join(installDir, 'hook.sock');
+
   const hestiaBin = await installBinary(installDir);
   const hookShim = writeHookShim(installDir, hestiaBin, socket);
   configureNix(installDir, listen, hookShim);
-  startDaemon(hestiaBin, listen, socket, logFile);
-  await waitForReadiness(listen, logFile);
+  const daemonPid = startDaemon(hestiaBin, listen, socket, logFile);
+  await waitForReadiness(listen, logFile, daemonPid);
 
   // Environment variables for the user's later shell steps. When the action
   // runs more than once in a job, these point at the latest daemon.

--- a/action/main.js
+++ b/action/main.js
@@ -63,6 +63,36 @@ function fail(message) {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+// On GitHub Enterprise Server, GITHUB_ACTION_REPOSITORY names a repo on the
+// instance; hardcoding public hosts would leak the instance token to
+// api.github.com and let a same-named public repo supply the binary.
+const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+const serverBase = process.env.GITHUB_SERVER_URL || 'https://github.com';
+
+/**
+ * Compare release tags like v0.1.0-alpha.10: dot/dash segments compared
+ * numerically where numeric, with a release outranking its prereleases.
+ */
+function compareTags(a, b) {
+  const parse = (t) =>
+    t
+      .replace(/^v/, '')
+      .split(/[.-]/)
+      .map((p) => (/^\d+$/.test(p) ? Number(p) : p));
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i];
+    const y = pb[i];
+    if (x === y) continue;
+    if (x === undefined) return 1; // 1.0.0 > 1.0.0-alpha.1
+    if (y === undefined) return -1;
+    if (typeof x !== typeof y) return typeof x === 'number' ? -1 : 1;
+    return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
 /** Ask the kernel for a free TCP port on the loopback interface. */
 function pickFreePort() {
   return new Promise((resolve, reject) => {
@@ -106,7 +136,7 @@ function captureTokens() {
  * download relies on.
  */
 async function verifyAttestation(repo, assetName, digest, token) {
-  const url = `https://api.github.com/repos/${repo}/attestations/sha256:${digest}`;
+  const url = `${apiBase}/repos/${repo}/attestations/sha256:${digest}`;
   const headers = {
     Accept: 'application/vnd.github+json',
     'X-GitHub-Api-Version': '2022-11-28',
@@ -153,8 +183,10 @@ async function resolveVersion(version) {
   if (version !== 'latest') return version;
   const repo = process.env.GITHUB_ACTION_REPOSITORY || 'Mic92/hestia';
   // /releases/latest skips prereleases, so list recent releases and pick
-  // the first published (non-draft) entry.
-  const url = `https://api.github.com/repos/${repo}/releases?per_page=10`;
+  // the highest published (non-draft) version. The list endpoint orders by
+  // creation date, so a hotfix for an older line would otherwise downgrade
+  // every 'latest' consumer.
+  const url = `${apiBase}/repos/${repo}/releases?per_page=10`;
   const headers = { Accept: 'application/vnd.github+json' };
   const token = getInput('github-token');
   if (token) headers.Authorization = `Bearer ${token}`;
@@ -166,6 +198,7 @@ async function resolveVersion(version) {
   if (!releases.length) {
     fail(`no published releases found for ${repo}`);
   }
+  releases.sort((a, b) => compareTags(b.tag_name, a.tag_name));
   const tag = releases[0].tag_name;
   console.log(`hestia-cache: resolved 'latest' to ${tag}`);
   return tag;
@@ -197,7 +230,7 @@ async function installBinary(installDir) {
     // from, so forks automatically download their own releases.
     const repo = process.env.GITHUB_ACTION_REPOSITORY || 'Mic92/hestia';
     const assetName = `hestia-${arch}-${process.platform}`;
-    const url = `https://github.com/${repo}/releases/download/${version}/${assetName}`;
+    const url = `${serverBase}/${repo}/releases/download/${version}/${assetName}`;
     console.log(`hestia-cache: downloading ${url}`);
     const response = await fetch(url, { redirect: 'follow' });
     if (!response.ok) {

--- a/action/main.js
+++ b/action/main.js
@@ -304,6 +304,10 @@ function startDaemon(hestiaBin, listen, socket, logFile) {
     stdio: ['ignore', log, log],
     env: process.env, // carries ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL
   });
+  // spawn failures (ENOEXEC from a wrong-arch binary, EACCES, ...) surface
+  // as an async 'error' event; without a listener Node dies with an opaque
+  // uncaught exception instead of an actionable message.
+  daemon.on('error', (err) => fail(`failed to start hestia daemon: ${err}`));
   daemon.unref();
   console.log(`hestia-cache: daemon started (pid ${daemon.pid}, log ${logFile})`);
 }

--- a/action/main.js
+++ b/action/main.js
@@ -296,12 +296,16 @@ function warnIfHookCannotFire() {
   if (show.status !== 0) {
     return; // cannot determine; stay quiet
   }
-  const trusted = show.stdout.trim().split(/\s+/);
+  const trusted = show.stdout.trim().split(/\s+/).filter(Boolean);
+  if (trusted.some((entry) => entry.startsWith('@'))) {
+    return; // trust via group membership is possible; avoid a false alarm
+  }
   const user = os.userInfo().username;
   if (!trusted.includes(user) && !trusted.includes('*')) {
     console.log(
       `::warning::hestia-cache: ${user} is not in nix trusted-users; ` +
-        'the post-build-hook cannot fire and built paths will not be cached'
+        'nix will ignore both the hestia substituter and the post-build-hook ' +
+        '(nothing will be restored from or saved to the cache)'
     );
   }
 }

--- a/action/main.js
+++ b/action/main.js
@@ -238,7 +238,11 @@ function configureNix(installDir, listen, hookShim) {
     '# written by the hestia-cache action\n' +
       `extra-substituters = http://${listen}?trusted=true&priority=30\n` +
       `post-build-hook = ${hookShim}\n` +
-      'fallback = true\n'
+      'fallback = true\n' +
+      // Without this, nix's on-disk narinfo cache remembers a 404 for an
+      // hour: on persistent self-hosted runners the next job would skip
+      // querying hestia for paths the previous job just uploaded.
+      'narinfo-cache-negative-ttl = 0\n'
   );
 
   // Prepend to the search path so existing user configuration stays active.

--- a/action/main.js
+++ b/action/main.js
@@ -156,8 +156,15 @@ async function installBinary(installDir) {
   } else {
     version = await resolveVersion(version);
     const arch = { x64: 'x86_64', arm64: 'aarch64' }[process.arch] || process.arch;
-    if (process.platform !== 'linux' && process.platform !== 'darwin') {
-      fail(`unsupported platform: ${process.platform}`);
+    // Must match the release.yml build matrix; there is no x86_64-darwin
+    // asset, so Intel macs need a locally built binary.
+    const supported = ['x86_64-linux', 'aarch64-linux', 'aarch64-darwin'];
+    const system = `${arch}-${process.platform}`;
+    if (!supported.includes(system)) {
+      fail(
+        `no release binary is published for ${system}; ` +
+          "pass the 'binary' input to use a locally built hestia"
+      );
     }
     // GITHUB_ACTION_REPOSITORY points at the repo this action was loaded
     // from, so forks automatically download their own releases.

--- a/action/main.js
+++ b/action/main.js
@@ -232,6 +232,17 @@ function writeHookShim(installDir, hestiaBin, socket) {
  * in trusted-users.
  */
 function configureNix(installDir, listen, hookShim) {
+  // nix has a single post-build-hook slot and our conf wins (applied last,
+  // see below): warn instead of silently disabling a pre-existing hook.
+  const show = spawnSync('nix', ['config', 'show', 'post-build-hook'], { encoding: 'utf8' });
+  const previousHook = show.status === 0 ? show.stdout.trim() : '';
+  if (previousHook) {
+    console.log(
+      `::warning::hestia-cache: replacing existing post-build-hook ${previousHook}; ` +
+        'it will no longer fire'
+    );
+  }
+
   const conf = path.join(installDir, 'nix.conf');
   fs.writeFileSync(
     conf,
@@ -245,7 +256,9 @@ function configureNix(installDir, listen, hookShim) {
       'narinfo-cache-negative-ttl = 0\n'
   );
 
-  // Prepend to the search path so existing user configuration stays active.
+  // Prepend to the search path: nix applies user conf files in reverse
+  // list order, so the first file wins conflicting settings -- our hook
+  // and substituter take effect even if the user configures their own.
   const home = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
   const dirs = (process.env.XDG_CONFIG_DIRS || '/etc/xdg').split(':');
   const defaults = [home, ...dirs].map((dir) => path.join(dir, 'nix', 'nix.conf')).join(':');

--- a/action/main.js
+++ b/action/main.js
@@ -20,10 +20,24 @@ const { spawn, spawnSync } = require('child_process');
 // Tiny replacements for @actions/core
 // ---------------------------------------------------------------------------
 
+/**
+ * Append a name/value pair to a runner file command (GITHUB_ENV,
+ * GITHUB_STATE). Uses the heredoc form like @actions/core: the simple
+ * `name=value` form would let a value with an embedded newline inject
+ * extra entries.
+ */
+function fileCommand(file, name, value) {
+  const delimiter = `ghadelimiter_${crypto.randomUUID()}`;
+  if (String(value).includes(delimiter)) {
+    throw new Error(`value of ${name} contains the file command delimiter`);
+  }
+  fs.appendFileSync(process.env[file], `${name}<<${delimiter}\n${value}\n${delimiter}\n`);
+}
+
 /** Export an environment variable to this process and all later job steps. */
 function exportVariable(name, value) {
   process.env[name] = value;
-  fs.appendFileSync(process.env.GITHUB_ENV, `${name}=${value}\n`);
+  fileCommand('GITHUB_ENV', name, value);
 }
 
 /** Read an action input (the runner exposes them as INPUT_* variables). */
@@ -38,7 +52,7 @@ function getInput(name) {
  * post steps, each draining its own daemon.
  */
 function saveState(name, value) {
-  fs.appendFileSync(process.env.GITHUB_STATE, `${name}=${value}\n`);
+  fileCommand('GITHUB_STATE', name, value);
 }
 
 function fail(message) {

--- a/action/main.js
+++ b/action/main.js
@@ -421,6 +421,7 @@ async function main() {
   saveState('socket', socket);
   saveState('serveLog', logFile);
   saveState('drainTimeout', getInput('drain-timeout') || '300');
+  saveState('daemonPid', String(daemonPid));
 }
 
 main().catch((error) => {

--- a/action/post.js
+++ b/action/post.js
@@ -29,6 +29,12 @@ function main() {
   const drain = spawnSync(binary, ['drain', '--socket', socket, '--timeout', timeout], {
     stdio: 'inherit',
   });
+  if (drain.error) {
+    // spawnSync does not throw on launch failures (e.g. ENOENT when the
+    // temp dir was cleaned mid-job); without this the only output is the
+    // generic drain-failed error below.
+    console.error(`::error::failed to run ${binary}: ${drain.error}`);
+  }
 
   // The daemon log carries what the drain summary does not: per-stage drain
   // timings, substituter hits, and error details. Collapsed on success so it
@@ -67,4 +73,6 @@ function main() {
   return drain.status === null ? 1 : drain.status;
 }
 
-process.exit(main());
+// Not process.exit(): that drops pending async stdout writes, truncating
+// the daemon log dump exactly when it is needed.
+process.exitCode = main();

--- a/action/post.js
+++ b/action/post.js
@@ -49,6 +49,21 @@ function main() {
   if (drain.status !== 0) {
     console.error('::error::hestia drain failed; the paths built by this job were not cached');
   }
+
+  // The daemon is spawned detached and never exits on its own; on
+  // persistent self-hosted runners it would outlive the job, holding its
+  // port and a revoked runtime token. SIGTERM triggers a graceful final
+  // drain before exit.
+  const pid = parseInt(getState('daemonPid'), 10);
+  if (pid > 0) {
+    try {
+      process.kill(pid, 'SIGTERM');
+      console.log(`hestia-cache: daemon (pid ${pid}) terminated`);
+    } catch {
+      // Already gone.
+    }
+  }
+
   return drain.status === null ? 1 : drain.status;
 }
 

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -5,9 +5,10 @@
 # Usage: bin/create-release.sh 0.1.0-alpha.3
 #
 # The tag push triggers .github/workflows/release.yml, which builds the
-# static binaries and creates the GitHub release. This script then points
-# the HESTIA_DOGFOOD_* repository variables at the new release so CI
-# dogfoods it.
+# static binaries and creates the GitHub release. CI dogfoods the latest
+# published release automatically; dogfooding must be enabled once by
+# setting the HESTIA_DOGFOOD repository variable to "true" (a manual kill
+# switch this script deliberately does not touch).
 
 set -euo pipefail
 
@@ -88,7 +89,8 @@ if [[ -z $run_id ]]; then
 fi
 gh run watch "$run_id" --exit-status
 
-# Dogfooding needs a published release; draft assets are not downloadable.
+# Dogfooding needs a published release: the action resolves 'latest' to
+# the newest non-draft release, so CI dogfoods this one once published.
 echo
 echo "draft release created:"
 gh release view "$tag" --json url --jq .url
@@ -97,12 +99,10 @@ while [[ "$(gh release view "$tag" --json isDraft --jq .isDraft)" == "true" ]]; 
   sleep 10
 done
 
-# Point CI dogfooding at the new release. Downloads are verified via build
-# attestations, so only the version variable is needed.
-gh variable set HESTIA_DOGFOOD_VERSION --body "$tag"
-
 echo
 echo "released ${tag}:"
 gh release view "$tag" --json url --jq .url
-echo "dogfood variables updated:"
-echo "  HESTIA_DOGFOOD_VERSION=${tag}"
+if [[ "$(gh variable get HESTIA_DOGFOOD 2>/dev/null || true)" != "true" ]]; then
+  echo "note: HESTIA_DOGFOOD is not 'true'; CI will not dogfood until you run:"
+  echo "  gh variable set HESTIA_DOGFOOD --body true"
+fi

--- a/bin/profile.sh
+++ b/bin/profile.sh
@@ -40,6 +40,15 @@ stop() {
     echo "no recording is running (start one with: $0 start)" >&2
     exit 1
   fi
+  # Check the render tools before teardown: failing after the pid file is
+  # removed would leave the captured data unrenderable through this script.
+  local tool
+  for tool in perf inferno-collapse-perf inferno-flamegraph; do
+    if ! command -v "$tool" >/dev/null; then
+      echo "$tool not found on PATH; install it before stopping" >&2
+      exit 1
+    fi
+  done
   local pid
   pid=$(cat "$perf_pid_file")
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   inputs.crane.url = "github:ipetkov/crane";
 
   outputs =
-    {
+    inputs@{
       self,
       nixpkgs,
       treefmt-nix,
@@ -85,6 +85,14 @@
           clippy = (craneFor pkgs).clippy;
           tests = (craneFor pkgs).tests;
           gha-real-tests = self.packages.${system}.gha-real-tests;
+          # Input sources end up in the binary cache, so later runs
+          # substitute them instead of re-fetching from GitHub.
+          flake-inputs = pkgs.linkFarm "flake-inputs" (
+            lib.mapAttrsToList (name: input: {
+              inherit name;
+              path = input.outPath;
+            }) (removeAttrs inputs [ "self" ])
+          );
         }
       );
     };

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -79,7 +79,8 @@ pub struct Chunk {
 /// Split file contents into content-defined chunks.
 ///
 /// Deterministic: the same input always produces the same chunk boundaries
-/// and hashes (FastCDC is seeded with a constant).
+/// and hashes (the gear table is fixed by the FastCDC algorithm; only
+/// MIN/AVG/MAX_CHUNK_SIZE and the fastcdc crate version affect boundaries).
 pub fn chunk_data(data: &Bytes) -> Vec<Chunk> {
     if data.is_empty() {
         return Vec::new();
@@ -147,10 +148,11 @@ impl PackBuilder {
 
     /// Append an already-compressed chunk frame without recompressing it.
     ///
-    /// Used by GC repack: frames are Range-read from source packs and copied
-    /// into new packs byte-identically, never recompressed. The caller must
-    /// have verified that `frame` decompresses to data hashing to `hash`
-    /// (see [`extract_chunk`]). Returns whether the chunk was actually added
+    /// Used by the write pipeline (frames freshly produced by
+    /// [`compress_chunks`]; integrity covered by the NAR-hash gate over the
+    /// uncompressed data) and by GC repack (frames Range-read from source
+    /// packs and copied byte-identically after verification via
+    /// [`extract_chunk`]). Returns whether the chunk was actually added
     /// (duplicates are skipped).
     pub fn add_compressed(
         &mut self,

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -389,9 +389,12 @@ impl TreeBuilder {
     }
 }
 
-fn name_to_string(name: &[u8]) -> Result<String, Error> {
+/// NAR permits arbitrary bytes in entry names and symlink targets, but the
+/// manifest stores them as UTF-8 (a representation limit); `what` names the
+/// field so the diagnostic points at the right one.
+fn name_to_string(name: &[u8], what: &str) -> Result<String, Error> {
     String::from_utf8(name.to_vec())
-        .map_err(|_| Error::InvalidNar(format!("non-UTF-8 entry name: {name:?}")))
+        .map_err(|_| Error::InvalidNar(format!("non-UTF-8 {what}: {name:?}")))
 }
 
 /// Walk `path` with harmonia's NAR dumper, splitting every regular file into
@@ -409,16 +412,16 @@ pub async fn chunk_path(path: impl Into<PathBuf>) -> Result<ChunkedPath, Error> 
     while let Some(event) = events.next().await {
         match event? {
             NarEvent::StartDirectory { name } => {
-                builder.start_directory(name_to_string(&name)?);
+                builder.start_directory(name_to_string(&name, "entry name")?);
             }
             NarEvent::EndDirectory => {
                 builder.end_directory()?;
             }
             NarEvent::Symlink { name, target } => {
                 builder.place(
-                    name_to_string(&name)?,
+                    name_to_string(&name, "entry name")?,
                     FileTree(FileSystemObject::Symlink(Symlink {
-                        target: name_to_string(&target)?,
+                        target: name_to_string(&target, "symlink target")?,
                     })),
                 )?;
             }
@@ -439,7 +442,7 @@ pub async fn chunk_path(path: impl Into<PathBuf>) -> Result<ChunkedPath, Error> 
                     }
                 }
                 builder.place(
-                    name_to_string(&name)?,
+                    name_to_string(&name, "entry name")?,
                     FileTree(FileSystemObject::Regular(Regular {
                         executable,
                         contents: list,

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -35,6 +35,14 @@ pub const MAX_CHUNK_SIZE: u32 = 256 * 1024;
 /// percent.
 const ZSTD_LEVEL: i32 = 3;
 
+/// Largest zstd window log accepted when decoding chunk frames.
+///
+/// Frames produced at [`ZSTD_LEVEL`] declare a window log of 21; anything
+/// larger in pack data is corrupt or malicious. Pinned together with
+/// [`ZSTD_LEVEL`]: raising the level can raise the declared window log,
+/// which would make existing extraction reject legitimate frames.
+const MAX_CHUNK_WINDOW_LOG: u32 = 21;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("I/O or compression error: {0}")]
@@ -674,9 +682,15 @@ async fn write_nar<W: tokio::io::AsyncWrite + Unpin>(
 pub fn extract_chunk(compressed: &[u8], expected: &ChunkHash) -> Result<Vec<u8>, Error> {
     use std::io::Read as _;
     let mut data = Vec::new();
+    let mut decoder = zstd::Decoder::with_buffer(compressed)?;
+    // Reject oversized declared windows at header parse time: a crafted
+    // frame in untrusted pack data could otherwise force a large window
+    // allocation (up to 128 MiB with libzstd's default cap) before any
+    // output is read.
+    decoder.window_log_max(MAX_CHUNK_WINDOW_LOG)?;
     // Read at most one byte past the limit: enough to detect oversize
     // without buffering the full payload.
-    zstd::Decoder::with_buffer(compressed)?
+    decoder
         .take(u64::from(MAX_CHUNK_SIZE) + 1)
         .read_to_end(&mut data)?;
     if data.len() > MAX_CHUNK_SIZE as usize {
@@ -890,6 +904,35 @@ mod tests {
             extract_chunk(&frame, &expected),
             Err(Error::OversizedChunk)
         ));
+    }
+
+    #[test]
+    fn extract_chunk_rejects_oversized_window_declarations() {
+        // A crafted frame can declare a huge decoder window in its header,
+        // forcing libzstd to allocate it before any output is read. Such
+        // frames must fail at header parse time, without the allocation.
+        let payload = test_data(1024, 6);
+        let mut encoder = zstd::Encoder::new(Vec::new(), 3).unwrap();
+        encoder.window_log(MAX_CHUNK_WINDOW_LOG + 3).unwrap();
+        // Streaming without a pledged content size forces the frame header
+        // to carry the window descriptor.
+        std::io::Write::write_all(&mut encoder, &payload).unwrap();
+        let frame = encoder.finish().unwrap();
+
+        let expected = ChunkHash::digest(&payload);
+        assert!(matches!(
+            extract_chunk(&frame, &expected),
+            Err(Error::Io(_))
+        ));
+
+        // Frames produced the production way (compress_chunks at
+        // ZSTD_LEVEL) still extract fine, up to the largest chunk size.
+        let big = test_data(MAX_CHUNK_SIZE as usize, 8);
+        for data in [payload, big] {
+            let expected = ChunkHash::digest(&data);
+            let normal = zstd::encode_all(data.as_ref(), ZSTD_LEVEL).unwrap();
+            assert_eq!(extract_chunk(&normal, &expected).unwrap(), data);
+        }
     }
 
     #[test]

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -264,7 +264,9 @@ pub fn coalesce_adjacent<T>(
         let (offset, _) = span(&item);
         let adjacent = runs.last().and_then(|run| run.last()).is_some_and(|last| {
             let (last_offset, last_size) = span(last);
-            last_offset + u64::from(last_size) == offset
+            // Checked: locations can come from a corrupt manifest; an
+            // offset near u64::MAX must not panic the comparison.
+            last_offset.checked_add(u64::from(last_size)) == Some(offset)
         });
         match runs.last_mut() {
             Some(run) if adjacent => run.push(item),

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -461,11 +461,13 @@ pub async fn chunk_path(path: impl Into<PathBuf>) -> Result<ChunkedPath, Error> 
 }
 
 /// NAR hash and size of a path, computed by streaming harmonia's
-/// [`NarByteStream`] (the exact code path that will serve NARs in Phase 4)
-/// into SHA-256.
+/// [`NarByteStream`] (an independent walk of the on-disk path) into
+/// SHA-256.
 ///
-/// Using the same serializer for hashing and for serving is what guarantees
-/// hashes match by construction.
+/// Test-only oracle: gives tests a hash derived without going through the
+/// chunk pipeline to compare against. The production by-construction
+/// guarantee lives in [`nar_hash_from_chunks`] / [`nar_from_chunks`],
+/// which share NAR event synthesis with the serving path.
 pub async fn nar_hash_and_size(path: impl Into<PathBuf>) -> Result<(Hash32, u64), Error> {
     let mut stream = NarByteStream::new(path.into());
     let mut context = harmonia_utils_hash::Context::new(harmonia_utils_hash::Algorithm::SHA256);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,7 +60,10 @@ pub struct ServeArgs {
     #[arg(
         long = "upstream-cache-key-name",
         value_name = "KEY_NAME",
-        default_value = "cache.nixos.org-1"
+        default_value = "cache.nixos.org-1",
+        // Without the filter flag the names are discarded; rejecting the
+        // combination beats silently ignoring an explicit configuration.
+        requires = "upstream_cache_filter"
     )]
     pub upstream_cache_key_names: Vec<String>,
 
@@ -186,6 +189,21 @@ mod tests {
             ]
         );
         assert_eq!(args.db_path, PathBuf::from("/custom/db.sqlite"));
+    }
+
+    #[test]
+    fn upstream_key_names_require_the_filter_flag() {
+        // Without `requires`, an explicit key name would parse fine and be
+        // silently discarded by serve::run's empty-filter branch.
+        assert!(
+            Cli::try_parse_from([
+                "hestia",
+                "serve",
+                "--upstream-cache-key-name",
+                "company-cache-1",
+            ])
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -110,17 +110,36 @@ pub fn stage_breakdown(stats: &DrainStats) -> String {
     stages.join(", ")
 }
 
+/// Exit code and output for a successful daemon response.
+///
+/// The module contract says a zero exit means the built paths were cached:
+/// verification failures mean exactly the opposite for the affected paths,
+/// so they must fail the step even though the daemon reported `ok`.
+fn report_outcome(response: protocol::Response) -> ExitCode {
+    let Some(stats) = response.stats else {
+        // A daemon from a different hestia build may omit the stats
+        // payload; do not fabricate a "pushed 0 paths" summary from zeros.
+        eprintln!("hestia drain: daemon reported success but sent no stats (version skew?)");
+        return ExitCode::SUCCESS;
+    };
+    eprintln!("hestia drain: {}", summarize(&stats));
+    if stats.failed_verification > 0 || stats.failed_chunking > 0 {
+        eprintln!(
+            "hestia drain: {} were NOT cached; see the daemon log",
+            count(stats.failed_verification + stats.failed_chunking, "path"),
+        );
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
+}
+
 pub async fn run(args: &DrainArgs) -> ExitCode {
     let timeout = Duration::from_secs(args.timeout);
     let result =
         tokio::time::timeout(timeout, protocol::roundtrip(&args.socket, &Request::Drain)).await;
 
     match result {
-        Ok(Ok(response)) => {
-            let stats = response.stats.unwrap_or_default();
-            eprintln!("hestia drain: {}", summarize(&stats));
-            ExitCode::SUCCESS
-        }
+        Ok(Ok(response)) => report_outcome(response),
         Ok(Err(err)) => {
             eprintln!(
                 "hestia drain: failed to drain daemon at {}: {err}",
@@ -129,8 +148,12 @@ pub async fn run(args: &DrainArgs) -> ExitCode {
             ExitCode::FAILURE
         }
         Err(_) => {
+            // Only the client-side wait is abandoned: the daemon's drain
+            // keeps running and may still commit, so the outcome is
+            // unknown -- do not claim the paths were not cached.
             eprintln!(
-                "hestia drain: daemon at {} did not finish within {}s",
+                "hestia drain: daemon at {} still draining after {}s; outcome unknown, \
+                 see the daemon log",
                 args.socket.display(),
                 args.timeout
             );
@@ -255,6 +278,37 @@ mod tests {
             ..DrainStats::default()
         };
         assert!(summarize(&stats).contains("1 FAILED CHUNKING"));
+    }
+
+    #[test]
+    fn verification_failures_fail_the_drain_exit_code() {
+        // The exit code is the action's only escalation signal: paths that
+        // failed verification or chunking were NOT cached, so an ok
+        // response carrying such counts must still exit non-zero.
+        for stats in [
+            DrainStats {
+                failed_verification: 1,
+                ..DrainStats::default()
+            },
+            DrainStats {
+                failed_chunking: 1,
+                ..DrainStats::default()
+            },
+        ] {
+            let code = report_outcome(protocol::Response::ok().with_stats(stats));
+            assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::FAILURE));
+        }
+
+        let clean = report_outcome(protocol::Response::ok().with_stats(DrainStats::default()));
+        assert_eq!(format!("{clean:?}"), format!("{:?}", ExitCode::SUCCESS));
+    }
+
+    #[test]
+    fn missing_stats_is_not_reported_as_an_empty_drain() {
+        // Version skew: an ok response without stats must not fabricate a
+        // "pushed 0 paths" summary, but it is not a failure either.
+        let code = report_outcome(protocol::Response::ok());
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
     }
 
     #[tokio::test]

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -31,7 +31,9 @@ pub fn human_bytes(bytes: u64) -> String {
     for next in ["KiB", "MiB", "GiB", "TiB"] {
         value /= 1024.0;
         unit = next;
-        if value < 1024.0 {
+        // 1023.95 instead of 1024.0: values in [1023.95, 1024.0) would
+        // round to the self-contradictory "1024.0" in the smaller unit.
+        if value < 1023.95 {
             break;
         }
     }
@@ -64,11 +66,14 @@ pub fn summarize(stats: &DrainStats) -> String {
     let mut summary = parts.join(", ");
     if stats.packs_uploaded > 0 {
         let mut inner = human_bytes(stats.bytes_uploaded);
-        if stats.elapsed_ms > 0 {
+        if stats.upload_ms > 0 {
+            // Rate over upload_ms, not elapsed_ms: a "/s" figure next to
+            // uploaded bytes reads as upload throughput, and dividing by
+            // whole-drain wall time understated it severalfold.
             inner.push_str(&format!(
                 " in {}, {}/s",
                 seconds(stats.elapsed_ms),
-                human_bytes(throughput(stats.bytes_uploaded, stats.elapsed_ms))
+                human_bytes(throughput(stats.bytes_uploaded, stats.upload_ms))
             ));
         }
         summary.push_str(&format!(" ({inner})"));
@@ -92,7 +97,10 @@ pub fn stage_breakdown(stats: &DrainStats) -> String {
         format!("load {}", seconds(stats.load_ms)),
         format!("chunk {}", seconds(stats.chunk_ms)),
     ];
-    if stats.packs_uploaded > 0 {
+    // Gate on new_chunks, not packs_uploaded: when a concurrent job won the
+    // upload race every pack comes back already_exists, yet the pack and
+    // upload stages still consumed most of the wall time and must show up.
+    if stats.new_chunks > 0 {
         stages.push(format!(
             "pack {} ({}, {})",
             seconds(stats.pack_ms),
@@ -190,7 +198,7 @@ mod tests {
         assert_eq!(
             summarize(&stats),
             "pushed 4 paths, 3 already cached, 2 upstream-signed, 1 invalid \
-             (446.1 KiB in 2.0s, 223.0 KiB/s); manifest m#7"
+             (446.1 KiB in 2.0s, 2.2 MiB/s); manifest m#7"
         );
         assert_eq!(
             stage_breakdown(&stats),
@@ -218,6 +226,31 @@ mod tests {
     }
 
     #[test]
+    fn dedup_race_still_shows_pack_and_upload_stages() {
+        // Every pack came back already_exists (a concurrent job won the
+        // race): packs_uploaded is 0, but the pack and upload stages still
+        // consumed the bulk of the drain and must appear in the breakdown.
+        let stats = DrainStats {
+            pushed: 2,
+            new_chunks: 50,
+            packs_uploaded: 0,
+            manifest_version: 3,
+            load_ms: 100,
+            chunk_ms: 400,
+            pack_ms: 700,
+            upload_ms: 900,
+            commit_ms: 100,
+            elapsed_ms: 2_300,
+            ..DrainStats::default()
+        };
+        assert_eq!(
+            stage_breakdown(&stats),
+            "load 0.1s, chunk 0.4s, pack 0.7s (50 chunks, 0 packs), \
+             upload 0.9s (0 B/s), commit 0.1s, total 2.3s"
+        );
+    }
+
+    #[test]
     fn singular_counts_have_no_plural_s() {
         let stats = DrainStats {
             pushed: 1,
@@ -234,7 +267,7 @@ mod tests {
         };
         assert_eq!(
             summarize(&stats),
-            "pushed 1 path (1.0 MiB in 1.0s, 1.0 MiB/s); manifest m#1"
+            "pushed 1 path (1.0 MiB in 1.0s, 2.0 MiB/s); manifest m#1"
         );
         assert_eq!(
             stage_breakdown(&stats),
@@ -257,6 +290,8 @@ mod tests {
         assert_eq!(human_bytes(1023), "1023 B");
         assert_eq!(human_bytes(1024), "1.0 KiB");
         assert_eq!(human_bytes(456_789), "446.1 KiB");
+        // One byte short of 1 MiB must not render as "1024.0 KiB".
+        assert_eq!(human_bytes(1_048_575), "1.0 MiB");
         assert_eq!(human_bytes(67_694_023), "64.6 MiB");
         assert_eq!(human_bytes(3_000_000_000), "2.8 GiB");
         assert_eq!(human_bytes(5_000_000_000_000), "4.5 TiB");

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -58,6 +58,9 @@ pub fn summarize(stats: &DrainStats) -> String {
     if stats.failed_verification > 0 {
         parts.push(format!("{} FAILED VERIFICATION", stats.failed_verification));
     }
+    if stats.failed_chunking > 0 {
+        parts.push(format!("{} FAILED CHUNKING", stats.failed_chunking));
+    }
     let mut summary = parts.join(", ");
     if stats.packs_uploaded > 0 {
         let mut inner = human_bytes(stats.bytes_uploaded);
@@ -149,6 +152,7 @@ mod tests {
             skipped_upstream: 2,
             skipped_invalid: 1,
             failed_verification: 0,
+            failed_chunking: 0,
             new_chunks: 123,
             packs_uploaded: 1,
             bytes_uploaded: 456_789,
@@ -242,6 +246,15 @@ mod tests {
             ..DrainStats::default()
         };
         assert!(summarize(&stats).contains("2 FAILED VERIFICATION"));
+    }
+
+    #[test]
+    fn chunking_failures_are_loud() {
+        let stats = DrainStats {
+            failed_chunking: 1,
+            ..DrainStats::default()
+        };
+        assert!(summarize(&stats).contains("1 FAILED CHUNKING"));
     }
 
     #[tokio::test]

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -59,6 +59,12 @@ pub enum Error {
 
     #[error("chunk verification failed during repack: {0}")]
     Chunker(#[from] chunker::Error),
+
+    #[error(
+        "manifest lookup returned nothing, but {0} manifest version entries exist in the \
+         REST listing; refusing to plan against a possibly stale empty view"
+    )]
+    ManifestLookupInconsistent(usize),
 }
 
 /// GC policy knobs.
@@ -722,10 +728,29 @@ impl GcContext {
     }
 
     /// Load the current manifest, or an empty one if none exists yet.
+    ///
+    /// A lookup miss is cross-checked against the REST listing: the Twirp
+    /// lookup is eventually consistent, and planning against a falsely
+    /// empty manifest would orphan-delete the entire pack store. The miss
+    /// is only trusted when the REST listing shows no manifest versions
+    /// either.
     pub async fn load_manifest(&self) -> Result<Manifest, Error> {
         match self.save_mutable().load().await? {
             Some(entry) => Ok(Manifest::decode(&entry.data)?),
-            None => Ok(Manifest::new()),
+            None => {
+                let prefix = format!("{}#", self.manifest_prefix);
+                let versions = self
+                    .rest
+                    .list_caches(&prefix)
+                    .await?
+                    .iter()
+                    .filter(|entry| entry.version == self.twirp.version())
+                    .count();
+                if versions > 0 {
+                    return Err(Error::ManifestLookupInconsistent(versions));
+                }
+                Ok(Manifest::new())
+            }
         }
     }
 

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -33,7 +33,7 @@ use crate::chunker::{
 use crate::cli::GcArgs;
 use crate::drain::human_bytes;
 use crate::gha::rest::{CacheEntry, RestClient};
-use crate::gha::savemutable::SaveMutable;
+use crate::gha::savemutable::{MutableEntry, SaveMutable};
 use crate::gha::twirp::{DownloadUrl, TwirpClient};
 use crate::gha::{Error as GhaError, blob};
 use crate::manifest::{
@@ -530,8 +530,7 @@ pub fn plan(
                     // 0 means no REST timestamp parsed: the idle time is
                     // unknown, so do not force a touch (mirrors the
                     // `created == 0` orphan guard).
-                    *last_accessed != 0
-                        && now.saturating_sub(*last_accessed) > policy.touch_age
+                    *last_accessed != 0 && now.saturating_sub(*last_accessed) > policy.touch_age
                 })
         })
         .map(|(pack, pack_stats)| (pack_stats.tier, pack_stats.live_bytes, *pack))
@@ -745,8 +744,17 @@ impl GcContext {
     /// is only trusted when the REST listing shows no manifest versions
     /// either.
     pub async fn load_manifest(&self) -> Result<Manifest, Error> {
-        match self.save_mutable().load().await? {
+        match self.load_manifest_entry().await? {
             Some(entry) => Ok(Manifest::decode(&entry.data)?),
+            None => Ok(Manifest::new()),
+        }
+    }
+
+    /// Like [`Self::load_manifest`], but keeps the raw entry (the commit
+    /// step needs its index as a reservation floor).
+    async fn load_manifest_entry(&self) -> Result<Option<MutableEntry>, Error> {
+        match self.save_mutable().load().await? {
+            Some(entry) => Ok(Some(entry)),
             None => {
                 let prefix = format!("{}#", self.manifest_prefix);
                 let versions = self
@@ -759,7 +767,7 @@ impl GcContext {
                 if versions > 0 {
                     return Err(Error::ManifestLookupInconsistent(versions));
                 }
-                Ok(Manifest::new())
+                Ok(None)
             }
         }
     }
@@ -990,19 +998,30 @@ impl GcContext {
     /// its paths/packs are respected — a path the stale plan wanted to drop
     /// stays if the push made it live again, and a pack only enters the
     /// deletable set if the *committed* manifest no longer references it.
-    pub async fn commit(
-        &self,
-        observations: &[PackObservation],
-        repacks: &RepackOutput,
-        now: u64,
-    ) -> Result<CommitOutcome, Error> {
+    pub async fn commit(&self, repacks: &RepackOutput, now: u64) -> Result<CommitOutcome, Error> {
+        // Re-list the pack observations: the plan-time listing predates the
+        // potentially long repack and touch phases. A pack a concurrent
+        // drain uploaded since then carries the drain's *start* time, which
+        // can exceed min_age — the stale listing would judge it evicted and
+        // heal away the drain's just-committed paths.
+        let observations = self.observe_packs().await?;
+        let observations = observations.as_slice();
+
         // Skip the commit when it would be a byte-identical no-op. Note
         // this only fires for an empty or fully-unreachable manifest:
         // mark_reachable bumps last_reachable on every reachable path, so
         // any cache with a live root always commits (the fresh clocks
         // preserve the full path_grace window for paths whose roots later
         // expire).
-        let base = self.load_manifest().await?;
+        let entry = self.load_manifest_entry().await?;
+        // Never reserve at or below the version observed here, even when
+        // the eventually consistent lookup inside save() regresses below it
+        // (same hazard the drain commit guards against).
+        let floor = entry.as_ref().map_or(0, |e| e.index);
+        let base = match &entry {
+            Some(entry) => Manifest::decode(&entry.data)?,
+            None => Manifest::new(),
+        };
         let base_plan = plan(&base, observations, now, &self.policy);
         let (transformed, deletable) = apply(base.clone(), &base_plan, repacks);
         if transformed == base {
@@ -1017,7 +1036,7 @@ impl GcContext {
         let mut committed: Option<(Vec<PackHash>, BTreeSet<String>)> = None;
         let version = self
             .save_mutable()
-            .save(|existing| {
+            .save_with_floor(floor, |existing| {
                 let latest = match existing {
                     Some(entry) => Manifest::decode(&entry.data)
                         .map_err(|err| GhaError::InvalidResponse(err.to_string()))?,
@@ -1117,7 +1136,7 @@ impl GcContext {
     /// The full GC flow: plan, then (unless `dry_run`) execute every step in
     /// crash-safe order.
     pub async fn run(&self, dry_run: bool, now: u64) -> Result<GcReport, Error> {
-        let (_, observations, gc_plan) = self.plan(now).await?;
+        let (_, _, gc_plan) = self.plan(now).await?;
         eprintln!("hestia gc: plan: {}", gc_plan.summary());
 
         let mut report = GcReport {
@@ -1137,8 +1156,8 @@ impl GcContext {
         // 2. Touch.
         report.packs_touched = self.execute_touches(&gc_plan).await?;
 
-        // 3. Commit the manifest (re-plans on conflict).
-        let outcome = self.commit(&observations, &repacks, now).await?;
+        // 3. Commit the manifest (re-plans on conflict, re-lists packs).
+        let outcome = self.commit(&repacks, now).await?;
         report.manifest_version = outcome.version;
 
         // 4-6. Deletes happen strictly after the commit landed.

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -892,8 +892,12 @@ impl GcContext {
         repacks: &RepackOutput,
         now: u64,
     ) -> Result<CommitOutcome, Error> {
-        // Skip the commit when it would be a byte-identical no-op (e.g. GC
-        // of an empty or already-clean cache).
+        // Skip the commit when it would be a byte-identical no-op. Note
+        // this only fires for an empty or fully-unreachable manifest:
+        // mark_reachable bumps last_reachable on every reachable path, so
+        // any cache with a live root always commits (the fresh clocks
+        // preserve the full path_grace window for paths whose roots later
+        // expire).
         let base = self.load_manifest().await?;
         let base_plan = plan(&base, observations, now, &self.policy);
         let (transformed, deletable) = apply(base.clone(), &base_plan, repacks);

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -109,6 +109,16 @@ impl Default for GcPolicy {
     }
 }
 
+/// Parse a manifest version key (`<prefix><index>`) back into its index.
+/// Only the canonical decimal form SaveMutable writes is accepted:
+/// `str::parse` alone also accepts `m#+99` and `m#007`, which would let a
+/// foreign same-prefix key inflate the newest-version computation.
+fn parse_manifest_index(prefix: &str, key: &str) -> Option<u64> {
+    let suffix = key.strip_prefix(prefix)?;
+    let index: u64 = suffix.parse().ok()?;
+    (suffix == index.to_string()).then_some(index)
+}
+
 /// Parse a `pack-<sha256 hex>` cache key back into the pack hash.
 fn parse_pack_key(key: &str) -> Option<PackHash> {
     let hex = key.strip_prefix("pack-")?;
@@ -1078,10 +1088,7 @@ impl GcContext {
             // (possibly higher) indices into `newest` would make GC delete
             // this namespace's live manifest head.
             .filter(|entry| entry.version == self.twirp.version())
-            .filter_map(|entry| {
-                let index: u64 = entry.key.strip_prefix(&prefix)?.parse().ok()?;
-                Some((index, entry))
-            })
+            .filter_map(|entry| Some((parse_manifest_index(&prefix, &entry.key)?, entry)))
             .collect();
         let Some(newest) = indexed.iter().map(|(index, _)| *index).max() else {
             return Ok(0);
@@ -1359,6 +1366,17 @@ mod tests {
         // Get-FileHash digest in an actions/cache key) is foreign.
         assert_eq!(parse_pack_key(&format!("pack-{}", "A".repeat(64))), None);
         assert_eq!(parse_pack_key(&format!("pack-{}", "+1".repeat(32))), None);
+    }
+
+    #[test]
+    fn manifest_index_parses_only_canonical_decimal() {
+        assert_eq!(parse_manifest_index("m#", "m#0"), Some(0));
+        assert_eq!(parse_manifest_index("m#", "m#42"), Some(42));
+        assert_eq!(parse_manifest_index("m#", "m#+99"), None);
+        assert_eq!(parse_manifest_index("m#", "m#007"), None);
+        assert_eq!(parse_manifest_index("m#", "m#"), None);
+        assert_eq!(parse_manifest_index("m#", "m#1x"), None);
+        assert_eq!(parse_manifest_index("m#", "other#1"), None);
     }
 
     #[test]

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -109,6 +109,12 @@ fn parse_pack_key(key: &str) -> Option<PackHash> {
     if hex.len() != 64 {
         return None;
     }
+    // Hestia only emits lowercase hex. `from_str_radix` would also accept
+    // uppercase digits and a leading `+` — keys hestia never created, so
+    // they belong to other workflows and must not parse.
+    if !hex.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')) {
+        return None;
+    }
     let mut bytes = [0u8; 32];
     for (i, byte) in bytes.iter_mut().enumerate() {
         *byte = u8::from_str_radix(hex.get(2 * i..2 * i + 2)?, 16).ok()?;
@@ -1286,6 +1292,10 @@ mod tests {
         assert_eq!(parse_pack_key("pack-"), None);
         assert_eq!(parse_pack_key("m#3"), None);
         assert_eq!(parse_pack_key(&format!("pack-{}", "0".repeat(63))), None);
+        // Hestia only emits lowercase hex; an uppercase 64-hex key (e.g. a
+        // Get-FileHash digest in an actions/cache key) is foreign.
+        assert_eq!(parse_pack_key(&format!("pack-{}", "A".repeat(64))), None);
+        assert_eq!(parse_pack_key(&format!("pack-{}", "+1".repeat(32))), None);
     }
 
     #[test]

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -840,8 +840,17 @@ impl GcContext {
         output: &mut RepackOutput,
     ) -> Result<(), Error> {
         let pack = builder.finish();
-        upload_pack(&self.twirp, &self.http, &pack).await?;
-        output.uploaded += pack.data.len() as u64;
+        if upload_pack(&self.twirp, &self.http, &pack).await? {
+            output.uploaded += pack.data.len() as u64;
+        } else {
+            // CAS no-op: the pack already existed, so nothing was
+            // transferred and the LRU clock was not reset by an upload.
+            // Touch it so the pack does not idle into the 7-day eviction
+            // while still referenced.
+            if let Some(url) = self.pack_url(&pack.hash).await? {
+                blob::get(&self.http, &url, Some(0..1)).await?;
+            }
+        }
         output.packs.insert(
             pack.hash,
             PackInfo {
@@ -1503,8 +1512,10 @@ mod tests {
         assert_eq!(plan.repack_jobs.len(), 1);
         assert_eq!(plan.repack_jobs[0].copies.len(), 5);
         assert_eq!(plan.delete_packs.len(), 5);
-        // Consolidating multiple packs always produces new content, so the
-        // CAS trap does not apply here.
+        // A multi-source consolidation can still reproduce a source pack
+        // byte-identically (the builder seals at the same target size the
+        // pipeline used); that case is handled at upload time, where the
+        // already-exists result triggers an LRU touch instead.
     }
 
     #[test]

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -700,13 +700,18 @@ impl GcContext {
         }
     }
 
-    /// REST-list all `pack-*` cache entries.
+    /// REST-list all `pack-*` cache entries in GC's own cache version
+    /// namespace. The listing is prefix-based and version-blind, so it
+    /// also returns same-key entries of other namespaces (salted runs,
+    /// foreign workflows): not ours to delete as orphans, and they must
+    /// not mask an eviction of our own entry during reconcile.
     pub async fn observe_packs(&self) -> Result<Vec<PackObservation>, Error> {
         Ok(self
             .rest
             .list_caches("pack-")
             .await?
             .iter()
+            .filter(|entry| entry.version == self.twirp.version())
             .map(PackObservation::from_entry)
             .collect())
     }
@@ -1015,6 +1020,10 @@ impl GcContext {
         let entries = self.rest.list_caches(&prefix).await?;
         let indexed: Vec<(u64, &CacheEntry)> = entries
             .iter()
+            // Another namespace's m#N sequence restarts at 1; letting its
+            // (possibly higher) indices into `newest` would make GC delete
+            // this namespace's live manifest head.
+            .filter(|entry| entry.version == self.twirp.version())
             .filter_map(|entry| {
                 let index: u64 = entry.key.strip_prefix(&prefix)?.parse().ok()?;
                 Some((index, entry))

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -318,10 +318,36 @@ pub fn plan(
         ..GcPlan::default()
     };
 
-    let observed: BTreeMap<PackHash, &PackObservation> = observations
-        .iter()
-        .filter_map(|observation| observation.pack.map(|pack| (pack, observation)))
-        .collect();
+    // The REST listing repeats a key once per ref, each entry with its own
+    // clocks. Keep the *stalest* parsed LRU clock per pack: any copy going
+    // idle warrants a touch, since each ref's entry is evicted
+    // independently. 0 means no copy's clock parsed.
+    let mut observed: BTreeMap<PackHash, u64> = BTreeMap::new();
+    for observation in observations {
+        let Some(pack) = observation.pack else {
+            continue;
+        };
+        let last_accessed = observed.entry(pack).or_insert(observation.last_accessed);
+        if *last_accessed == 0
+            || (observation.last_accessed != 0 && observation.last_accessed < *last_accessed)
+        {
+            *last_accessed = observation.last_accessed;
+        }
+    }
+    // Newest creation time per key across refs; 0 when any duplicate's
+    // timestamp failed to parse. Deletion is by key across all refs, so a
+    // key is only safe to judge by its newest entry.
+    let mut newest_created: BTreeMap<&str, u64> = BTreeMap::new();
+    for observation in observations.iter().filter(|o| o.pack.is_some()) {
+        let created = newest_created
+            .entry(observation.key.as_str())
+            .or_insert(observation.created);
+        *created = if *created == 0 || observation.created == 0 {
+            0
+        } else {
+            (*created).max(observation.created)
+        };
+    }
 
     // ① Reconcile: packs GitHub already evicted
     // Packs younger than min_age are never judged evicted: they may have been
@@ -484,12 +510,12 @@ pub fn plan(
         .filter(|(pack, pack_stats)| {
             !pack_stats.live.is_empty()
                 && !repack_sources.contains(*pack)
-                && observed.get(*pack).is_some_and(|observation| {
-                    // `last_accessed == 0` means the REST timestamp did not
-                    // parse: the idle time is unknown, so do not force a
-                    // touch (mirrors the `created == 0` orphan guard).
-                    observation.last_accessed != 0
-                        && now.saturating_sub(observation.last_accessed) > policy.touch_age
+                && observed.get(*pack).is_some_and(|last_accessed| {
+                    // 0 means no REST timestamp parsed: the idle time is
+                    // unknown, so do not force a touch (mirrors the
+                    // `created == 0` orphan guard).
+                    *last_accessed != 0
+                        && now.saturating_sub(*last_accessed) > policy.touch_age
                 })
         })
         .map(|(pack, pack_stats)| (pack_stats.tier, pack_stats.live_bytes, *pack))
@@ -511,12 +537,15 @@ pub fn plan(
             let Some(pack) = observation.pack else {
                 return false;
             };
-            // `created == 0` means the REST timestamp did not parse: the
-            // entry's age is unknown, so treat it as too young to judge
-            // (it could be a concurrent push's just-uploaded pack).
+            // Judge the key by its *newest* entry across refs: a fresh
+            // duplicate on another ref is an in-flight push's upload (or a
+            // retried push's dedup re-use), and deletion removes every
+            // ref's copy. `newest == 0` means the age is unknown: treat it
+            // as too young to judge.
+            let newest = newest_created[observation.key.as_str()];
             !manifest.packs.contains_key(&pack)
-                && observation.created != 0
-                && now.saturating_sub(observation.created) > policy.min_age
+                && newest != 0
+                && now.saturating_sub(newest) > policy.min_age
         })
         .map(|observation| observation.key.clone())
         .collect();
@@ -1719,6 +1748,67 @@ mod tests {
         assert_eq!(
             plan.orphan_keys,
             BTreeSet::from([pack_cache_key(&pack_hash(9))])
+        );
+    }
+
+    #[test]
+    fn orphan_keys_require_every_duplicate_entry_to_be_old() {
+        // A week-old entry on one ref must not orphan the key while
+        // another ref holds a minutes-old entry (an in-flight push's
+        // upload): deletion is by key across all refs.
+        let manifest = ManifestBuilder::new()
+            .pack(1, TIER_VOLATILE, NOW - SECS_PER_DAY)
+            .chunk(1, 1, 100, 0)
+            .path(1, &[1], &[], NOW, NOW)
+            .root("main", &[1], NOW)
+            .build();
+
+        let mut observations = observe_all(&manifest, NOW);
+        for created in [NOW - 7 * SECS_PER_DAY, NOW - 60] {
+            observations.push(PackObservation {
+                key: pack_cache_key(&pack_hash(9)),
+                pack: Some(pack_hash(9)),
+                created,
+                last_accessed: NOW,
+            });
+        }
+
+        let plan = plan(&manifest, &observations, NOW, &policy());
+        assert!(
+            plan.orphan_keys.is_empty(),
+            "a key with a fresh duplicate on another ref must not be deleted: {:?}",
+            plan.orphan_keys
+        );
+    }
+
+    #[test]
+    fn touch_judges_staleness_by_the_stalest_duplicate_entry() {
+        // Each ref-scoped entry has its own LRU clock and is evicted
+        // independently. A fresh feature-branch copy must not mask a 6-day
+        // idle default-branch copy of the same key.
+        let old = NOW - 30 * SECS_PER_DAY;
+        let manifest = ManifestBuilder::new()
+            .pack(1, TIER_VOLATILE, old)
+            .chunk(1, 1, 100, 0)
+            .path(1, &[1], &[], old, NOW)
+            .root("main", &[1], NOW)
+            .build();
+
+        // Stale copy listed first, fresh copy second (last-wins collapse
+        // would judge against the fresh clock).
+        let mut observations = observe_all(&manifest, NOW - 6 * SECS_PER_DAY);
+        observations.push(PackObservation {
+            key: pack_cache_key(&pack_hash(1)),
+            pack: Some(pack_hash(1)),
+            created: old,
+            last_accessed: NOW,
+        });
+
+        let plan = plan(&manifest, &observations, NOW, &policy());
+        assert_eq!(
+            plan.touch_packs,
+            vec![pack_hash(1)],
+            "the stalest per-ref copy decides whether a touch is needed"
         );
     }
 

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -568,7 +568,15 @@ pub fn apply(
         }
     }
     for (pack, info) in &repacks.packs {
-        manifest.packs.entry(*pack).or_insert_with(|| info.clone());
+        // A repack output can reproduce an existing pack byte-identically
+        // (same content-addressed hash). Merge higher-tier-wins (like
+        // PackInfo::merge) so a stable-tier promotion is never lost —
+        // otherwise consolidation would re-plan the pack forever.
+        manifest
+            .packs
+            .entry(*pack)
+            .and_modify(|existing| existing.tier = existing.tier.max(info.tier))
+            .or_insert_with(|| info.clone());
     }
 
     // Prune: chunks no surviving path references, then packs no surviving
@@ -1745,6 +1753,54 @@ mod tests {
             );
         }
         output
+    }
+
+    #[test]
+    fn apply_merges_repack_output_with_higher_tier_wins() {
+        // A repack output reproducing an existing pack byte-identically
+        // carries the same pack hash. Its tier promotion must not be
+        // dropped, or the pack stays volatile and consolidation re-plans
+        // it on every run.
+        let old = NOW - 30 * SECS_PER_DAY;
+        let manifest = ManifestBuilder::new()
+            .pack(1, TIER_VOLATILE, old)
+            .chunk(1, 1, 100, 1)
+            .path(1, &[1], &[], old, NOW)
+            .root("main", &[1], NOW)
+            .build();
+
+        let gc_plan = GcPlan {
+            now: NOW,
+            ..GcPlan::default()
+        };
+        let location = manifest.chunks[&chunk_hash(1)].clone();
+        let repacks = RepackOutput {
+            packs: BTreeMap::from([(
+                pack_hash(1),
+                PackInfo {
+                    size: 100,
+                    created: NOW,
+                    tier: TIER_STABLE,
+                },
+            )]),
+            locations: BTreeMap::from([(
+                chunk_hash(1),
+                ChunkLocation {
+                    repacks_survived: location.repacks_survived + 1,
+                    ..location
+                },
+            )]),
+            replaced: BTreeSet::from([pack_hash(1)]),
+            ..RepackOutput::default()
+        };
+
+        let (committed, deletable) = apply(manifest, &gc_plan, &repacks);
+        assert_eq!(
+            committed.packs[&pack_hash(1)].tier,
+            TIER_STABLE,
+            "a same-hash repack output must promote the existing pack's tier"
+        );
+        assert!(deletable.is_empty());
     }
 
     #[test]

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -479,7 +479,11 @@ pub fn plan(
             !pack_stats.live.is_empty()
                 && !repack_sources.contains(*pack)
                 && observed.get(*pack).is_some_and(|observation| {
-                    now.saturating_sub(observation.last_accessed) > policy.touch_age
+                    // `last_accessed == 0` means the REST timestamp did not
+                    // parse: the idle time is unknown, so do not force a
+                    // touch (mirrors the `created == 0` orphan guard).
+                    observation.last_accessed != 0
+                        && now.saturating_sub(observation.last_accessed) > policy.touch_age
                 })
         })
         .map(|(pack, pack_stats)| (pack_stats.tier, pack_stats.live_bytes, *pack))
@@ -878,11 +882,27 @@ impl GcContext {
         for pack in &plan.touch_packs {
             // A missing pack was evicted since planning; the next run
             // reconciles it.
-            if let Some(url) = self.pack_url(pack).await? {
-                // Downloads through the Twirp/Azure path bump
-                // last_accessed_at (verified against the real service).
-                blob::get(&self.http, &url, Some(0..1)).await?;
-                touched += 1;
+            let Some(url) = self.pack_url(pack).await? else {
+                continue;
+            };
+            let pack = *pack;
+            let refresh = async move || match self
+                .twirp
+                .get_download_url(&pack_cache_key(&pack), &[])
+                .await?
+            {
+                DownloadUrl::Hit { url, .. } => Ok(url),
+                DownloadUrl::Miss => Err(GhaError::InvalidResponse(format!(
+                    "pack {pack} disappeared while touching"
+                ))),
+            };
+            // Downloads through the Twirp/Azure path bump last_accessed_at
+            // (verified against the real service). A touch is a pure LRU
+            // optimization that self-heals next run; a failure must not
+            // abort the run and strand the commit and deletes behind it.
+            match blob::get_with_refresh(&self.http, &url, Some(0..1), refresh).await {
+                Ok(_) => touched += 1,
+                Err(err) => eprintln!("hestia gc: touch of pack {pack} failed ({err}); skipping"),
             }
         }
         Ok(touched)
@@ -1591,6 +1611,27 @@ mod tests {
         assert!(
             plan.touch_packs.contains(&pack_hash(1)),
             "the pack skipped by the CAS guard must be touched instead: {:?}",
+            plan.touch_packs
+        );
+    }
+
+    #[test]
+    fn packs_with_unparsable_lru_clock_are_not_force_touched() {
+        // `last_accessed == 0` means the REST timestamp did not parse.
+        // Treating the unknown idle time as "idle since 1970" would
+        // force-touch every referenced pack on every run.
+        let old = NOW - 30 * SECS_PER_DAY;
+        let manifest = ManifestBuilder::new()
+            .pack(1, TIER_VOLATILE, old)
+            .chunk(1, 1, 100, 0)
+            .path(1, &[1], &[], old, NOW)
+            .root("main", &[1], NOW)
+            .build();
+
+        let plan = plan(&manifest, &observe_all(&manifest, 0), NOW, &policy());
+        assert!(
+            plan.touch_packs.is_empty(),
+            "a pack of unknown idle time must not be force-touched: {:?}",
             plan.touch_packs
         );
     }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -161,8 +161,11 @@ pub struct RepackJob {
 
 impl RepackJob {
     /// Compressed bytes that must be Range-read from source packs. Frames
-    /// are copied without recompression, so this is also the size of the
-    /// output pack.
+    /// are copied without recompression, so this is also the total size of
+    /// the output packs (the job seals and uploads a pack each time it
+    /// reaches [`GcPolicy::pack_target_size`]). The actual output can be
+    /// smaller when a source pack disappeared mid-run and its chunks were
+    /// skipped.
     pub fn download_bytes(&self) -> u64 {
         self.copies
             .iter()

--- a/src/gha/blob.rs
+++ b/src/gha/blob.rs
@@ -46,7 +46,9 @@ fn url_expired(status: u16) -> bool {
 /// fresh signed URL instead.
 pub fn is_transient(error: &Error) -> bool {
     match error {
-        Error::Http(err) => !err.is_builder(),
+        // Builder and redirect-policy failures are deterministic: retrying
+        // them only burns the whole backoff budget on the same outcome.
+        Error::Http(err) => !err.is_builder() && !err.is_redirect(),
         Error::Status { status, .. } => *status >= 500,
         _ => false,
     }

--- a/src/gha/mod.rs
+++ b/src/gha/mod.rs
@@ -29,8 +29,8 @@ pub enum Error {
 
     #[error(
         "GitHub Actions rejected the runtime token during {method} (HTTP 401): the token has \
-         expired (runtime tokens are only valid for ~6 hours) or is invalid; nothing was \
-         committed; re-run the job to get a fresh token"
+         expired (runtime tokens are only valid for ~6 hours) or is invalid; re-run the job \
+         to get a fresh token"
     )]
     TokenExpired { method: String },
 

--- a/src/gha/rest.rs
+++ b/src/gha/rest.rs
@@ -367,13 +367,14 @@ impl RestClient {
             }
             let list: CacheList = self.send(&url, request, false).await?;
             // Termination must not depend on `total_count` ever becoming
-            // consistent with the returned pages: an empty page means there
-            // is nothing more to fetch, whatever the server claims.
-            if list.actions_caches.is_empty() {
-                return Ok(entries);
-            }
+            // consistent with the returned pages: the counter can be stale
+            // or shrunk by concurrent deletions while later pages still
+            // hold entries. A short page (fewer than requested) is the only
+            // trustworthy end marker: it means nothing exists past this
+            // offset right now, whatever the server claims.
+            let received = list.actions_caches.len();
             entries.extend(list.actions_caches);
-            if entries.len() as u64 >= list.total_count {
+            if received < PER_PAGE as usize {
                 return Ok(entries);
             }
             page += 1;

--- a/src/gha/rest.rs
+++ b/src/gha/rest.rs
@@ -144,6 +144,12 @@ pub fn format_timestamp(seconds: u64) -> String {
 #[derive(Debug, Clone, Deserialize)]
 pub struct CacheEntry {
     pub key: String,
+    /// Cache `version` namespace the entry was created under (the value the
+    /// Twirp client sent with CreateCacheEntry). Lets GC distinguish its own
+    /// entries from same-key entries of other namespaces (salted runs,
+    /// foreign workflows): the listing itself is version-blind.
+    #[serde(default)]
+    pub version: String,
     #[serde(default)]
     pub last_accessed_at: String,
     #[serde(default)]

--- a/src/gha/rest.rs
+++ b/src/gha/rest.rs
@@ -65,6 +65,18 @@ fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
     era * 146_097 + day_of_era as i64 - 719_468
 }
 
+/// Days in `month` of `year` (proleptic Gregorian).
+fn days_in_month(year: i64, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        _ => {
+            let leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+            if leap { 29 } else { 28 }
+        }
+    }
+}
+
 /// Inverse of [`days_from_civil`].
 fn civil_from_days(days: i64) -> (i64, u32, u32) {
     let days = days + 719_468;
@@ -99,19 +111,37 @@ pub fn parse_timestamp(s: &str) -> Option<u64> {
     {
         return None;
     }
+    // Integer FromStr alone is too lenient (it accepts a leading '+'), so
+    // every field byte must be an ASCII digit.
+    const DIGIT_POSITIONS: [usize; 14] = [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18];
+    if DIGIT_POSITIONS.iter().any(|&i| !bytes[i].is_ascii_digit()) {
+        return None;
+    }
     let year: i64 = s.get(0..4)?.parse().ok()?;
     let month: u32 = s.get(5..7)?.parse().ok()?;
     let day: u32 = s.get(8..10)?.parse().ok()?;
     let hour: u64 = s.get(11..13)?.parse().ok()?;
     let minute: u64 = s.get(14..16)?.parse().ok()?;
     let second: u64 = s.get(17..19)?.parse().ok()?;
-    if !(1..=12).contains(&month) || !(1..=31).contains(&day) || hour > 23 || minute > 59 {
+    // second == 60 is allowed for leap seconds and clamped below;
+    // days_from_civil is pure arithmetic, so an impossible date like
+    // Feb 31 would silently roll into March instead of being rejected.
+    if !(1..=12).contains(&month)
+        || !(1..=days_in_month(year, month)).contains(&day)
+        || hour > 23
+        || minute > 59
+        || second > 60
+    {
         return None;
     }
     // Optional fractional seconds, then a UTC marker.
     let mut rest = &s[19..];
     if let Some(stripped) = rest.strip_prefix('.') {
         rest = stripped.trim_start_matches(|c: char| c.is_ascii_digit());
+        if rest.len() == stripped.len() {
+            // RFC 3339 requires at least one fractional digit.
+            return None;
+        }
     }
     if rest != "Z" && rest != "z" && rest != "+00:00" {
         return None;
@@ -393,6 +423,22 @@ mod tests {
         assert_eq!(parse_timestamp("not a timestamp"), None);
         assert_eq!(parse_timestamp("2019-13-24T22:45:36Z"), None);
         assert_eq!(parse_timestamp("2019-01-24T22:45:36+02:00"), None);
+        // Impossible calendar dates must not silently roll over.
+        assert_eq!(parse_timestamp("2026-02-31T00:00:00Z"), None);
+        assert_eq!(parse_timestamp("2023-02-29T00:00:00Z"), None);
+        assert_eq!(parse_timestamp("2019-04-31T00:00:00Z"), None);
+        // Seconds beyond the leap-second value must not silently clamp.
+        assert_eq!(parse_timestamp("2019-01-24T22:45:99Z"), None);
+        // Leap seconds themselves still clamp to :59.
+        assert_eq!(
+            parse_timestamp("2019-01-24T22:45:60Z"),
+            Some(1_548_369_936 + 23)
+        );
+        // RFC 3339 requires at least one digit after the decimal point.
+        assert_eq!(parse_timestamp("2019-01-24T22:45:36.Z"), None);
+        // Field bytes must be digits; integer FromStr would accept "+1".
+        assert_eq!(parse_timestamp("2019-+1-24T22:45:36Z"), None);
+        assert_eq!(parse_timestamp("+019-01-24T22:45:36Z"), None);
     }
 
     #[test]

--- a/src/gha/rest.rs
+++ b/src/gha/rest.rs
@@ -39,6 +39,18 @@ const RATE_LIMIT_FALLBACK_WAIT: Duration = Duration::from_secs(60);
 /// Give up after this many rate-limited responses for a single request.
 const RATE_LIMIT_MAX_ATTEMPTS: u32 = 5;
 
+/// Never sleep longer than this on a server-provided Retry-After: the
+/// header is server-controlled data and must not be able to stall a GC run
+/// indefinitely.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(300);
+
+/// Retries for transient failures (5xx, dropped connections), mirroring the
+/// data plane's policy in [`crate::gha::blob`].
+const TRANSIENT_RETRIES: u32 = 3;
+
+/// First transient-retry delay; doubles per attempt.
+const TRANSIENT_RETRY_DELAY: Duration = Duration::from_millis(500);
+
 /// Build the caches collection URL for a repository.
 fn caches_url(api_url: &str, repo: &str) -> String {
     format!(
@@ -294,7 +306,10 @@ impl RestClient {
     }
 
     /// Send a request and decode the response, waiting and retrying when
-    /// GitHub rate-limits it. `mutating` requests are additionally paced.
+    /// GitHub rate-limits it and retrying transient failures (5xx, dropped
+    /// connections) with bounded backoff. `mutating` requests are
+    /// additionally paced. Every request this client sends is idempotent
+    /// (listing pages, delete-by-key), so retrying is always safe.
     ///
     /// Rate limits answer 403 or 429; a Retry-After header or a "rate
     /// limit" message distinguishes them from a real permission error.
@@ -305,18 +320,40 @@ impl RestClient {
         mutating: bool,
     ) -> Result<T, Error> {
         let mut attempts = 0;
+        let mut transient_left = TRANSIENT_RETRIES;
+        let mut transient_delay = TRANSIENT_RETRY_DELAY;
         loop {
             if mutating {
                 self.pace_mutation().await;
             }
-            let response = request
+            let result = request
                 .try_clone()
                 .expect("cache API requests have no streaming body")
                 .send()
-                .await?;
+                .await;
+            let response = match result {
+                Ok(response) => response,
+                Err(err) => {
+                    let error = Error::Http(err);
+                    if crate::gha::blob::is_transient(&error) && transient_left > 0 {
+                        transient_left -= 1;
+                        tokio::time::sleep(transient_delay).await;
+                        transient_delay *= 2;
+                        continue;
+                    }
+                    return Err(error);
+                }
+            };
             let status = response.status();
             if status.is_success() {
                 return Ok(response.json().await?);
+            }
+
+            if status.is_server_error() && transient_left > 0 {
+                transient_left -= 1;
+                tokio::time::sleep(transient_delay).await;
+                transient_delay *= 2;
+                continue;
             }
 
             let retry_after = response
@@ -338,7 +375,11 @@ impl RestClient {
                     body,
                 });
             }
-            tokio::time::sleep(retry_after.unwrap_or(self.rate_limit_fallback_wait)).await;
+            let wait = retry_after
+                .unwrap_or(self.rate_limit_fallback_wait)
+                .min(MAX_RETRY_AFTER);
+            eprintln!("GitHub rate limit on {url}: waiting {wait:?} before retrying");
+            tokio::time::sleep(wait).await;
         }
     }
 

--- a/src/gha/savemutable.rs
+++ b/src/gha/savemutable.rs
@@ -134,11 +134,19 @@ impl<'a> SaveMutable<'a> {
         let index = parse_index(&self.prefix, &matched_key)?;
 
         // The signed URL was just issued, but refresh anyway if it raced
-        // with an expiry.
+        // with an expiry. The refresh re-runs the prefix lookup, which may
+        // resolve to a *newer* version (a concurrent writer finalized in
+        // between), so the refreshed key must replace the original one:
+        // key, index and data must always describe the same version.
         let twirp = self.twirp;
+        let refreshed_key = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+        let refreshed_in = std::sync::Arc::clone(&refreshed_key);
         let data = blob::get_with_refresh(self.http, &url, None, async move || {
             match twirp.get_download_url(&prefix, &[prefix.as_str()]).await? {
-                DownloadUrl::Hit { url, .. } => Ok(url),
+                DownloadUrl::Hit { url, matched_key } => {
+                    *refreshed_in.lock().expect("not poisoned") = Some(matched_key);
+                    Ok(url)
+                }
                 DownloadUrl::Miss => Err(Error::InvalidResponse(format!(
                     "entry {prefix:?} disappeared while downloading"
                 ))),
@@ -146,11 +154,15 @@ impl<'a> SaveMutable<'a> {
         })
         .await?;
 
-        Ok(Some(MutableEntry {
-            key: matched_key,
-            index,
-            data,
-        }))
+        let (key, index) = match refreshed_key.lock().expect("not poisoned").take() {
+            Some(key) => {
+                let index = parse_index(&self.prefix, &key)?;
+                (key, index)
+            }
+            None => (matched_key, index),
+        };
+
+        Ok(Some(MutableEntry { key, index, data }))
     }
 
     /// Save a new version produced by `merge`.

--- a/src/gha/savemutable.rs
+++ b/src/gha/savemutable.rs
@@ -18,9 +18,15 @@
 //! assumes a crashed peer and skips over that index.
 //!
 //! Consistency model (verified against the real service): **reservations
-//! are strongly consistent** (two writers can never both reserve the same
-//! key) but **lookups are eventually consistent** (a
-//! just-finalized entry may not be returned by load() for a while). The
+//! are strongly consistent within a ref scope** (two writers in the same
+//! scope can never both reserve the same key) but **lookups are eventually
+//! consistent** (a
+//! just-finalized entry may not be returned by load() for a while).
+//! Cache entry uniqueness is per (key, version, ref scope): writers in
+//! different scopes (a PR job and a default-branch job) can both reserve
+//! and finalize the same key. Their lineages fork; the PR-scoped fork is
+//! discarded with its branch (see "PR scope isolation" in the README), so
+//! the no-lost-writes merge guarantee below is scope-local. The
 //! conflict-retry loop therefore re-loads until it sees the version that
 //! blocked it; the stale-skip window must be comfortably larger than the
 //! observed propagation lag, otherwise lag would be misdiagnosed as a

--- a/src/gha/savemutable.rs
+++ b/src/gha/savemutable.rs
@@ -83,7 +83,7 @@ pub struct SaveMutable<'a> {
     retry_delay: Duration,
     /// Give up after this many conflicting save attempts.
     max_attempts: u32,
-    /// Skip over an index after this many consecutive conflicts on it
+    /// Skip over an index after this many conflicts on it
     /// (crashed-writer recovery).
     stale_skip_after: u32,
 }
@@ -180,8 +180,11 @@ impl<'a> SaveMutable<'a> {
         let mut attempts: u32 = 0;
         // Indexes at or below this are blocked by (presumably crashed) writers.
         let mut skip_through: u64 = floor;
-        let mut last_conflict: Option<u64> = None;
-        let mut conflict_streak: u32 = 0;
+        // Conflicts are counted per index, not as a single consecutive
+        // streak: eventually consistent loads can oscillate between two
+        // versions (non-monotonic reads), and a streak that resets on every
+        // index change would never reach the stale-skip threshold.
+        let mut conflicts: std::collections::BTreeMap<u64, u32> = std::collections::BTreeMap::new();
 
         loop {
             let current = self.load().await?;
@@ -200,22 +203,19 @@ impl<'a> SaveMutable<'a> {
                 }
                 Reservation::AlreadyExists => {
                     attempts += 1;
-                    if attempts >= self.max_attempts {
-                        return Err(Error::Conflict { key, attempts });
-                    }
-                    if last_conflict == Some(index) {
-                        conflict_streak += 1;
-                    } else {
-                        last_conflict = Some(index);
-                        conflict_streak = 1;
-                    }
-                    if conflict_streak >= self.stale_skip_after {
+                    let streak = conflicts.entry(index).or_insert(0);
+                    *streak += 1;
+                    if *streak >= self.stale_skip_after {
                         // Nobody finalized this index after several waits:
                         // assume the writer holding the reservation crashed
                         // and skip over it.
                         skip_through = index;
-                        last_conflict = None;
-                        conflict_streak = 0;
+                        conflicts.remove(&index);
+                    } else if attempts >= self.max_attempts {
+                        // Checked only when no skip fired: an attempt that
+                        // skips a dead index is progress, not grounds for
+                        // giving up, however many conflicts preceded it.
+                        return Err(Error::Conflict { key, attempts });
                     }
                     tokio::time::sleep(self.retry_delay).await;
                 }

--- a/src/gha/twirp.rs
+++ b/src/gha/twirp.rs
@@ -234,9 +234,19 @@ impl TwirpClient {
             .call::<_, CreateCacheEntryResponse>("CreateCacheEntry", &request)
             .await
         {
-            Ok(response) if response.ok => Ok(Reservation::Created {
-                upload_url: response.signed_upload_url,
-            }),
+            // ok=true with no upload URL is a protocol violation; forwarding
+            // the empty URL would only fail later as an opaque builder error.
+            Ok(response) if response.ok => {
+                if response.signed_upload_url.is_empty() {
+                    return Err(Error::InvalidResponse(format!(
+                        "CreateCacheEntry for {key} returned ok=true with an empty \
+                         signed_upload_url"
+                    )));
+                }
+                Ok(Reservation::Created {
+                    upload_url: response.signed_upload_url,
+                })
+            }
             // Some backends signal "exists" with ok=false instead of a Twirp
             // error; treat both the same.
             Ok(_) => Ok(Reservation::AlreadyExists),
@@ -316,10 +326,20 @@ impl TwirpClient {
             .call::<_, GetCacheEntryDownloadUrlResponse>("GetCacheEntryDownloadURL", &request)
             .await
         {
-            Ok(response) if response.ok => Ok(DownloadUrl::Hit {
-                url: response.signed_download_url,
-                matched_key: response.matched_key,
-            }),
+            // ok=true with empty fields is a protocol violation; forwarding
+            // it would surface later as a misleading key-parse or URL error.
+            Ok(response) if response.ok => {
+                if response.signed_download_url.is_empty() || response.matched_key.is_empty() {
+                    return Err(Error::InvalidResponse(format!(
+                        "GetCacheEntryDownloadURL for {key} returned ok=true with an empty \
+                         signed_download_url or matched_key"
+                    )));
+                }
+                Ok(DownloadUrl::Hit {
+                    url: response.signed_download_url,
+                    matched_key: response.matched_key,
+                })
+            }
             Ok(_) => Ok(DownloadUrl::Miss),
             // not_found is a miss, not an error.
             Err(Error::Twirp { code, .. }) if code == "not_found" => Ok(DownloadUrl::Miss),

--- a/src/gha/twirp.rs
+++ b/src/gha/twirp.rs
@@ -41,7 +41,7 @@ pub const ENV_RUNTIME_TOKEN: &str = "ACTIONS_RUNTIME_TOKEN";
 /// workflow sets this to the run id.
 pub const ENV_VERSION_SALT: &str = "HESTIA_CACHE_VERSION_SALT";
 
-/// [`CACHE_VERSION`] when `salt` is empty, sha256("hestia-1:<salt>")
+/// [`CACHE_VERSION`] when `salt` is empty, sha256("hestia-2:<salt>")
 /// otherwise.
 fn cache_version(salt: &str) -> String {
     use sha2::{Digest, Sha256};

--- a/src/gha/twirp.rs
+++ b/src/gha/twirp.rs
@@ -44,12 +44,10 @@ pub const ENV_VERSION_SALT: &str = "HESTIA_CACHE_VERSION_SALT";
 /// [`CACHE_VERSION`] when `salt` is empty, sha256("hestia-2:<salt>")
 /// otherwise.
 fn cache_version(salt: &str) -> String {
-    use sha2::{Digest, Sha256};
     if salt.is_empty() {
         return CACHE_VERSION.to_string();
     }
-    let digest = Sha256::digest(format!("hestia-2:{salt}"));
-    digest.iter().map(|b| format!("{b:02x}")).collect()
+    crate::manifest::Hash32::digest(format!("hestia-2:{salt}")).to_hex()
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -336,9 +334,7 @@ mod tests {
 
     #[test]
     fn cache_version_is_sha256_of_hestia_2() {
-        use sha2::{Digest, Sha256};
-        let digest = Sha256::digest(b"hestia-2");
-        let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+        let hex = crate::manifest::Hash32::digest(b"hestia-2").to_hex();
         assert_eq!(CACHE_VERSION, hex);
     }
 

--- a/src/gha/twirp.rs
+++ b/src/gha/twirp.rs
@@ -170,6 +170,11 @@ impl TwirpClient {
         Ok(Self::new(http, url, token).with_version_salt(&salt))
     }
 
+    /// The cache `version` namespace this client writes and reads.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
     /// Switch to the cache namespace derived from `salt` (no-op for an
     /// empty salt). See [`ENV_VERSION_SALT`].
     pub fn with_version_salt(mut self, salt: &str) -> Self {

--- a/src/gha/twirp.rs
+++ b/src/gha/twirp.rs
@@ -275,9 +275,11 @@ impl TwirpClient {
 
     /// PUT `data` to a reserved entry's upload URL, then finalize it.
     ///
-    /// If the SAS URL expires mid-upload, the key is re-reserved once for
-    /// a fresh URL. An `AlreadyExists` answer means no fresh URL is coming
-    /// and the upload fails.
+    /// If the SAS URL expires mid-upload, the upload fails: the v2 API has
+    /// no RPC to re-derive an upload URL for an already-reserved key (the
+    /// caller by construction holds the reservation, so re-reserving always
+    /// answers `AlreadyExists`), and the key is left reserved-but-
+    /// unfinalized. Transient failures are still retried by the blob layer.
     pub async fn upload_and_finalize(
         &self,
         http: &reqwest::Client,
@@ -287,12 +289,9 @@ impl TwirpClient {
     ) -> Result<(), Error> {
         let size = data.len() as u64;
         blob::put_with_refresh(http, &upload_url, data, async move || {
-            match self.create_cache_entry(key).await? {
-                Reservation::Created { upload_url } => Ok(upload_url),
-                Reservation::AlreadyExists => Err(Error::InvalidResponse(format!(
-                    "upload URL for {key:?} expired and cannot be refreshed"
-                ))),
-            }
+            Err(Error::InvalidResponse(format!(
+                "upload URL for {key:?} expired and cannot be refreshed"
+            )))
         })
         .await?;
         self.finalize_upload(key, size).await?;

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -5,9 +5,12 @@
 //! over the unix socket and exits.
 //!
 //! **This command must always exit 0.** A failing post-build-hook fails
-//! the nix build that triggered it. Losing a path registration is harmless
-//! (the path gets rebuilt and re-registered on a future run); failing a
-//! build over it is not. All errors go to stderr only.
+//! the nix build that triggered it. On ephemeral runners losing a path
+//! registration is harmless (the path gets rebuilt and re-registered on a
+//! future run); on persistent runners a leaf path may stay uncached until
+//! the local store is GC'd, because Nix never rebuilds a still-valid path
+//! and so never fires the hook for it again. Failing a build over it is
+//! worse either way. All errors go to stderr only.
 
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -67,9 +67,11 @@ pub async fn run(args: &HookArgs) -> ExitCode {
         Ok(Ok(buffered)) => {
             eprintln!("hestia hook: registered {count} path(s), {buffered} buffered for upload");
         }
+        // Most error variants occur after the daemon was reached, so do
+        // not claim it was unreachable.
         Ok(Err(err)) => {
             eprintln!(
-                "hestia hook: failed to reach daemon at {}: {err} \
+                "hestia hook: daemon at {} did not accept the paths: {err} \
                  (build continues; paths will be re-pushed on a future run)",
                 args.socket.display()
             );

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-// Re-exports so integration tests and later phases can build trees without
+// Re-exports so integration tests and other modules can build trees without
 // depending on harmonia crates directly.
 pub use harmonia_file_core::{Directory, FileSystemObject, FileTree, Regular, Symlink};
 pub use harmonia_store_path::{StorePath, StorePathHash};

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -17,7 +17,7 @@ pub use harmonia_store_path::{StorePath, StorePathHash};
 
 /// Window inside which two root updates are considered concurrent and get
 /// unioned instead of newest-wins (10 minutes).
-const ROOT_UNION_WINDOW_SECS: u64 = 600;
+pub(crate) const ROOT_UNION_WINDOW_SECS: u64 = 600;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -575,6 +575,16 @@ fn visit_contents<C>(tree: &FileTree<C>, visit: &mut impl FnMut(&C)) {
 /// incompressible hash bytes, so higher levels gain little.
 const ZSTD_LEVEL: i32 = 9;
 
+/// Decompression bound for stored manifest blobs.
+///
+/// The GHA cache is not trusted storage: without a bound, a small zstd
+/// bomb stored as the next manifest version would abort every serve,
+/// drain, and GC inside the allocator -- before the corrupt-manifest
+/// fallback (`decode_manifest_or_empty`) can trigger. Production manifest
+/// CBOR is single-digit megabytes, so 64 MiB is ample headroom while an
+/// over-long stream surfaces as a normal decode error.
+const MAX_MANIFEST_CBOR_BYTES: u64 = 64 * 1024 * 1024;
+
 impl Manifest {
     pub fn new() -> Self {
         Self::default()
@@ -589,7 +599,19 @@ impl Manifest {
 
     /// Deserialize from zstd-compressed columnar CBOR.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        let cbor = zstd::decode_all(data)?;
+        use std::io::Read as _;
+        let mut cbor = Vec::new();
+        // Read one byte past the bound: enough to detect an oversized
+        // stream without buffering its full payload.
+        zstd::Decoder::with_buffer(data)?
+            .take(MAX_MANIFEST_CBOR_BYTES + 1)
+            .read_to_end(&mut cbor)?;
+        if cbor.len() as u64 > MAX_MANIFEST_CBOR_BYTES {
+            return Err(Error::InvalidEncoding(format!(
+                "manifest decompresses past the {MAX_MANIFEST_CBOR_BYTES}-byte bound \
+                 (corrupt or malicious data)"
+            )));
+        }
         Self::from_wire(ciborium::from_reader(cbor.as_slice())?)
     }
 
@@ -723,8 +745,15 @@ impl Manifest {
         let mut previous_offset: BTreeMap<u64, u64> = BTreeMap::new();
         for row in 0..rows {
             let pack = wire.location_packs[row];
-            let offset =
-                previous_offset.get(&pack).copied().unwrap_or(0) + wire.location_offsets[row];
+            // Checked: deltas come straight from untrusted CBOR, and an
+            // overflowing accumulation must be a decode error, not a
+            // debug-build panic or a silently wrapped offset.
+            let offset = previous_offset
+                .get(&pack)
+                .copied()
+                .unwrap_or(0)
+                .checked_add(wire.location_offsets[row])
+                .ok_or_else(|| invalid(format!("chunk offset overflow in row {row}")))?;
             previous_offset.insert(pack, offset);
             chunks.insert(
                 chunk_at(wire.location_chunks[row])?,
@@ -1011,6 +1040,45 @@ mod tests {
         let compressed = zstd::encode_all(patched.as_slice(), 3).unwrap();
 
         let result = Manifest::decode(&compressed);
+        assert!(
+            matches!(result, Err(Error::InvalidEncoding(_))),
+            "expected InvalidEncoding, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn overflowing_wire_offsets_are_an_error_not_a_panic() {
+        // Delta-encoded offsets come from untrusted CBOR: two rows for the
+        // same pack whose deltas sum past u64::MAX must surface as
+        // InvalidEncoding instead of panicking (debug) or wrapping
+        // (release).
+        let wire = WireManifest {
+            chunk_hashes: Blob([1u8; 2 * ChunkHash::LEN].to_vec()),
+            pack_hashes: Blob([2u8; PackHash::LEN].to_vec()),
+            location_chunks: vec![0, 1],
+            location_packs: vec![0, 0],
+            location_offsets: vec![u64::MAX, 1],
+            location_compressed_sizes: vec![1, 1],
+            location_uncompressed_sizes: vec![1, 1],
+            location_repacks_survived: vec![0, 0],
+            ..WireManifest::default()
+        };
+        let result = Manifest::from_wire(wire);
+        assert!(
+            matches!(result, Err(Error::InvalidEncoding(_))),
+            "expected InvalidEncoding, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn manifest_zstd_bomb_is_an_error_not_an_allocation() {
+        // A small zstd stream of zeros decompressing far past any real
+        // manifest must be rejected at the size bound, before the full
+        // payload is buffered.
+        let bomb_payload = vec![0u8; 128 * 1024 * 1024];
+        let bomb = zstd::encode_all(bomb_payload.as_slice(), 3).unwrap();
+        assert!(bomb.len() < 1024 * 1024, "bomb must be small on the wire");
+        let result = Manifest::decode(&bomb);
         assert!(
             matches!(result, Err(Error::InvalidEncoding(_))),
             "expected InvalidEncoding, got {result:?}"

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -301,6 +301,12 @@ impl PathEntry {
 
     /// Merge two entries describing the same store path.
     fn merge(a: Self, b: Self) -> Self {
+        // Identical entries are the common case (drain commits merge
+        // near-identical manifests on every retry); skip the tie-break
+        // below, which clones and CBOR-serializes both entries.
+        if a == b {
+            return a;
+        }
         // Deterministic winner: newer push wins, nar_hash as tie-break, the
         // CBOR encoding of the remaining content as the final tie-break.
         //
@@ -311,8 +317,9 @@ impl PathEntry {
         // concurrent jobs push within the same second routinely). Without a
         // total order the merge would not be commutative, and the surviving
         // entry would depend on which concurrent writer wins the
-        // SaveMutable race.
-        fn order_key(entry: &PathEntry) -> (u64, NarHash, Vec<u8>) {
+        // SaveMutable race. The expensive encoding is computed only on a
+        // (last_pushed, nar_hash) tie.
+        fn content_key(entry: &PathEntry) -> Vec<u8> {
             // The clocks are folded with max() below; exclude them from the
             // content tie-break so that folding never changes an entry's
             // ordering (this keeps the merge associative as well).
@@ -324,13 +331,15 @@ impl PathEntry {
             // the same code path Manifest::encode uses); a failure would
             // only weaken the tie-break, never panic.
             let _ = ciborium::into_writer(&content, &mut encoded);
-            (entry.last_pushed, entry.nar_hash, encoded)
+            encoded
         }
-        let (mut winner, loser) = if order_key(&a) >= order_key(&b) {
-            (a, b)
-        } else {
-            (b, a)
+        let quick_key = |entry: &PathEntry| (entry.last_pushed, entry.nar_hash);
+        let a_wins = match quick_key(&a).cmp(&quick_key(&b)) {
+            std::cmp::Ordering::Greater => true,
+            std::cmp::Ordering::Less => false,
+            std::cmp::Ordering::Equal => content_key(&a) >= content_key(&b),
         };
+        let (mut winner, loser) = if a_wins { (a, b) } else { (b, a) };
         // Clocks advance monotonically across both histories.
         winner.last_reachable = winner.last_reachable.max(loser.last_reachable);
         winner.last_pushed = winner.last_pushed.max(loser.last_pushed);

--- a/src/pathinfo.rs
+++ b/src/pathinfo.rs
@@ -57,17 +57,6 @@ impl PathInfo {
     pub fn path_hash(&self) -> PathHash {
         PathHash::from_store_path(&self.store_path)
     }
-
-    /// All referenced store paths, excluding the self-reference (the
-    /// manifest reachability walk treats self-edges as no-ops anyway, but
-    /// dropping them keeps entries smaller).
-    pub fn references_without_self(&self) -> Vec<StorePath> {
-        self.references
-            .iter()
-            .filter(|reference| **reference != self.store_path)
-            .cloned()
-            .collect()
-    }
 }
 
 /// Result of looking up one path string.

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -456,6 +456,32 @@ impl PipelineContext {
             },
         );
 
+        // Skip commits that would only refresh the root's `updated` clock:
+        // the access log is never cleared and the SIGTERM final drain runs
+        // unconditionally, so otherwise every job that substituted a path
+        // burns a redundant manifest version at teardown. Only skip while
+        // the committed clock is recent: it drives root-TTL liveness in GC
+        // and must still be refreshed on long-lived daemons.
+        let refresh_only = {
+            let mut probe = current.clone().merge(delta.clone());
+            match (
+                probe.roots.get_mut(&self.root_key),
+                current.roots.get(&self.root_key),
+            ) {
+                (Some(probed), Some(committed))
+                    if now.saturating_sub(committed.updated)
+                        <= crate::manifest::ROOT_UNION_WINDOW_SECS =>
+                {
+                    probed.updated = committed.updated;
+                    probe == current
+                }
+                _ => false,
+            }
+        };
+        if refresh_only {
+            return Ok(stats);
+        }
+
         // The merge closure keeps the manifest it encoded so the committed
         // version can be published without re-loading it from the cache.
         let commit_started = std::time::Instant::now();

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -94,7 +94,18 @@ pub fn current_system() -> String {
         "macos" => "darwin",
         os => os,
     };
-    format!("{}-{os}", std::env::consts::ARCH)
+    // Rust arch names diverge from Nix system spellings on some platforms;
+    // the value defaults the manifest root key, so an unmapped spelling
+    // fragments (or collides) GC roots against jobs passing --system with
+    // the Nix spelling.
+    let arch = match std::env::consts::ARCH {
+        "x86" => "i686",
+        // Rust reports "arm" for all 32-bit ARM; armv7l is the common
+        // case. armv6l hosts must pass --system explicitly.
+        "arm" => "armv7l",
+        arch => arch,
+    };
+    format!("{arch}-{os}")
 }
 
 /// Manifest root key for a branch + system pair, e.g. `main-x86_64-linux`.
@@ -572,11 +583,13 @@ mod tests {
 
     #[test]
     fn current_system_matches_nix_convention() {
+        // Assert the arch-os shape rather than enumerating blessed values:
+        // the function must work on any host the binary is built for.
         let system = current_system();
-        // x86_64-linux, aarch64-linux, aarch64-darwin, x86_64-darwin
         let (arch, os) = system.split_once('-').expect("system has arch-os form");
-        assert!(["x86_64", "aarch64"].contains(&arch), "arch: {arch}");
-        assert!(["linux", "darwin"].contains(&os), "os: {os}");
+        assert!(!arch.is_empty() && !os.is_empty(), "system: {system}");
+        assert!(!["x86", "arm", "macos"].contains(&arch), "arch: {arch}");
+        assert_ne!(os, "macos", "os must use the Nix spelling");
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -391,7 +391,11 @@ impl PipelineContext {
                 prepared.push(PreparedPath {
                     hash: info.path_hash(),
                     entry: PathEntry {
-                        references: info.references_without_self(),
+                        // Verbatim, including any self-reference: this list
+                        // becomes the narinfo References line, and stripping
+                        // self would diverge substituted clients' store
+                        // metadata from the builder's.
+                        references: info.references,
                         store_path: info.store_path,
                         nar_hash,
                         nar_size,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -535,12 +535,4 @@ mod tests {
         log.record(hash);
         assert_eq!(log.snapshot().len(), 1);
     }
-
-    #[test]
-    fn now_unix_is_sane() {
-        let now = now_unix();
-        // After 2024-01-01, before 2100-01-01.
-        assert!(now > 1_704_067_200, "clock too early: {now}");
-        assert!(now < 4_102_444_800, "clock too late: {now}");
-    }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -286,11 +286,11 @@ impl PipelineContext {
             }
 
             let hash = info.path_hash();
-            root_paths.insert(hash);
 
             if let Some(existing) = current.paths.get(&hash) {
                 // Already stored: bump the push clock so push-TTL-based
                 // liveness keeps protecting it.
+                root_paths.insert(hash);
                 let mut entry = existing.clone();
                 entry.last_pushed = now;
                 bumped.insert(hash, entry);
@@ -429,6 +429,10 @@ impl PipelineContext {
         };
 
         let (prepared, uploads) = tokio::try_join!(producer, consumer)?;
+        // Paths the producer rejected (failed verification or chunking)
+        // must not enter the committed root: it would pin hashes the
+        // manifest cannot serve.
+        root_paths.extend(prepared.iter().map(|path| path.hash));
         // Stage times overlap now: chunk/pack are producer busy times,
         // upload is the wall time of the whole pipelined section.
         stats.upload_ms = upload_started.elapsed().as_millis() as u64;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -318,13 +318,34 @@ impl PipelineContext {
 
             'paths: for (path, info) in to_push {
                 let chunk_started = std::time::Instant::now();
-                let chunked = chunk_path(&path).await?;
+                // Per-path chunking failures (unreadable files, NAR contents
+                // hestia cannot represent) are skipped, not propagated: a
+                // pipeline error would re-buffer the whole batch, and a
+                // deterministic failure would then keep every later drain --
+                // including the final shutdown drain -- from caching
+                // anything at all.
+                let chunked = match chunk_path(&path).await {
+                    Ok(chunked) => chunked,
+                    Err(err) => {
+                        eprintln!("hestia: NOT uploading {path}: chunking failed: {err}");
+                        stats.failed_chunking += 1;
+                        continue;
+                    }
+                };
                 let chunk_map = chunked.chunk_map();
 
                 // Integrity gate: the chunked representation must reproduce
                 // the NAR hash Nix recorded for this path. A mismatch means
                 // hestia would serve corrupt data; never upload it.
-                let (nar_hash, nar_size) = nar_hash_from_chunks(&chunked.tree, &chunk_map).await?;
+                let (nar_hash, nar_size) =
+                    match nar_hash_from_chunks(&chunked.tree, &chunk_map).await {
+                        Ok(result) => result,
+                        Err(err) => {
+                            eprintln!("hestia: NOT uploading {path}: NAR replay failed: {err}");
+                            stats.failed_chunking += 1;
+                            continue;
+                        }
+                    };
                 stats.chunk_ms += chunk_started.elapsed().as_millis() as u64;
                 if nar_hash != info.nar_hash || nar_size != info.nar_size {
                     eprintln!(

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -423,12 +423,18 @@ impl PipelineContext {
                 rx.recv().await.map(|pack| (pack, rx))
             });
             pack_stream
-                .map(|pack| async move {
+                .map(|mut pack| async move {
                     let uploaded = upload_pack(&self.twirp, &self.http, &pack).await?;
-                    Ok::<_, Error>((uploaded, pack))
+                    // Only metadata is read after upload; dropping the blob
+                    // here keeps peak memory bounded by the in-flight packs
+                    // instead of growing with the drain's total compressed
+                    // size.
+                    let size = pack.data.len() as u64;
+                    pack.data = bytes::Bytes::new();
+                    Ok::<_, Error>((uploaded, size, pack))
                 })
                 .buffer_unordered(UPLOAD_CONCURRENCY)
-                .try_collect::<Vec<(bool, chunker::Pack)>>()
+                .try_collect::<Vec<(bool, u64, chunker::Pack)>>()
                 .await
         };
 
@@ -442,24 +448,24 @@ impl PipelineContext {
         stats.upload_ms = upload_started.elapsed().as_millis() as u64;
 
         let mut delta = Manifest::new();
-        let mut packs: Vec<chunker::Pack> = Vec::new();
-        for (uploaded, pack) in uploads {
+        let mut packs: Vec<(u64, chunker::Pack)> = Vec::new();
+        for (uploaded, size, pack) in uploads {
             if uploaded {
                 stats.packs_uploaded += 1;
-                stats.bytes_uploaded += pack.data.len() as u64;
+                stats.bytes_uploaded += size;
             }
-            packs.push(pack);
+            packs.push((size, pack));
         }
-        stats.new_chunks = packs.iter().map(|pack| pack.chunks.len()).sum();
+        stats.new_chunks = packs.iter().map(|(_, pack)| pack.chunks.len()).sum();
 
-        for pack in &packs {
+        for (size, pack) in &packs {
             for (chunk_hash, location) in pack.locations() {
                 delta.chunks.insert(chunk_hash, location);
             }
             delta.packs.insert(
                 pack.hash,
                 PackInfo {
-                    size: pack.data.len() as u64,
+                    size: *size,
                     created: now,
                     tier: 0,
                 },

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -312,6 +312,12 @@ impl PipelineContext {
 
         let producer = async {
             let mut prepared: Vec<PreparedPath> = Vec::new();
+            // Stage timers accumulate as Durations and convert to ms once:
+            // per-path as_millis() truncation would drop up to ~1 ms per
+            // path, systematically underreporting drains of many small
+            // paths.
+            let mut chunk_time = std::time::Duration::ZERO;
+            let mut pack_time = std::time::Duration::ZERO;
             // Chunks of earlier prepared paths in this batch (cross-path dedup).
             let mut batch_chunks: BTreeSet<crate::manifest::ChunkHash> = BTreeSet::new();
             let mut builder = PackBuilder::new();
@@ -346,7 +352,7 @@ impl PipelineContext {
                             continue;
                         }
                     };
-                stats.chunk_ms += chunk_started.elapsed().as_millis() as u64;
+                chunk_time += chunk_started.elapsed();
                 if nar_hash != info.nar_hash || nar_size != info.nar_size {
                     eprintln!(
                         "hestia: NOT uploading {path}: chunked NAR hash {nar_hash} (size \
@@ -377,7 +383,7 @@ impl PipelineContext {
                         // Pause the pack timer across the send: a full
                         // channel blocks on upload backpressure, which must
                         // not be booked as packing time.
-                        stats.pack_ms += pack_started.elapsed().as_millis() as u64;
+                        pack_time += pack_started.elapsed();
                         if pack_tx.send(pack).await.is_err() {
                             // Uploader gone: it failed, and try_join below
                             // reports its error; stop producing.
@@ -386,7 +392,7 @@ impl PipelineContext {
                         pack_started = std::time::Instant::now();
                     }
                 }
-                stats.pack_ms += pack_started.elapsed().as_millis() as u64;
+                pack_time += pack_started.elapsed();
 
                 prepared.push(PreparedPath {
                     hash: info.path_hash(),
@@ -414,6 +420,8 @@ impl PipelineContext {
             }
             // pack_tx drops here, ending the consumer's stream.
             drop(pack_tx);
+            stats.chunk_ms = chunk_time.as_millis() as u64;
+            stats.pack_ms = pack_time.as_millis() as u64;
             Ok::<_, Error>(prepared)
         };
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -8,7 +8,14 @@
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
+
+/// Responses are a single small JSON object (at most a [`DrainStats`]), so
+/// cap the line read: the default socket lives under world-writable /tmp,
+/// and a hostile or buggy listener squatting there must not be able to make
+/// the client buffer an unbounded line in memory (mirrors the daemon-side
+/// MAX_REQUEST_BYTES cap in serve.rs).
+const MAX_RESPONSE_BYTES: u64 = 1024 * 1024;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -171,7 +178,10 @@ pub async fn roundtrip(socket: &Path, request: &Request) -> Result<Response, Err
     stream.get_mut().flush().await?;
 
     let mut response_line = String::new();
-    let read = stream.read_line(&mut response_line).await?;
+    let read = (&mut stream)
+        .take(MAX_RESPONSE_BYTES)
+        .read_line(&mut response_line)
+        .await?;
     if read == 0 {
         return Err(Error::ConnectionClosed);
     }
@@ -270,6 +280,33 @@ mod tests {
             serde_json::from_str(r#"{"ok":true,"buffered":1,"future_field":[1,2,3]}"#).unwrap();
         assert!(response.ok);
         assert_eq!(response.buffered, Some(1));
+    }
+
+    #[tokio::test]
+    async fn roundtrip_caps_response_size() {
+        // A squatter on the socket path streaming newline-free bytes must
+        // produce a bounded error, not an unbounded allocation.
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("hook.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            use tokio::io::AsyncWriteExt as _;
+            let garbage = vec![b'x'; 64 * 1024];
+            // Well past MAX_RESPONSE_BYTES, never a newline.
+            for _ in 0..64 {
+                if stream.write_all(&garbage).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let result = roundtrip(&socket, &Request::Status).await;
+        assert!(
+            matches!(result, Err(Error::Json(_))),
+            "capped read must surface as a parse error, got {result:?}"
+        );
+        server.abort();
     }
 
     #[tokio::test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -45,10 +45,10 @@ pub enum Request {
     Status,
 }
 
-/// What one drain accomplished. Also the daemon's status payload.
+/// What one drain accomplished.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DrainStats {
-    /// Paths received from hooks since the daemon started.
+    /// Paths handed to this drain (buffered since the previous drain).
     #[serde(default)]
     pub paths_received: usize,
     /// Paths skipped because an upstream cache already serves them.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -66,6 +66,11 @@ pub struct DrainStats {
     /// chunker bug or store corruption; never uploaded).
     #[serde(default)]
     pub failed_verification: usize,
+    /// Paths skipped because chunking them failed (unreadable files, NAR
+    /// contents hestia cannot represent such as non-UTF-8 names; never
+    /// uploaded).
+    #[serde(default)]
+    pub failed_chunking: usize,
     /// Paths newly added to the manifest.
     #[serde(default)]
     pub pushed: usize,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -357,13 +357,14 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
     let system = args.system.clone().unwrap_or_else(pipeline::current_system);
 
     let store_dir = store.store_dir().clone();
+    let root_key = pipeline::root_key(&branch, &system);
     let pipeline = PipelineContext {
         twirp: twirp.clone(),
         http: http.clone(),
         store,
         upstream,
         expand_closure: !args.no_closure,
-        root_key: pipeline::root_key(&branch, &system),
+        root_key: root_key.clone(),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         pack_target_size: pipeline::PACK_TARGET_SIZE,
         // Replaced by Daemon::bind with the daemon's shared ManifestStore.
@@ -448,11 +449,9 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
     };
 
     eprintln!(
-        "hestia serve: hook socket {}, substituter http://{} (root key: {}-{})",
+        "hestia serve: hook socket {}, substituter http://{} (root key: {root_key})",
         args.socket.display(),
         args.listen,
-        branch,
-        system
     );
 
     // SIGTERM (runner shutdown) and SIGINT (^C) both trigger drain + exit.

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -503,7 +503,13 @@ async fn handle_connection(
 /// until SIGTERM/SIGINT.
 pub async fn run(args: &ServeArgs) -> ExitCode {
     // GHA cache credentials (injected by the hestia action wrapper).
-    let http = reqwest::Client::new();
+    // Connect timeout only: a total request timeout would break large
+    // pack uploads/downloads, but a connection that cannot even be
+    // established should fail fast instead of hanging a drain or fetch.
+    let http = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .build()
+        .expect("building the HTTP client failed");
     let twirp = match TwirpClient::from_env(http.clone()) {
         Ok(twirp) => twirp,
         Err(err) => {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -71,12 +71,49 @@ struct DaemonState {
     /// Serializes drains: concurrent drain requests run one at a time.
     drain_lock: tokio::sync::Mutex<()>,
     /// Last time anything happened (for idle-exit).
-    last_activity: Mutex<Instant>,
+    last_activity: Arc<Mutex<Instant>>,
+    /// Number of operations currently in progress (drains, substituter
+    /// requests). Idle-exit only measures time since the *start* of work,
+    /// so without this count any operation longer than the idle timeout
+    /// (a long drain, a large NAR fetch) would trip the timer mid-flight
+    /// and get severed by the shutdown.
+    in_flight: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+/// Keeps the daemon alive while held: counts as in-flight work for the
+/// idle-exit timer and restarts the idle clock when dropped.
+pub struct WorkGuard {
+    in_flight: Arc<std::sync::atomic::AtomicUsize>,
+    last_activity: Arc<Mutex<Instant>>,
+}
+
+impl Drop for WorkGuard {
+    fn drop(&mut self) {
+        // Touch on completion: the idle window starts after the work
+        // finished, not when it began.
+        *self.last_activity.lock().expect("activity lock poisoned") = Instant::now();
+        self.in_flight
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 impl DaemonState {
     fn touch(&self) {
         *self.last_activity.lock().expect("activity lock poisoned") = Instant::now();
+    }
+
+    fn begin_work(&self) -> WorkGuard {
+        self.touch();
+        self.in_flight
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        WorkGuard {
+            in_flight: Arc::clone(&self.in_flight),
+            last_activity: Arc::clone(&self.last_activity),
+        }
+    }
+
+    fn has_in_flight(&self) -> bool {
+        self.in_flight.load(std::sync::atomic::Ordering::SeqCst) > 0
     }
 
     fn idle_for(&self) -> Duration {
@@ -95,8 +132,8 @@ impl DaemonState {
     /// On failure the paths go back into the buffer so a later drain (or
     /// the final drain at shutdown) can retry them.
     async fn drain(&self) -> Result<DrainStats, pipeline::Error> {
+        let _work = self.begin_work();
         let _guard = self.drain_lock.lock().await;
-        self.touch();
 
         let paths = std::mem::take(&mut *self.buffered.lock().expect("buffer lock poisoned"));
         let accessed = self.access_log.snapshot();
@@ -191,7 +228,8 @@ impl Daemon {
                 access_log,
                 pipeline,
                 drain_lock: tokio::sync::Mutex::new(()),
-                last_activity: Mutex::new(Instant::now()),
+                last_activity: Arc::new(Mutex::new(Instant::now())),
+                in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             }),
             listener,
             idle_exit,
@@ -208,7 +246,7 @@ impl Daemon {
     /// actively substituting must not be cut off).
     pub fn activity_hook(&self) -> crate::substituter::ActivityHook {
         let state = Arc::clone(&self.state);
-        Arc::new(move || state.touch())
+        Arc::new(move || Box::new(state.begin_work()))
     }
 
     /// Serve until `shutdown` resolves or the idle timeout expires, then
@@ -258,7 +296,9 @@ impl Daemon {
                 None => std::future::pending::<()>().await,
                 Some(timeout) => loop {
                     tokio::time::sleep(IDLE_CHECK_INTERVAL.min(timeout)).await;
-                    if idle_state.idle_for() >= timeout {
+                    // In-flight work (a drain, an active NAR download)
+                    // counts as activity: exiting now would sever it.
+                    if !idle_state.has_in_flight() && idle_state.idle_for() >= timeout {
                         break;
                     }
                 },

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -19,7 +19,7 @@
 //!   drain   -> run the write pipeline over buffered + accessed paths
 //!              -> refresh the served manifest
 //!   status  -> report buffered count
-//!   narinfo -> record access, prefetch chunks
+//!   narinfo -> record access
 //!   nar     -> serve chunks fetched from packs
 //! exit on: shutdown signal (SIGTERM/SIGINT) or idle timeout
 //!   -> one final drain before returning

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -227,7 +227,25 @@ impl Daemon {
         pipeline.publish = Some(manifest_store);
 
         if let Some(parent) = socket.parent() {
-            std::fs::create_dir_all(parent)?;
+            // The default path lives under world-writable /tmp and the
+            // line protocol has no authentication: create the directory
+            // 0700 so other local users cannot connect, and refuse a
+            // pre-existing directory owned by someone else (its owner
+            // could unlink our socket and bind their own in its place).
+            use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _};
+            let mut builder = std::fs::DirBuilder::new();
+            builder.recursive(true).mode(0o700);
+            builder.create(parent)?;
+            let metadata = std::fs::metadata(parent)?;
+            let uid = unsafe { libc::getuid() };
+            if metadata.uid() != uid {
+                return Err(std::io::Error::other(format!(
+                    "socket directory {} is owned by uid {} (we are uid {uid}); \
+                     a foreign owner could replace the socket underneath us",
+                    parent.display(),
+                    metadata.uid(),
+                )));
+            }
         }
         if std::os::unix::net::UnixStream::connect(socket).is_ok() {
             return Err(std::io::Error::new(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -197,8 +197,9 @@ impl Daemon {
     /// Bind the hook socket and assemble the daemon.
     ///
     /// The socket's parent directory is created if missing. An existing
-    /// socket file is removed first (leftover from a previous daemon that
-    /// did not shut down cleanly).
+    /// socket file is removed first — but only after probing it: if a
+    /// daemon still answers on it, binding would silently sever that
+    /// daemon from all of its clients, so the bind is refused instead.
     pub fn bind(
         socket: &Path,
         idle_exit: Option<Duration>,
@@ -214,6 +215,15 @@ impl Daemon {
 
         if let Some(parent) = socket.parent() {
             std::fs::create_dir_all(parent)?;
+        }
+        if std::os::unix::net::UnixStream::connect(socket).is_ok() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AddrInUse,
+                format!(
+                    "another daemon is already serving {}; refusing to take over its socket",
+                    socket.display()
+                ),
+            ));
         }
         match std::fs::remove_file(socket) {
             Ok(()) => {}
@@ -440,6 +450,20 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
 
     let manifest_store = ManifestStore::new();
 
+    // Bind the substituter port before touching the hook socket: if the
+    // port is taken (most likely by another hestia serve with default
+    // flags), failing here must leave that daemon's socket alone.
+    let listener = match tokio::net::TcpListener::bind(&args.listen).await {
+        Ok(listener) => listener,
+        Err(err) => {
+            eprintln!(
+                "hestia serve: cannot bind substituter address {}: {err}",
+                args.listen
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+
     let idle_exit = args.idle_exit.map(Duration::from_secs);
     let daemon = match Daemon::bind(
         &args.socket,
@@ -468,16 +492,6 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         http.clone(),
     )
         .with_activity_hook(daemon.activity_hook());
-    let listener = match tokio::net::TcpListener::bind(&args.listen).await {
-        Ok(listener) => listener,
-        Err(err) => {
-            eprintln!(
-                "hestia serve: cannot bind substituter address {}: {err}",
-                args.listen
-            );
-            return ExitCode::FAILURE;
-        }
-    };
     let substituter_task = tokio::spawn(async move {
         if let Err(err) = axum::serve(listener, substituter.into_router()).await {
             eprintln!("hestia serve: substituter server failed: {err}");
@@ -536,6 +550,10 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
     let result = daemon.run(shutdown).await;
     load_task.abort();
     substituter_task.abort();
+    // Remove the socket file: a leftover socket at the fixed default path
+    // makes later hook invocations connect to a dead endpoint and makes
+    // the next daemon's takeover look like a crash recovery.
+    let _ = std::fs::remove_file(&args.socket);
     match result {
         Ok(stats) => {
             eprintln!(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -412,6 +412,28 @@ impl Daemon {
     }
 }
 
+/// Load the newest committed manifest and publish it into the served
+/// store if it is newer than the current view. A drain may have published
+/// a newer manifest while the load was in flight (or the load may return a
+/// stale version: lookups are eventually consistent); that version must
+/// win. Recording the version makes drains start their reservations above
+/// it even when cache lookups lag.
+async fn load_published_manifest(
+    twirp: &TwirpClient,
+    http: &reqwest::Client,
+    manifest_store: &ManifestStore,
+) {
+    let save = crate::gha::savemutable::SaveMutable::new(twirp, http, MANIFEST_PREFIX);
+    match save.load().await {
+        Ok(Some(entry)) => manifest_store
+            .set_version_if_newer(pipeline::decode_manifest_or_empty(&entry.data), entry.index),
+        Ok(None) => {}
+        Err(err) => {
+            eprintln!("hestia serve: cannot load the manifest, substituting nothing: {err}");
+        }
+    }
+}
+
 /// Accept errors that do not mean the listener is dead: a queued client
 /// that disconnected before being accepted, or momentary fd/buffer
 /// exhaustion. Treating these as fatal would kill caching for the rest of
@@ -576,7 +598,20 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         twirp.clone(),
         http.clone(),
     )
-        .with_activity_hook(daemon.activity_hook());
+    .with_activity_hook(daemon.activity_hook())
+    .with_manifest_reload({
+        let twirp = twirp.clone();
+        let http = http.clone();
+        let manifest_store = manifest_store.clone();
+        Arc::new(move || {
+            let twirp = twirp.clone();
+            let http = http.clone();
+            let manifest_store = manifest_store.clone();
+            Box::pin(async move {
+                load_published_manifest(&twirp, &http, &manifest_store).await;
+            })
+        })
+    });
     let substituter_task = tokio::spawn(async move {
         if let Err(err) = axum::serve(listener, substituter.into_router()).await {
             eprintln!("hestia serve: substituter server failed: {err}");
@@ -594,23 +629,7 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         let http = http.clone();
         let manifest_store = manifest_store.clone();
         tokio::spawn(async move {
-            let save = crate::gha::savemutable::SaveMutable::new(&twirp, &http, MANIFEST_PREFIX);
-            match save.load().await {
-                // Recording the version makes drains start their
-                // reservations above it even when cache lookups lag. A
-                // drain may already have published a newer manifest while
-                // this load was in flight; that version must win.
-                Ok(Some(entry)) => manifest_store.set_version_if_newer(
-                    pipeline::decode_manifest_or_empty(&entry.data),
-                    entry.index,
-                ),
-                Ok(None) => {}
-                Err(err) => {
-                    eprintln!(
-                        "hestia serve: cannot load the manifest, substituting nothing: {err}"
-                    );
-                }
-            }
+            load_published_manifest(&twirp, &http, &manifest_store).await;
         })
     };
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -280,19 +280,23 @@ impl Daemon {
 /// Serve one client connection: JSON request lines, JSON response lines.
 async fn handle_connection(state: &DaemonState, stream: UnixStream) -> std::io::Result<()> {
     let mut stream = BufReader::new(stream);
-    let mut line = String::new();
+    let mut line = Vec::new();
     loop {
         line.clear();
         // Bound how much one request line may buffer: `take` makes
-        // `read_line` stop at the cap as if the stream had ended there.
+        // `read_until` stop at the cap as if the stream had ended there.
+        // Raw bytes, not `read_line`: that validates UTF-8 over the
+        // accumulated buffer and would error out before the oversize and
+        // malformed-request responses below get a chance to be sent (e.g.
+        // when the cap lands inside a multi-byte character).
         let read = (&mut stream)
             .take(MAX_REQUEST_BYTES)
-            .read_line(&mut line)
+            .read_until(b'\n', &mut line)
             .await?;
         if read == 0 {
             return Ok(()); // client hung up
         }
-        if read as u64 == MAX_REQUEST_BYTES && !line.ends_with('\n') {
+        if read as u64 == MAX_REQUEST_BYTES && line.last() != Some(&b'\n') {
             // The cap was hit before a newline: oversized request. Answer
             // with an error and drop the connection (the rest of the line
             // is still in flight, so there is no way to resync to the next
@@ -305,6 +309,9 @@ async fn handle_connection(state: &DaemonState, stream: UnixStream) -> std::io::
             stream.get_mut().flush().await?;
             return Ok(());
         }
+        // Lossy conversion: invalid UTF-8 falls into the malformed-request
+        // arm via the serde parse error instead of killing the connection.
+        let line = String::from_utf8_lossy(&line);
         let response = match serde_json::from_str::<Request>(&line) {
             Ok(request) => state.handle_request(request).await,
             Err(err) => Response::error(format!("malformed request: {err}")),

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -14,7 +14,7 @@
 //! Lifecycle:
 //!
 //! ```text
-//! load manifest -> bind hook socket + substituter listener
+//! bind hook socket + substituter listener (manifest loads concurrently)
 //!   add     -> buffer paths in memory
 //!   drain   -> run the write pipeline over buffered + accessed paths
 //!              -> refresh the served manifest
@@ -370,18 +370,7 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         publish: None,
     };
 
-    // Load the manifest committed by previous runs so the substituter can
-    // serve those paths from the start. No manifest yet (first run) or a
-    // load failure both mean "serve nothing until the first drain".
     let manifest_store = ManifestStore::new();
-    match pipeline.load_manifest_versioned().await {
-        // Recording the version makes drains start their reservations
-        // above it even when cache lookups lag.
-        Ok((version, manifest)) => manifest_store.set_version(manifest, version),
-        Err(err) => {
-            eprintln!("hestia serve: cannot load the manifest, substituting nothing: {err}");
-        }
-    }
 
     let idle_exit = args.idle_exit.map(Duration::from_secs);
     let daemon = match Daemon::bind(
@@ -403,7 +392,13 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
 
     // The substituter HTTP server shares the manifest and access log with
     // the daemon and runs until the daemon exits.
-    let substituter = Substituter::new(store_dir, manifest_store, daemon.access_log(), twirp, http)
+    let substituter = Substituter::new(
+        store_dir,
+        manifest_store.clone(),
+        daemon.access_log(),
+        twirp.clone(),
+        http.clone(),
+    )
         .with_activity_hook(daemon.activity_hook());
     let listener = match tokio::net::TcpListener::bind(&args.listen).await {
         Ok(listener) => listener,
@@ -420,6 +415,37 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
             eprintln!("hestia serve: substituter server failed: {err}");
         }
     });
+
+    // Load the manifest committed by previous runs so the substituter can
+    // serve those paths. Loaded concurrently: the listeners are already
+    // bound, so a slow or stalled cache API cannot delay the action's
+    // readiness probe (which gives up after 30s and fails the job). No
+    // manifest yet (first run) or a load failure both mean "serve nothing
+    // until the first drain".
+    let load_task = {
+        let twirp = twirp.clone();
+        let http = http.clone();
+        let manifest_store = manifest_store.clone();
+        tokio::spawn(async move {
+            let save = crate::gha::savemutable::SaveMutable::new(&twirp, &http, MANIFEST_PREFIX);
+            match save.load().await {
+                // Recording the version makes drains start their
+                // reservations above it even when cache lookups lag. A
+                // drain may already have published a newer manifest while
+                // this load was in flight; that version must win.
+                Ok(Some(entry)) => manifest_store.set_version_if_newer(
+                    pipeline::decode_manifest_or_empty(&entry.data),
+                    entry.index,
+                ),
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!(
+                        "hestia serve: cannot load the manifest, substituting nothing: {err}"
+                    );
+                }
+            }
+        })
+    };
 
     eprintln!(
         "hestia serve: hook socket {}, substituter http://{} (root key: {}-{})",
@@ -442,6 +468,7 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
     };
 
     let result = daemon.run(shutdown).await;
+    load_task.abort();
     substituter_task.abort();
     match result {
         Ok(stats) => {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -78,6 +78,14 @@ struct DaemonState {
     /// (a long drain, a large NAR fetch) would trip the timer mid-flight
     /// and get severed by the shutdown.
     in_flight: Arc<std::sync::atomic::AtomicUsize>,
+    /// Set once shutdown begins: Add requests are rejected from then on
+    /// (an accepted-and-ACKed path that misses the final drain would be
+    /// silently dropped at process exit).
+    shutting_down: std::sync::atomic::AtomicBool,
+    /// Number of connection tasks currently alive. The shutdown path
+    /// waits for this to reach zero so a response in flight (e.g. the
+    /// drain client's stats) is flushed before the process exits.
+    connections: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 /// Keeps the daemon alive while held: counts as in-flight work for the
@@ -170,6 +178,11 @@ impl DaemonState {
         self.touch();
         match request {
             Request::Add { paths } => {
+                if self.shutting_down.load(std::sync::atomic::Ordering::SeqCst) {
+                    return Response::error(
+                        "daemon is shutting down; path not registered".to_string(),
+                    );
+                }
                 let count = {
                     let mut buffered = self.buffered.lock().expect("buffer lock poisoned");
                     buffered.extend(paths);
@@ -240,6 +253,8 @@ impl Daemon {
                 drain_lock: tokio::sync::Mutex::new(()),
                 last_activity: Arc::new(Mutex::new(Instant::now())),
                 in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                shutting_down: std::sync::atomic::AtomicBool::new(false),
+                connections: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             }),
             listener,
             idle_exit,
@@ -271,6 +286,10 @@ impl Daemon {
             idle_exit,
         } = self;
 
+        // Closing this channel tells connection tasks to stop at their
+        // next read instead of waiting for the client to hang up.
+        let (conn_shutdown_tx, conn_shutdown_rx) = tokio::sync::watch::channel(false);
+
         // Accept loop: one task per connection.
         let accept_state = Arc::clone(&state);
         let accept = async move {
@@ -278,10 +297,19 @@ impl Daemon {
                 match listener.accept().await {
                     Ok((stream, _)) => {
                         let state = Arc::clone(&accept_state);
+                        let mut shutdown_rx = conn_shutdown_rx.clone();
+                        state
+                            .connections
+                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                         tokio::spawn(async move {
-                            if let Err(err) = handle_connection(&state, stream).await {
+                            if let Err(err) =
+                                handle_connection(&state, stream, &mut shutdown_rx).await
+                            {
                                 eprintln!("hestia serve: connection error: {err}");
                             }
+                            state
+                                .connections
+                                .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
                         });
                     }
                     Err(err) if is_transient_accept_error(&err) => {
@@ -327,9 +355,42 @@ impl Daemon {
             }
         }
 
+        // No new registrations from here on: an Add accepted after the
+        // final drain snapshots the buffer would be ACKed and then
+        // silently dropped at process exit.
+        state
+            .shutting_down
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
         // Final drain: whatever is still buffered must be uploaded before
-        // the runner disappears.
-        state.drain().await
+        // the runner disappears. Adds that raced in before the flag
+        // landed are caught by re-draining until the buffer stays empty.
+        let mut stats = state.drain().await?;
+        while state.buffered_count() > 0 {
+            let more = state.drain().await?;
+            stats.paths_received += more.paths_received;
+            stats.pushed += more.pushed;
+            stats.new_chunks += more.new_chunks;
+            stats.packs_uploaded += more.packs_uploaded;
+            stats.bytes_uploaded += more.bytes_uploaded;
+            if more.manifest_version > 0 {
+                stats.manifest_version = more.manifest_version;
+            }
+        }
+
+        // Let connection tasks flush their responses (e.g. the drain
+        // client's stats line) before the runtime is torn down. Tasks
+        // idle at a read return promptly via the watch channel; the
+        // timeout bounds a client that never reads its response.
+        let _ = conn_shutdown_tx.send(true);
+        let flush_deadline = Instant::now() + Duration::from_secs(5);
+        while state.connections.load(std::sync::atomic::Ordering::SeqCst) > 0
+            && Instant::now() < flush_deadline
+        {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        Ok(stats)
     }
 }
 
@@ -348,7 +409,12 @@ fn is_transient_accept_error(err: &std::io::Error) -> bool {
 }
 
 /// Serve one client connection: JSON request lines, JSON response lines.
-async fn handle_connection(state: &DaemonState, stream: UnixStream) -> std::io::Result<()> {
+/// Returns when the client hangs up or `shutdown` flips to true.
+async fn handle_connection(
+    state: &DaemonState,
+    stream: UnixStream,
+    shutdown: &mut tokio::sync::watch::Receiver<bool>,
+) -> std::io::Result<()> {
     let mut stream = BufReader::new(stream);
     let mut line = Vec::new();
     loop {
@@ -359,10 +425,11 @@ async fn handle_connection(state: &DaemonState, stream: UnixStream) -> std::io::
         // accumulated buffer and would error out before the oversize and
         // malformed-request responses below get a chance to be sent (e.g.
         // when the cap lands inside a multi-byte character).
-        let read = (&mut stream)
-            .take(MAX_REQUEST_BYTES)
-            .read_until(b'\n', &mut line)
-            .await?;
+        let mut bounded = (&mut stream).take(MAX_REQUEST_BYTES);
+        let read = tokio::select! {
+            read = bounded.read_until(b'\n', &mut line) => read?,
+            _ = shutdown.wait_for(|down| *down) => return Ok(()),
+        };
         if read == 0 {
             return Ok(()); // client hung up
         }
@@ -545,6 +612,19 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
                 result.expect("installing SIGINT handler failed");
             },
         }
+        // Tokio's signal registration disables the default disposition
+        // for the rest of the process, so without a live listener a
+        // second SIGTERM/^C during a hung final drain would be silently
+        // swallowed and only SIGKILL would work. Keep listening and
+        // force-exit on the second signal.
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = sigterm.recv() => {},
+                _ = tokio::signal::ctrl_c() => {},
+            }
+            eprintln!("hestia serve: second signal received, exiting without finishing the drain");
+            std::process::exit(1);
+        });
     };
 
     let result = daemon.run(shutdown).await;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -236,6 +236,12 @@ impl Daemon {
                             }
                         });
                     }
+                    Err(err) if is_transient_accept_error(&err) => {
+                        // The short sleep lets fds free up instead of
+                        // spinning.
+                        eprintln!("hestia serve: accept failed (transient), retrying: {err}");
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
                     Err(err) => {
                         eprintln!("hestia serve: accept failed: {err}");
                         // Socket is gone; nothing left to serve.
@@ -275,6 +281,20 @@ impl Daemon {
         // the runner disappears.
         state.drain().await
     }
+}
+
+/// Accept errors that do not mean the listener is dead: a queued client
+/// that disconnected before being accepted, or momentary fd/buffer
+/// exhaustion. Treating these as fatal would kill caching for the rest of
+/// the job over a single transient failure.
+fn is_transient_accept_error(err: &std::io::Error) -> bool {
+    if err.kind() == std::io::ErrorKind::ConnectionAborted {
+        return true;
+    }
+    matches!(
+        err.raw_os_error(),
+        Some(libc::EMFILE | libc::ENFILE | libc::ENOBUFS | libc::ENOMEM)
+    )
 }
 
 /// Serve one client connection: JSON request lines, JSON response lines.
@@ -488,5 +508,29 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
             eprintln!("hestia serve: final drain failed: {err}");
             ExitCode::FAILURE
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_accept_errors_are_classified() {
+        for errno in [libc::EMFILE, libc::ENFILE, libc::ENOBUFS, libc::ENOMEM] {
+            assert!(is_transient_accept_error(
+                &std::io::Error::from_raw_os_error(errno)
+            ));
+        }
+        assert!(is_transient_accept_error(&std::io::Error::from(
+            std::io::ErrorKind::ConnectionAborted
+        )));
+        // A listener that is actually gone must still end the loop.
+        assert!(!is_transient_accept_error(&std::io::Error::from(
+            std::io::ErrorKind::NotFound
+        )));
+        assert!(!is_transient_accept_error(
+            &std::io::Error::from_raw_os_error(libc::EBADF)
+        ));
     }
 }

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -14,7 +14,7 @@
 //!   so Nix falls through to the next substituter — never partial or
 //!   corrupt data.
 //!
-//! A semaphore caps concurrent NAR fetches so parallel narinfo queries
+//! A semaphore caps concurrent pack reads so parallel narinfo queries
 //! from Nix (`WantMassQuery: 1`) do not flood the GHA cache API.
 //!
 //! Responses are unsigned: the action configures the store URL with
@@ -62,11 +62,11 @@ const PACK_URL_TTL: Duration = Duration::from_secs(10 * 60);
 /// Oldest chunks are dropped first.
 const CHUNK_CACHE_BUDGET: usize = 256 * 1024 * 1024;
 
-/// Maximum number of NAR downloads served concurrently.  Each NAR fetch
-/// may issue multiple GHA cache API calls (one per pack); capping
-/// concurrency prevents hitting the API rate limit when Nix requests many
-/// paths at once.
-const MAX_CONCURRENT_NAR_FETCHES: usize = 8;
+/// Maximum number of pack reads in flight across all NAR requests. A pack
+/// read is the unit of GHA cache API traffic (one Twirp URL lookup plus
+/// Azure Range requests), so this bounds the total API concurrency no
+/// matter how the packs distribute over paths.
+const MAX_CONCURRENT_PACK_FETCHES: usize = 8;
 
 /// How many times a pack Range read is retried after a transient failure
 /// (connection drop, timeout, 5xx) before the whole NAR request gives up
@@ -213,6 +213,11 @@ struct ChunkFetcher {
     /// Per-path serialization: concurrent NAR requests for the same path
     /// must not fetch the same chunks twice.
     path_locks: Mutex<HashMap<PathHash, Arc<tokio::sync::Mutex<()>>>>,
+    /// Caps pack reads that hit the GHA cache API. Acquired per pack,
+    /// *after* the per-path lock and the cache check, so idle waiters and
+    /// cache hits never pin a permit. FIFO: a many-pack path cannot
+    /// starve others.
+    fetch_semaphore: Semaphore,
 }
 
 impl ChunkFetcher {
@@ -223,6 +228,7 @@ impl ChunkFetcher {
             url_cache: Mutex::new(HashMap::new()),
             chunk_cache: Mutex::new(ChunkCache::default()),
             path_locks: Mutex::new(HashMap::new()),
+            fetch_semaphore: Semaphore::new(MAX_CONCURRENT_PACK_FETCHES),
         }
     }
 
@@ -342,10 +348,17 @@ impl ChunkFetcher {
             }
         }
 
-        // Fetch packs in parallel.
-        let fetches = missing
-            .into_iter()
-            .map(|(pack, chunks)| self.fetch_from_pack(pack, chunks));
+        // Fetch packs in parallel; each fetch holds one global permit
+        // while it talks to the GHA cache API. The semaphore is never
+        // closed, so acquire only fails after close.
+        let fetches = missing.into_iter().map(|(pack, chunks)| async move {
+            let _permit = self
+                .fetch_semaphore
+                .acquire()
+                .await
+                .expect("fetch semaphore closed");
+            self.fetch_from_pack(pack, chunks).await
+        });
         for fetched in futures_util::future::try_join_all(fetches).await? {
             let mut cache = self.chunk_cache.lock().expect("chunk cache poisoned");
             for (hash, data) in fetched {
@@ -416,7 +429,6 @@ pub struct Substituter {
     access_log: AccessLog,
     fetcher: ChunkFetcher,
     activity_hook: Option<ActivityHook>,
-    nar_semaphore: Arc<Semaphore>,
 }
 
 impl Substituter {
@@ -433,7 +445,6 @@ impl Substituter {
             access_log,
             fetcher: ChunkFetcher::new(twirp, http),
             activity_hook: None,
-            nar_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_NAR_FETCHES)),
         }
     }
 
@@ -578,14 +589,9 @@ async fn nar(
     // would let GC collect paths that are actively being substituted.
     state.access_log.record(path_hash);
 
-    // Cap concurrent fetches — each NAR pull may issue several Twirp +
-    // Range calls and Nix fires all requests at once (WantMassQuery: 1).
-    let Ok(_permit) = state.nar_semaphore.acquire().await else {
-        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    };
-
-    // Fetch all chunks; any failure means 404 (Nix rebuilds or falls
-    // through), never partial data.
+    // Fetch all chunks (concurrency-capped inside the fetcher); any
+    // failure means 404 (Nix rebuilds or falls through), never partial
+    // data.
     let chunks = match state
         .fetcher
         .fetch_path_chunks(&view.manifest, path_hash, entry)
@@ -600,7 +606,7 @@ async fn nar(
 
     // NAR assembly and the full-NAR hash are CPU-bound and run as single
     // non-yielding polls (the Vec sink never pends), so they go off the
-    // runtime workers: with up to MAX_CONCURRENT_NAR_FETCHES of them, a
+    // runtime workers: with many NAR requests assembling at once, a
     // multi-hundred-MiB path would otherwise pin every worker thread and
     // starve the hook socket (whose client times out and silently drops
     // path registrations).

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -128,6 +128,17 @@ impl ManifestStore {
             Arc::new(ManifestView::new(manifest, version));
     }
 
+    /// Replace the served manifest only if `version` is newer than the
+    /// served one. Used by the startup load, which runs concurrently with
+    /// the daemon: a drain may commit (and publish) a newer manifest before
+    /// the initial load finishes, and that newer version must win.
+    pub fn set_version_if_newer(&self, manifest: Manifest, version: u64) {
+        let mut inner = self.inner.write().expect("manifest lock poisoned");
+        if version > inner.version {
+            *inner = Arc::new(ManifestView::new(manifest, version));
+        }
+    }
+
     /// The served manifest and its version (clone; manifests are small).
     pub fn versioned(&self) -> (u64, Manifest) {
         let view = self.view();

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -399,9 +399,12 @@ impl ChunkFetcher {
                 for (hash, location) in run {
                     let from = (location.offset - start) as usize;
                     let to = from + location.compressed_size as usize;
-                    // extract_chunk verifies the SHA-256 of the
-                    // decompressed data; corrupt or truncated cache
-                    // contents cannot pass.
+                    // In bounds by construction: blob::get errors unless
+                    // the ranged response is exactly end - start bytes,
+                    // and coalesce_adjacent only groups chunks that tile
+                    // [start, end) contiguously. extract_chunk verifies
+                    // the SHA-256 of the decompressed data; corrupt or
+                    // truncated cache contents cannot pass.
                     let chunk = extract_chunk(&data[from..to], &hash)?;
                     extracted.push((hash, Bytes::from(chunk)));
                 }

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -170,8 +170,10 @@ enum FetchError {
     Chunker(#[from] chunker::Error),
 }
 
-/// Decompressed chunks kept in memory, evicted oldest-first once over
-/// budget.
+/// Decompressed chunks kept in memory, evicted least-recently-used first
+/// once over budget: chunks shared across paths (dedup) and repeated NAR
+/// requests keep hitting early-inserted chunks, so insertion-order
+/// eviction would drop the hot set first.
 #[derive(Default)]
 struct ChunkCache {
     chunks: HashMap<ChunkHash, Bytes>,
@@ -180,8 +182,15 @@ struct ChunkCache {
 }
 
 impl ChunkCache {
-    fn get(&self, hash: &ChunkHash) -> Option<Bytes> {
-        self.chunks.get(hash).cloned()
+    fn get(&mut self, hash: &ChunkHash) -> Option<Bytes> {
+        let data = self.chunks.get(hash).cloned()?;
+        // Move-to-back on hit (entry counts are small enough for the
+        // linear scan): a hit must postpone eviction.
+        if let Some(position) = self.order.iter().position(|entry| entry == hash) {
+            let entry = self.order.remove(position).expect("position is valid");
+            self.order.push_back(entry);
+        }
+        Some(data)
     }
 
     fn insert(&mut self, hash: ChunkHash, data: Bytes) {
@@ -332,7 +341,7 @@ impl ChunkFetcher {
         let mut result: BTreeMap<ChunkHash, Bytes> = BTreeMap::new();
         let mut missing: BTreeMap<PackHash, Vec<(ChunkHash, ChunkLocation)>> = BTreeMap::new();
         {
-            let cache = self.chunk_cache.lock().expect("chunk cache poisoned");
+            let mut cache = self.chunk_cache.lock().expect("chunk cache poisoned");
             for chunk in needed {
                 if let Some(data) = cache.get(&chunk) {
                     result.insert(chunk, data);
@@ -774,6 +783,21 @@ mod tests {
         );
         assert!(cache.get(&ChunkHash::digest([2])).is_some(), "newest kept");
         assert!(cache.total <= CHUNK_CACHE_BUDGET);
+    }
+
+    #[test]
+    fn chunk_cache_hits_refresh_recency() {
+        let mut cache = ChunkCache::default();
+        let big = Bytes::from(vec![0u8; 100 * 1024 * 1024]);
+        cache.insert(ChunkHash::digest([0]), big.clone());
+        cache.insert(ChunkHash::digest([1]), big.clone());
+        assert!(cache.get(&ChunkHash::digest([0])).is_some());
+        cache.insert(ChunkHash::digest([2]), big.clone());
+        assert!(cache.get(&ChunkHash::digest([0])).is_some(), "hit kept");
+        assert!(
+            cache.get(&ChunkHash::digest([1])).is_none(),
+            "least recently used evicted"
+        );
     }
 
     #[test]

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -396,8 +396,10 @@ impl ChunkFetcher {
 
 /// Callback invoked on every substituter request (the daemon uses it to
 /// reset its idle-exit timer: an actively substituting Nix counts as
-/// activity).
-pub type ActivityHook = Arc<dyn Fn() + Send + Sync>;
+/// activity). The returned guard is held for the whole request so that
+/// long downloads count as in-flight work instead of only touching the
+/// idle clock once at request start.
+pub type ActivityHook = Arc<dyn Fn() -> Box<dyn Send> + Send + Sync>;
 
 /// The substituter's shared state and configuration.
 pub struct Substituter {
@@ -443,15 +445,15 @@ impl Substituter {
             .with_state(state)
     }
 
-    fn touch(&self) {
-        if let Some(hook) = &self.activity_hook {
-            hook();
-        }
+    /// Mark this request as in-flight work for the daemon's idle-exit
+    /// timer; the guard must live until the response is built.
+    fn touch(&self) -> Option<Box<dyn Send>> {
+        self.activity_hook.as_ref().map(|hook| hook())
     }
 }
 
 async fn nix_cache_info(State(state): State<Arc<Substituter>>) -> Response {
-    state.touch();
+    let _activity = state.touch();
     let body = format!(
         "StoreDir: {}\nWantMassQuery: 1\nPriority: {PRIORITY}\n",
         state.store_dir
@@ -498,7 +500,7 @@ fn narinfo_for_entry(store_dir: &StoreDir, entry: &PathEntry, hash: &str) -> Vec
 }
 
 async fn narinfo(State(state): State<Arc<Substituter>>, Path(file): Path<String>) -> Response {
-    state.touch();
+    let _activity = state.touch();
     let Some(hash_str) = file.strip_suffix(".narinfo") else {
         return StatusCode::NOT_FOUND.into_response();
     };
@@ -532,7 +534,7 @@ async fn nar(
     Path(file): Path<String>,
     Query(query): Query<NarQuery>,
 ) -> Response {
-    state.touch();
+    let _activity = state.touch();
     let Some(nar_hash_str) = file.strip_suffix(".nar") else {
         return StatusCode::NOT_FOUND.into_response();
     };

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -419,6 +419,15 @@ impl ChunkFetcher {
     }
 }
 
+/// Reloads the served manifest from the cache backend (the daemon wires
+/// this to a SaveMutable load + ManifestStore::set_version_if_newer). The
+/// NAR handler invokes it when a pack the current view points at is gone:
+/// a concurrent gc repack moves live chunks into new packs and deletes the
+/// old ones, so the committed manifest knows where the data went while the
+/// daemon's view does not.
+pub type ManifestReload =
+    Arc<dyn Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> + Send + Sync>;
+
 /// Callback invoked on every substituter request (the daemon uses it to
 /// reset its idle-exit timer: an actively substituting Nix counts as
 /// activity). The returned guard is held for the whole request so that
@@ -433,6 +442,7 @@ pub struct Substituter {
     access_log: AccessLog,
     fetcher: ChunkFetcher,
     activity_hook: Option<ActivityHook>,
+    manifest_reload: Option<ManifestReload>,
 }
 
 impl Substituter {
@@ -449,12 +459,19 @@ impl Substituter {
             access_log,
             fetcher: ChunkFetcher::new(twirp, http),
             activity_hook: None,
+            manifest_reload: None,
         }
     }
 
     /// Install a callback invoked on every request.
     pub fn with_activity_hook(mut self, hook: ActivityHook) -> Self {
         self.activity_hook = Some(hook);
+        self
+    }
+
+    /// Install a manifest-reload callback (see [`ManifestReload`]).
+    pub fn with_manifest_reload(mut self, reload: ManifestReload) -> Self {
+        self.manifest_reload = Some(reload);
         self
     }
 
@@ -593,6 +610,8 @@ async fn nar(
         // The URL's NAR hash does not match the entry: stale URL.
         return StatusCode::NOT_FOUND.into_response();
     }
+    let mut entry = entry.clone();
+    let mut manifest_view = view;
 
     // A NAR download is an access (the GC liveness signal), just like a
     // narinfo hit. Nix caches narinfo lookups locally and may fetch a NAR
@@ -602,16 +621,34 @@ async fn nar(
 
     // Fetch all chunks (concurrency-capped inside the fetcher); any
     // failure means 404 (Nix rebuilds or falls through), never partial
-    // data.
-    let chunks = match state
-        .fetcher
-        .fetch_path_chunks(&view.manifest, path_hash, entry)
-        .await
-    {
-        Ok(chunks) => chunks,
-        Err(err) => {
-            eprintln!("hestia substituter: cannot serve NAR for {path_hash}: {err}");
-            return StatusCode::NOT_FOUND.into_response();
+    // data. A missing pack gets one retry against a freshly loaded
+    // manifest (see [`ManifestReload`]).
+    let mut reloaded = false;
+    let chunks = loop {
+        match state
+            .fetcher
+            .fetch_path_chunks(&manifest_view.manifest, path_hash, &entry)
+            .await
+        {
+            Ok(chunks) => break chunks,
+            Err(err @ (FetchError::PackUnavailable(_) | FetchError::UnknownChunk(_)))
+                if !reloaded && state.manifest_reload.is_some() =>
+            {
+                reloaded = true;
+                eprintln!(
+                    "hestia substituter: {err}; reloading the manifest (concurrent gc repack?)"
+                );
+                (state.manifest_reload.as_ref().expect("checked above"))().await;
+                manifest_view = state.manifest.view();
+                match manifest_view.manifest.paths.get(&path_hash) {
+                    Some(fresh) if fresh.nar_hash == nar_hash => entry = fresh.clone(),
+                    _ => return StatusCode::NOT_FOUND.into_response(),
+                }
+            }
+            Err(err) => {
+                eprintln!("hestia substituter: cannot serve NAR for {path_hash}: {err}");
+                return StatusCode::NOT_FOUND.into_response();
+            }
         }
     };
 

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -233,13 +233,11 @@ impl ChunkFetcher {
     }
 
     fn path_lock(&self, path: PathHash) -> Arc<tokio::sync::Mutex<()>> {
-        Arc::clone(
-            self.path_locks
-                .lock()
-                .expect("path lock map poisoned")
-                .entry(path)
-                .or_default(),
-        )
+        let mut locks = self.path_locks.lock().expect("path lock map poisoned");
+        // Drop locks no request holds anymore: without pruning the map
+        // grows by one entry per distinct path for the process lifetime.
+        locks.retain(|_, lock| Arc::strong_count(lock) > 1);
+        Arc::clone(locks.entry(path).or_default())
     }
 
     /// Get a signed download URL for a pack, reusing a cached one if it is
@@ -256,10 +254,13 @@ impl ChunkFetcher {
         let key = pack_cache_key(&pack);
         match self.twirp.get_download_url(&key, &[]).await? {
             DownloadUrl::Hit { url, .. } => {
-                self.url_cache
-                    .lock()
-                    .expect("url cache poisoned")
-                    .insert(pack, (url.clone(), Instant::now()));
+                let mut cache = self.url_cache.lock().expect("url cache poisoned");
+                // Expired entries are only ever bypassed, never overwritten
+                // unless the same pack is fetched again — prune them here so
+                // URLs of packs GC has repacked away do not accumulate for
+                // the process lifetime.
+                cache.retain(|_, (_, issued)| issued.elapsed() < PACK_URL_TTL);
+                cache.insert(pack, (url.clone(), Instant::now()));
                 Ok(url)
             }
             DownloadUrl::Miss => Err(FetchError::PackUnavailable(pack)),
@@ -701,6 +702,25 @@ mod tests {
             Some(&test_path_hash(1))
         );
         assert_eq!(view.by_nar_hash.get(&Hash32::digest([99])), None);
+    }
+
+    #[test]
+    fn unused_path_locks_are_pruned() {
+        let fetcher = ChunkFetcher::new(
+            TwirpClient::new(reqwest::Client::new(), "http://unused", "token"),
+            reqwest::Client::new(),
+        );
+        let held = fetcher.path_lock(test_path_hash(1));
+        drop(fetcher.path_lock(test_path_hash(2)));
+        // The next call prunes everything no request holds.
+        let _other = fetcher.path_lock(test_path_hash(3));
+        let locks = fetcher.path_locks.lock().unwrap();
+        assert!(locks.contains_key(&test_path_hash(1)), "held lock kept");
+        assert!(
+            !locks.contains_key(&test_path_hash(2)),
+            "released lock pruned"
+        );
+        drop(held);
     }
 
     #[test]

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -551,7 +551,10 @@ struct NarQuery {
 async fn nar(
     State(state): State<Arc<Substituter>>,
     Path(file): Path<String>,
-    Query(query): Query<NarQuery>,
+    // Result: an unparsable query string must yield the same 404 as every
+    // other NAR failure (the module contract Nix relies on to fall through
+    // to the next substituter), not axum's 400 extractor rejection.
+    query: Result<Query<NarQuery>, axum::extract::rejection::QueryRejection>,
 ) -> Response {
     let _activity = state.touch();
     let Some(nar_hash_str) = file.strip_suffix(".nar") else {
@@ -565,6 +568,10 @@ async fn nar(
 
     // Resolve the path entry: by ?hash= if present, otherwise via the
     // NAR-hash index.
+    let query = match query {
+        Ok(Query(query)) => query,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
     let path_hash = match &query.hash {
         Some(hash) => match hash.parse::<PathHash>() {
             Ok(path_hash) => path_hash,

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -378,17 +378,25 @@ impl ChunkFetcher {
             let end = last.offset + u64::from(last.compressed_size);
             let data = self.read_pack_range(pack, start..end).await?;
 
-            for (hash, location) in run {
-                let from = (location.offset - start) as usize;
-                let to = from + location.compressed_size as usize;
-                if to > data.len() {
-                    return Err(FetchError::PackUnavailable(pack));
+            // Decompression + hash verification are CPU-bound: off the
+            // runtime workers, like the write pipeline's compression
+            // stages, so concurrent fetches cannot starve the hook socket.
+            let extracted = tokio::task::spawn_blocking(move || {
+                let mut extracted = Vec::with_capacity(run.len());
+                for (hash, location) in run {
+                    let from = (location.offset - start) as usize;
+                    let to = from + location.compressed_size as usize;
+                    // extract_chunk verifies the SHA-256 of the
+                    // decompressed data; corrupt or truncated cache
+                    // contents cannot pass.
+                    let chunk = extract_chunk(&data[from..to], &hash)?;
+                    extracted.push((hash, Bytes::from(chunk)));
                 }
-                // extract_chunk verifies the SHA-256 of the decompressed
-                // data; corrupt or truncated cache contents cannot pass.
-                let chunk = extract_chunk(&data[from..to], &hash)?;
-                fetched.push((hash, Bytes::from(chunk)));
-            }
+                Ok::<_, FetchError>(extracted)
+            })
+            .await
+            .expect("chunk extraction task panicked")?;
+            fetched.extend(extracted);
         }
         Ok(fetched)
     }
@@ -590,23 +598,41 @@ async fn nar(
         }
     };
 
-    let nar = match nar_from_chunks(&entry.tree, &chunks).await {
+    // NAR assembly and the full-NAR hash are CPU-bound and run as single
+    // non-yielding polls (the Vec sink never pends), so they go off the
+    // runtime workers: with up to MAX_CONCURRENT_NAR_FETCHES of them, a
+    // multi-hundred-MiB path would otherwise pin every worker thread and
+    // starve the hook socket (whose client times out and silently drops
+    // path registrations).
+    let tree = entry.tree.clone();
+    let nar_size = entry.nar_size;
+    let expected_hash = entry.nar_hash;
+    let nar = tokio::task::spawn_blocking(move || {
+        use futures_util::FutureExt as _;
+        let nar = nar_from_chunks(&tree, &chunks)
+            .now_or_never()
+            .expect("NAR synthesis into a Vec sink never pends")
+            .map_err(|err| format!("NAR synthesis failed: {err}"))?;
+        // Final integrity gate: the response must hash to exactly the NAR
+        // hash the manifest (and the narinfo we served) promised.
+        if nar.len() as u64 != nar_size || Hash32::digest(&nar) != expected_hash {
+            return Err(
+                "synthesized NAR does not match its recorded hash/size; refusing to serve \
+                 corrupt data"
+                    .to_string(),
+            );
+        }
+        Ok(nar)
+    })
+    .await
+    .expect("NAR synthesis task panicked");
+    let nar = match nar {
         Ok(nar) => nar,
         Err(err) => {
-            eprintln!("hestia substituter: NAR synthesis for {path_hash} failed: {err}");
+            eprintln!("hestia substituter: cannot serve NAR for {path_hash}: {err}");
             return StatusCode::NOT_FOUND.into_response();
         }
     };
-
-    // Final integrity gate: the response must hash to exactly the NAR hash
-    // the manifest (and the narinfo we served) promised.
-    if nar.len() as u64 != entry.nar_size || Hash32::digest(&nar) != entry.nar_hash {
-        eprintln!(
-            "hestia substituter: synthesized NAR for {path_hash} does not match its recorded \
-             hash/size; refusing to serve corrupt data"
-        );
-        return StatusCode::NOT_FOUND.into_response();
-    }
 
     // axum derives Content-Length from the sized body; because the NAR is
     // fully assembled and verified before responding, the length is always

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -471,7 +471,18 @@ fn narinfo_for_entry(store_dir: &StoreDir, entry: &PathEntry, hash: &str) -> Vec
         ultimate: false,
         // Unsigned: the store URL carries ?trusted=true.
         signatures: BTreeSet::new(),
-        ca: entry.ca.as_deref().and_then(|ca| ca.parse().ok()),
+        ca: entry.ca.as_deref().and_then(|ca| match ca.parse() {
+            Ok(ca) => Some(ca),
+            // Served without a CA line the path silently degrades to
+            // input-addressed on the substituting side; leave a trace.
+            Err(err) => {
+                eprintln!(
+                    "hestia substituter: dropping unparsable CA string {ca:?} for {}: {err}",
+                    entry.store_path
+                );
+                None
+            }
+        }),
         store_dir: store_dir.clone(),
     };
     let narinfo = build_narinfo(

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -1,9 +1,10 @@
 //! Upstream-signature filtering.
 //!
-//! Hestia only stores locally-built paths. Anything carrying a signature
-//! from a trusted upstream cache (cache.nixos.org by default) is already
-//! served by that cache and would only waste GHA cache quota, so the write
-//! pipeline skips it.
+//! Opt-in (`hestia serve --upstream-cache-filter`): when enabled, anything
+//! carrying a signature from a trusted upstream cache (cache.nixos.org by
+//! default) is already served by that cache and would only waste GHA cache
+//! quota, so the write pipeline skips it. By default the filter is off and
+//! everything is cached, upstream-served paths included.
 //!
 //! The check is on the signature's *key name* only — no cryptographic
 //! verification. That is deliberate: a forged signature name in the local

--- a/tests/chunker_e2e.rs
+++ b/tests/chunker_e2e.rs
@@ -67,7 +67,10 @@ fn create_fixture(root: &Path) {
 async fn assert_reconstruction_from_pack(path: &Path) {
     let chunked = chunk_path(path).await.unwrap();
 
-    // Build the pack the way the write pipeline will.
+    // Build a single pack from the chunks. (The production pipeline goes
+    // through compress_chunks + add_compressed and splits packs at the
+    // target size; add() produces byte-identical frames, pinned by
+    // add_compressed_copies_frames_byte_identically.)
     let mut builder = PackBuilder::new();
     for chunk in &chunked.chunks {
         builder.add(chunk).unwrap();

--- a/tests/chunker_e2e.rs
+++ b/tests/chunker_e2e.rs
@@ -1,5 +1,5 @@
 //! End-to-end tests for the chunker against real filesystem trees and real
-//! store paths (Phase 2 milestone):
+//! store paths:
 //!
 //! 1. Walk a path with harmonia's NAR dumper, chunk all files, pack them,
 //!    and rebuild every file byte-identical from the pack buffer.
@@ -219,7 +219,7 @@ async fn nar_hash_matches_nix_store_dump_for_fixture() {
 
 #[tokio::test]
 async fn nar_hash_matches_nix_path_info_for_real_store_path() {
-    // The Phase 2 milestone check: our NAR serialization must agree with
+    // The key check: our NAR serialization must agree with
     // Nix's own database record for a real store path.
     let Some(store_path) = find_real_store_path() else {
         eprintln!("skipping: no real /nix/store path available");

--- a/tests/failure_modes.rs
+++ b/tests/failure_modes.rs
@@ -488,7 +488,7 @@ async fn drained_paths_are_substitutable_despite_lookup_lag() {
         let substituter = hestia::substituter::Substituter::new(
             store.database().store_dir().clone(),
             manifest_store.clone(),
-            access_log,
+            access_log.clone(),
             fake.twirp(&http),
             http.clone(),
         );
@@ -539,11 +539,16 @@ async fn drained_paths_are_substitutable_despite_lookup_lag() {
              (read-your-writes), regardless of lookup propagation lag"
         );
 
-        // Guarantee 2: the shutdown drain (root update from the narinfo
-        // hit) commits m#2 promptly. Without the reservation floor it
-        // would spin in the conflict loop against its own m#1 until the
-        // stale-skip window (60s in production) expired — the whole test
-        // would blow its timeout.
+        // Guarantee 2: the shutdown drain commits m#2 promptly. Without
+        // the reservation floor it would spin in the conflict loop against
+        // its own m#1 until the stale-skip window (60s in production)
+        // expired — the whole test would blow its timeout. The narinfo
+        // hit alone would be a pure root-clock refresh (skipped, no
+        // commit), so record a new accessed hash to give the shutdown
+        // drain a real root delta.
+        let extra_accessed: hestia::manifest::PathHash =
+            "86yk8b7ny30zl1wsq2vd66j9vrcgrkah".parse().unwrap();
+        access_log.record(extra_accessed);
         drop(shutdown_tx);
         let final_stats = daemon_handle.await.unwrap().expect("final drain failed");
         assert_eq!(
@@ -562,6 +567,11 @@ async fn drained_paths_are_substitutable_despite_lookup_lag() {
             "the second commit must not lose the first commit's paths"
         );
         assert!(manifest.roots[TEST_ROOT_KEY].paths.contains(&hash));
+        assert!(
+            manifest.roots[TEST_ROOT_KEY]
+                .paths
+                .contains(&extra_accessed)
+        );
     };
     tokio::time::timeout(Duration::from_secs(120), test)
         .await

--- a/tests/failure_modes.rs
+++ b/tests/failure_modes.rs
@@ -19,6 +19,7 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use hestia::chunker::pack_cache_key;
 use hestia::gc::{GcContext, GcPolicy};
 use hestia::gha::savemutable::SaveMutable;
 use hestia::pipeline::{AccessLog, MANIFEST_PREFIX, PipelineContext, now_unix};
@@ -237,7 +238,11 @@ async fn gc_refuses_to_act_on_a_corrupt_manifest() {
     let twirp = fake.twirp(&http);
 
     store_entry(&twirp, &http, "m#1", b"garbage manifest").await;
-    store_entry(&twirp, &http, "pack-data", b"some pack contents").await;
+    // A hestia-shaped pack key, old enough to pass the min_age guard: if GC
+    // misjudged the corrupt manifest as empty and ran its orphan sweep, this
+    // is exactly what it would delete.
+    let pack_key = pack_cache_key(&hestia::manifest::PackHash::digest(b"some pack contents"));
+    store_entry(&twirp, &http, &pack_key, b"some pack contents").await;
 
     let gc = GcContext {
         twirp: fake.twirp(&http),
@@ -247,14 +252,17 @@ async fn gc_refuses_to_act_on_a_corrupt_manifest() {
         policy: GcPolicy::default(),
     };
 
-    let result = gc.run(false, now_unix()).await;
+    // Run well past min_age so the planted pack is not shielded by the
+    // too-young-to-delete guard.
+    let gc_now = now_unix() + GcPolicy::default().min_age + 1;
+    let result = gc.run(false, gc_now).await;
     assert!(result.is_err(), "GC must fail on a corrupt manifest");
 
     // Nothing was deleted.
     let entries = fake.rest(&http).list_caches("").await.unwrap();
     let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
     assert!(keys.contains(&"m#1"), "corrupt manifest left in place");
-    assert!(keys.contains(&"pack-data"), "packs left in place");
+    assert!(keys.contains(&pack_key.as_str()), "packs left in place");
 }
 
 #[tokio::test]

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -649,6 +649,56 @@ async fn evicted_pack_heals_and_repush_restores_the_path() {
 }
 
 // ---------------------------------------------------------------------------
+// Manifest lookup consistency
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn stale_manifest_lookup_aborts_gc_instead_of_wiping_the_cache() {
+    timed(async {
+        let fake = FakeGha::start().await;
+        let http = client();
+        let sim = SimCache::new(&fake, &http);
+
+        let app = SimPath::new("the-app", 1, 60_000);
+        fake.set_clock(T0);
+        sim.push(
+            "main",
+            std::slice::from_ref(&app),
+            std::slice::from_ref(&app),
+            T0,
+        )
+        .await;
+        let packs_before = sim.stored_pack_keys().await;
+        assert!(!packs_before.is_empty());
+
+        // Twirp manifest lookups go stale (eventual consistency): the
+        // committed m#1 is not returned. GC must not interpret this as "no
+        // manifest exists" - against an empty view every pack older than
+        // min_age is an orphan and the whole pack store would be deleted.
+        fake.set_stale_lookups(&http, true).await;
+        let t1 = T0 + 2 * HOUR;
+        fake.set_clock(t1);
+        let result = sim.gc(GcPolicy::default()).run(false, t1).await;
+        assert!(
+            result.is_err(),
+            "GC must refuse to run against a manifest lookup miss while \
+             manifest version entries exist, got {result:?}"
+        );
+        assert_eq!(
+            sim.stored_pack_keys().await,
+            packs_before,
+            "no pack may be deleted on an inconsistent manifest view"
+        );
+
+        // Once the lookup catches up, GC works again and the path is intact.
+        fake.set_stale_lookups(&http, false).await;
+        sim.gc(GcPolicy::default()).run(false, t1).await.unwrap();
+        sim.assert_readable(&[&app]).await;
+    })
+    .await;
+}
+
+// ---------------------------------------------------------------------------
 // Cache version namespaces
 // ---------------------------------------------------------------------------
 

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -538,8 +538,13 @@ async fn touch_failures_do_not_abort_the_gc_run() {
         let one = SimPath::new("app-one", 1, 60_000);
         let two = SimPath::new("lib-two", 3, 60_000);
         fake.set_clock(T0);
-        sim.push("main", std::slice::from_ref(&one), &[one.clone(), two.clone()], T0)
-            .await;
+        sim.push(
+            "main",
+            std::slice::from_ref(&one),
+            &[one.clone(), two.clone()],
+            T0,
+        )
+        .await;
         sim.push(
             "main",
             std::slice::from_ref(&two),
@@ -796,7 +801,7 @@ async fn concurrent_push_during_gc_keeps_both_outcomes_correct() {
             .await;
 
         let gc = sim.gc(GcPolicy::default());
-        let (_, observations, plan) = gc.plan(t1).await.unwrap();
+        let (_, _, plan) = gc.plan(t1).await.unwrap();
         assert!(plan.drop_paths.contains(&big.path_hash()));
         assert_eq!(plan.repack_jobs.len(), 1);
 
@@ -814,7 +819,7 @@ async fn concurrent_push_during_gc_keeps_both_outcomes_correct() {
         .await;
 
         // The commit re-plans against the new manifest.
-        let outcome = gc.commit(&observations, &repacks, t1).await.unwrap();
+        let outcome = gc.commit(&repacks, t1).await.unwrap();
         let deleted = gc.delete_packs(&outcome.deletable).await.unwrap();
         gc.delete_orphans(&outcome.orphan_keys).await.unwrap();
 
@@ -843,6 +848,61 @@ async fn concurrent_push_during_gc_keeps_both_outcomes_correct() {
 
         sim.assert_readable(&[&big, &small]).await;
         sim.assert_no_dangling_pack_references().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn commit_relists_packs_so_a_long_drain_is_not_judged_evicted() {
+    timed(async {
+        let fake = FakeGha::start().await;
+        let http = client();
+        let sim = SimCache::new(&fake, &http);
+
+        let app = SimPath::new("the-app", 1, 60_000);
+        fake.set_clock(T0);
+        sim.push(
+            "main",
+            std::slice::from_ref(&app),
+            std::slice::from_ref(&app),
+            T0,
+        )
+        .await;
+
+        // GC plans (taking its REST pack listing) at t1.
+        let t1 = T0 + DAY;
+        fake.set_clock(t1);
+        let gc = sim.gc(GcPolicy::default());
+        let (_, _, plan) = gc.plan(t1).await.unwrap();
+        let repacks = gc.execute_repacks(&plan).await.unwrap();
+
+        // While GC was repacking, a long drain that *started* hours ago
+        // (the pipeline stamps every pack with the drain start time, which
+        // can exceed min_age for multi-hour pushes) uploads its pack and
+        // commits. The pack is absent from GC's plan-time listing.
+        let late = SimPath::new("late-build", 3, 60_000);
+        sim.push(
+            "main",
+            std::slice::from_ref(&late),
+            &[app.clone(), late.clone()],
+            t1 - 2 * HOUR,
+        )
+        .await;
+
+        // The commit re-plans against the drain's manifest; it must not
+        // judge the drain's pack evicted just because the plan-time listing
+        // predates its upload.
+        let outcome = gc.commit(&repacks, t1).await.unwrap();
+        gc.delete_packs(&outcome.deletable).await.unwrap();
+        gc.delete_orphans(&outcome.orphan_keys).await.unwrap();
+
+        let manifest = sim.manifest().await;
+        assert!(
+            manifest.paths.contains_key(&late.path_hash()),
+            "the concurrent drain's path must survive the GC commit"
+        );
+        sim.assert_no_dangling_pack_references().await;
+        sim.assert_readable(&[&app, &late]).await;
     })
     .await;
 }
@@ -893,7 +953,7 @@ async fn crash_between_any_two_execute_steps_never_loses_live_paths() {
             let (sim, dying, surviving, t1) = crash_scenario(&fake, &http).await;
             let gc = sim.gc(GcPolicy::default());
 
-            let (_, observations, plan) = gc.plan(t1).await.unwrap();
+            let (_, _, plan) = gc.plan(t1).await.unwrap();
             let mut repacks = RepackOutput::default();
             let mut outcome = None;
 
@@ -904,7 +964,7 @@ async fn crash_between_any_two_execute_steps_never_loses_live_paths() {
                 gc.execute_touches(&plan).await.unwrap();
             }
             if stop_after >= 3 {
-                outcome = Some(gc.commit(&observations, &repacks, t1).await.unwrap());
+                outcome = Some(gc.commit(&repacks, t1).await.unwrap());
             }
             if stop_after >= 4 {
                 let deletable = &outcome.as_ref().unwrap().deletable;

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -231,6 +231,58 @@ async fn repack_copies_live_chunks_and_deletes_old_pack_after_commit() {
 }
 
 #[tokio::test]
+async fn repack_hitting_existing_pack_counts_no_upload_and_touches_it() {
+    timed(async {
+        let fake = FakeGha::start().await;
+        let http = client();
+        let sim = SimCache::new(&fake, &http);
+
+        // Same mostly-dead-pack scenario as the repack test above.
+        let big = SimPath::new("big-app", 1, 200_000);
+        let small = SimPath::new("small-lib", 2, 40_000);
+        fake.set_clock(T0);
+        sim.push(
+            "main",
+            &[big.clone(), small.clone()],
+            &[big.clone(), small.clone()],
+            T0,
+        )
+        .await;
+
+        let t1 = T0 + 20 * DAY;
+        fake.set_clock(t1);
+        sim.push("main", &[], std::slice::from_ref(&small), t1)
+            .await;
+
+        // A previous GC run crashed after uploading its repack output: the
+        // re-run reproduces the identical pack and hits the CAS
+        // already-exists path. Simulate by executing the same plan twice.
+        let gc = sim.gc(GcPolicy::default());
+        let (_, _, plan) = gc.plan(t1).await.unwrap();
+        let first = gc.execute_repacks(&plan).await.unwrap();
+        assert_eq!(first.packs.len(), 1);
+        assert!(first.uploaded > 0);
+        let new_pack = *first.packs.keys().next().unwrap();
+
+        let second = gc.execute_repacks(&plan).await.unwrap();
+        assert_eq!(
+            second.packs.keys().collect::<Vec<_>>(),
+            first.packs.keys().collect::<Vec<_>>(),
+            "the repack output is deterministic"
+        );
+        assert_eq!(
+            second.uploaded, 0,
+            "a dedup-skipped upload must not be counted as uploaded"
+        );
+        assert!(
+            one_byte_reads(&fake, &pack_cache_key(&new_pack)) >= 1,
+            "a dedup-skipped upload must touch the existing pack instead"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn truncated_pack_fails_repack_with_an_error_not_a_panic() {
     timed(async {
         let fake = FakeGha::start().await;

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -527,6 +527,54 @@ async fn fully_live_pack_is_touched_and_never_repacked() {
     .await;
 }
 
+#[tokio::test]
+async fn touch_failures_do_not_abort_the_gc_run() {
+    timed(async {
+        let fake = FakeGha::start().await;
+        let http = client();
+        let sim = SimCache::new(&fake, &http);
+
+        // Two separate pushes -> two packs, both fully live.
+        let one = SimPath::new("app-one", 1, 60_000);
+        let two = SimPath::new("lib-two", 3, 60_000);
+        fake.set_clock(T0);
+        sim.push("main", std::slice::from_ref(&one), &[one.clone(), two.clone()], T0)
+            .await;
+        sim.push(
+            "main",
+            std::slice::from_ref(&two),
+            &[one.clone(), two.clone()],
+            T0 + 60,
+        )
+        .await;
+
+        // 5 days later both packs are idle past TouchAge.
+        let t1 = T0 + 5 * DAY;
+        fake.set_clock(t1);
+        sim.push("main", &[], &[one.clone(), two.clone()], t1).await;
+
+        // The first pack's touch fails persistently (initial read plus all
+        // transient retries); the second pack's touch must still happen and
+        // the step must complete - a touch is a pure LRU optimization that
+        // self-heals next run, and aborting here would strand the commit
+        // and all deletes behind it.
+        let gc = sim.gc(GcPolicy::default());
+        let (_, _, plan) = gc.plan(t1).await.unwrap();
+        assert_eq!(plan.touch_packs.len(), 2);
+
+        fake.fail_blob_reads(&http, 4).await;
+        let touched = gc
+            .execute_touches(&plan)
+            .await
+            .expect("a failed touch must not abort the touch step");
+        assert_eq!(
+            touched, 1,
+            "the touch after the failed one must still happen"
+        );
+    })
+    .await;
+}
+
 // ---------------------------------------------------------------------------
 // Eviction healing
 // ---------------------------------------------------------------------------

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -1022,7 +1022,7 @@ async fn crash_between_any_two_execute_steps_never_loses_live_paths() {
 }
 
 // ---------------------------------------------------------------------------
-// 30-day simulation (the Phase 5 milestone)
+// 30-day GC convergence simulation
 // ---------------------------------------------------------------------------
 
 #[tokio::test]

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -649,6 +649,74 @@ async fn evicted_pack_heals_and_repush_restores_the_path() {
 }
 
 // ---------------------------------------------------------------------------
+// Cache version namespaces
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn gc_never_deletes_packs_of_another_cache_version_namespace() {
+    timed(async {
+        let fake = FakeGha::start().await;
+        let http = client();
+        let sim = SimCache::new(&fake, &http);
+
+        // A salted perf run (HESTIA_CACHE_VERSION_SALT) lives in its own
+        // Twirp version namespace but shares the prefix-based REST listing
+        // with production.
+        let salted = SimCache {
+            http: http.clone(),
+            twirp: fake.twirp(&http).with_version_salt("perf-run"),
+            rest: fake.rest(&http),
+        };
+
+        let prod_path = SimPath::new("prod-app", 1, 60_000);
+        let perf_path = SimPath::new("perf-app", 3, 60_000);
+        fake.set_clock(T0);
+        sim.push(
+            "main",
+            std::slice::from_ref(&prod_path),
+            std::slice::from_ref(&prod_path),
+            T0,
+        )
+        .await;
+        salted
+            .push(
+                "main",
+                std::slice::from_ref(&perf_path),
+                std::slice::from_ref(&perf_path),
+                T0,
+            )
+            .await;
+
+        let salted_manifest = salted.manifest().await;
+        let salted_pack = chunk_locations_of(&salted_manifest, &perf_path)[0].pack;
+
+        // Production GC two hours later (the salted entries are past
+        // min_age). The salted pack is referenced only by the salted
+        // namespace's manifest, which production GC cannot read - it must
+        // not be judged a production orphan. Manifest `m#N` entries are
+        // not covered by this isolation: REST deletion is by key across
+        // versions.
+        let t1 = T0 + 2 * HOUR;
+        fake.set_clock(t1);
+        let report = sim.gc(GcPolicy::default()).run(false, t1).await.unwrap();
+
+        assert_eq!(
+            report.orphans_deleted, 0,
+            "another namespace's packs are not production orphans: {:?}",
+            report.plan.orphan_keys
+        );
+        assert!(
+            sim.stored_pack_keys()
+                .await
+                .contains(&pack_cache_key(&salted_pack)),
+            "the salted namespace's pack must survive production GC"
+        );
+        sim.assert_readable(&[&prod_path]).await;
+    })
+    .await;
+}
+
+// ---------------------------------------------------------------------------
 // GC vs concurrent push
 // ---------------------------------------------------------------------------
 

--- a/tests/gha_fake.rs
+++ b/tests/gha_fake.rs
@@ -436,6 +436,46 @@ async fn download_lookup_only_consults_restore_keys() {
 }
 
 #[tokio::test]
+async fn degraded_ok_true_responses_are_rejected_not_forwarded_as_empty_urls() {
+    // A degraded backend (proxy, GHES) can answer 200 {"ok": true} with the
+    // URL fields missing; every response field is #[serde(default)], so
+    // deserialization cannot catch it. The client must reject such bodies
+    // at the protocol boundary instead of handing empty URLs downstream
+    // (where they fail as misleading key-parse or URL-builder errors).
+    use axum::routing::post;
+    let router = axum::Router::new().route(
+        "/twirp/github.actions.results.api.v1.CacheService/{method}",
+        post(|| async { axum::Json(serde_json::json!({ "ok": true })) }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    let http = reqwest::Client::new();
+    let twirp = hestia::gha::twirp::TwirpClient::new(http.clone(), &base_url, "token");
+
+    let error = twirp.get_download_url("m#", &["m#"]).await.unwrap_err();
+    let Error::InvalidResponse(msg) = &error else {
+        panic!("expected InvalidResponse, got {error:?}");
+    };
+    assert!(
+        msg.contains("GetCacheEntryDownloadURL"),
+        "error must name the RPC: {msg}"
+    );
+
+    let error = twirp.create_cache_entry("pack-x").await.unwrap_err();
+    let Error::InvalidResponse(msg) = &error else {
+        panic!("expected InvalidResponse, got {error:?}");
+    };
+    assert!(
+        msg.contains("CreateCacheEntry"),
+        "error must name the RPC: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn version_salt_isolates_the_cache_namespace() {
     // A salted client must see none of the entries an unsalted client
     // wrote, and vice versa.

--- a/tests/gha_fake.rs
+++ b/tests/gha_fake.rs
@@ -407,6 +407,16 @@ async fn eviction_makes_entry_disappear() {
         panic!("expected 404 after eviction, got {error:?}");
     };
 
+    // Manifest keys contain '#', which a naive URL interpolation would
+    // truncate into a fragment, turning the eviction into a silent no-op.
+    store_entry(&twirp, &http, "m#1", b"manifest").await;
+    fake.evict(&http, "m#1").await;
+    assert_eq!(
+        twirp.get_download_url("m#", &["m#"]).await.unwrap(),
+        DownloadUrl::Miss,
+        "manifest entry must actually be evicted"
+    );
+
     // The key can be re-uploaded after eviction (heal path).
     store_entry(&twirp, &http, "pack-evictme", b"healed").await;
     let DownloadUrl::Hit { url, .. } = twirp.get_download_url("pack-evictme", &[]).await.unwrap()

--- a/tests/gha_fake.rs
+++ b/tests/gha_fake.rs
@@ -289,6 +289,36 @@ async fn savemutable_skips_stale_reservation() {
 }
 
 #[tokio::test]
+async fn savemutable_recovers_from_many_consecutive_dead_reservations() {
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let twirp = fake.twirp(&http);
+
+    // Three writers crashed in a row at the frontier: m#1..m#3 are all
+    // reserved but never finalized (e.g. a mass workflow cancellation).
+    for index in 1..=3 {
+        let Reservation::Created { .. } = twirp
+            .create_cache_entry(&format!("m#{index}"))
+            .await
+            .unwrap()
+        else {
+            panic!("expected reservation for m#{index}");
+        };
+    }
+
+    // max_attempts is exactly stale_skip_after x dead reservations (the
+    // production ratio: 60 = 3 x 20). The give-up check must not fire on
+    // the attempt that performs the last skip, otherwise three dead
+    // reservations permanently wedge every save and the cache never heals.
+    let save = SaveMutable::new(&twirp, &http, "m").with_retry(Duration::from_millis(1), 6, 2);
+    let index = save.save(|_| Ok(b"recovered".to_vec())).await.unwrap();
+    assert_eq!(index, 4, "writer must skip all three dead indexes");
+
+    let entry = save.load().await.unwrap().expect("entry exists");
+    assert_eq!(entry.data.as_ref(), b"recovered");
+}
+
+#[tokio::test]
 async fn savemutable_conflict_gives_up_eventually() {
     let fake = FakeGha::start().await;
     let http = reqwest::Client::new();

--- a/tests/gha_fake.rs
+++ b/tests/gha_fake.rs
@@ -289,6 +289,31 @@ async fn savemutable_skips_stale_reservation() {
 }
 
 #[tokio::test]
+async fn savemutable_load_stays_consistent_across_url_refresh() {
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let twirp = fake.twirp(&http);
+
+    store_entry(&twirp, &http, "m#1", b"manifest v1").await;
+    store_entry(&twirp, &http, "m#2", b"manifest v2").await;
+
+    // The first lookup lags (returns m#1) and its signed URL is born dead,
+    // so the download 403s and the refresh path re-resolves — by which time
+    // the lookup has caught up to m#2. Whatever load() returns, key, index
+    // and data must describe the same version: a m#1 label on m#2 bytes
+    // under-reports the version and recreates the conflict spin the
+    // save floor exists to prevent.
+    fake.set_stale_lookups_for(&http, 1).await;
+    fake.dead_sigs(&http, 1).await;
+
+    let save = SaveMutable::new(&twirp, &http, "m");
+    let entry = save.load().await.unwrap().expect("entry exists");
+    assert_eq!(entry.data.as_ref(), b"manifest v2");
+    assert_eq!(entry.key, "m#2", "label must match the downloaded bytes");
+    assert_eq!(entry.index, 2, "index must match the downloaded bytes");
+}
+
+#[tokio::test]
 async fn savemutable_recovers_from_many_consecutive_dead_reservations() {
     let fake = FakeGha::start().await;
     let http = reqwest::Client::new();

--- a/tests/gha_fake.rs
+++ b/tests/gha_fake.rs
@@ -428,6 +428,56 @@ async fn eviction_makes_entry_disappear() {
 }
 
 #[tokio::test]
+async fn rest_list_honors_the_stable_created_at_sort_order() {
+    // RestClient::list_caches requests sort=created_at&direction=asc
+    // because GitHub's default order (last_accessed_at desc) is mutable
+    // and makes page-numbered pagination skip entries. The fake must
+    // honor those parameters, otherwise dropping them from the client
+    // would pass the whole suite while reintroducing the hazard.
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let twirp = fake.twirp(&http);
+
+    store_entry(&twirp, &http, "pack-old", b"a").await;
+    store_entry(&twirp, &http, "pack-new", b"b").await;
+
+    let url = format!("{}/repos/fake/repo/actions/caches", fake.base_url);
+    let keys_for = |query: &'static str| {
+        let http = http.clone();
+        let url = url.clone();
+        async move {
+            let body: serde_json::Value = http
+                .get(format!("{url}?{query}"))
+                .send()
+                .await
+                .unwrap()
+                .json()
+                .await
+                .unwrap();
+            body["actions_caches"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|e| e["key"].as_str().unwrap().to_string())
+                .collect::<Vec<_>>()
+        }
+    };
+
+    // GitHub's default: last_accessed_at descending (newest first).
+    assert_eq!(
+        keys_for("key=pack-").await,
+        vec!["pack-new", "pack-old"],
+        "default order must be LRU-descending like the real service"
+    );
+    // The stable order the production client requests.
+    assert_eq!(
+        keys_for("key=pack-&sort=created_at&direction=asc").await,
+        vec!["pack-old", "pack-new"],
+        "created_at ascending must be honored"
+    );
+}
+
+#[tokio::test]
 async fn download_lookup_only_consults_restore_keys() {
     // Fidelity test for a production-API behavior discovered by
     // tests/gha_real.rs in CI: GetCacheEntryDownloadURL ignores the `key`

--- a/tests/gha_rest_robustness.rs
+++ b/tests/gha_rest_robustness.rs
@@ -268,6 +268,78 @@ async fn start_rate_limited_server(
     (start_server(router).await, state)
 }
 
+/// A flaky endpoint: the first `failures` requests get a 502, then it
+/// serves normally (the intermittent 5xx GitHub's results service throws
+/// under load).
+struct FlakyServer {
+    failures: usize,
+    requests: usize,
+}
+
+async fn flaky_list_handler(State(state): State<Arc<Mutex<FlakyServer>>>) -> Response {
+    let mut inner = state.lock().unwrap();
+    inner.requests += 1;
+    if inner.requests <= inner.failures {
+        return (StatusCode::BAD_GATEWAY, "upstream error").into_response();
+    }
+    single_entry_listing("pack-flaky").into_response()
+}
+
+#[tokio::test]
+async fn list_retries_transient_server_errors() {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let state = Arc::new(Mutex::new(FlakyServer {
+            failures: 2,
+            requests: 0,
+        }));
+        let router = Router::new()
+            .route(
+                "/repos/{owner}/{repo}/actions/caches",
+                get(flaky_list_handler),
+            )
+            .with_state(state.clone());
+        let url = start_server(router).await;
+        let rest = RestClient::new(reqwest::Client::new(), &url, "fake/repo", "fake-token")
+            .with_pacing(Duration::ZERO, Duration::from_millis(100));
+
+        // A single transient 502 during pagination must not abort the whole
+        // GC run; the data plane (blob.rs) already retries 5xx with backoff
+        // and the control plane deserves the same.
+        let listed = rest.list_caches("pack-").await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(state.lock().unwrap().requests, 3);
+    })
+    .await
+    .expect("test timed out");
+}
+
+#[tokio::test]
+async fn persistent_server_errors_still_fail() {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let state = Arc::new(Mutex::new(FlakyServer {
+            failures: usize::MAX,
+            requests: 0,
+        }));
+        let router = Router::new()
+            .route(
+                "/repos/{owner}/{repo}/actions/caches",
+                get(flaky_list_handler),
+            )
+            .with_state(state.clone());
+        let url = start_server(router).await;
+        let rest = RestClient::new(reqwest::Client::new(), &url, "fake/repo", "fake-token")
+            .with_pacing(Duration::ZERO, Duration::from_millis(10));
+
+        let err = rest.list_caches("pack-").await.unwrap_err();
+        assert!(
+            err.to_string().contains("502"),
+            "error should carry the HTTP status: {err}"
+        );
+    })
+    .await
+    .expect("test timed out");
+}
+
 #[tokio::test]
 async fn delete_retries_after_secondary_rate_limit() {
     tokio::time::timeout(TEST_TIMEOUT, async {

--- a/tests/gha_rest_robustness.rs
+++ b/tests/gha_rest_robustness.rs
@@ -134,6 +134,39 @@ async fn empty_pages_handler() -> Json<serde_json::Value> {
     }))
 }
 
+/// A listing endpoint whose `total_count` underreports the entries it
+/// actually serves (an eventually consistent counter, or one shrunk by
+/// concurrent deletions). Pagination termination must come from an empty
+/// page, never from trusting the counter.
+async fn understated_total_count_handler(
+    Query(params): Query<HashMap<String, String>>,
+) -> Json<serde_json::Value> {
+    let per_page: usize = params
+        .get("per_page")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30);
+    let page: usize = params.get("page").and_then(|v| v.parse().ok()).unwrap_or(1);
+    let page_entries: Vec<serde_json::Value> = (0..150usize)
+        .skip((page - 1) * per_page)
+        .take(per_page)
+        .map(|i| {
+            json!({
+                "id": i,
+                "ref": "refs/heads/main",
+                "key": format!("pack-{i:03}"),
+                "version": "v",
+                "created_at": format_timestamp(1_000 + i as u64),
+                "last_accessed_at": format_timestamp(1_000 + i as u64),
+                "size_in_bytes": 1,
+            })
+        })
+        .collect();
+    Json(json!({
+        "total_count": 1,
+        "actions_caches": page_entries,
+    }))
+}
+
 async fn start_server(router: Router) -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -348,6 +381,30 @@ async fn pagination_returns_every_entry_despite_concurrent_lru_reordering() {
             listed.len(),
             expected.len(),
             "pagination duplicated entries"
+        );
+    })
+    .await
+    .expect("test timed out");
+}
+
+#[tokio::test]
+async fn pagination_does_not_trust_an_understated_total_count() {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let router = Router::new().route(
+            "/repos/{owner}/{repo}/actions/caches",
+            get(understated_total_count_handler),
+        );
+        let url = start_server(router).await;
+        let rest = RestClient::new(reqwest::Client::new(), &url, "fake/repo", "fake-token");
+
+        // GC treats packs missing from this listing as evicted and drops
+        // the paths referencing them, so ending the listing early on a
+        // stale counter loses live data.
+        let listed = rest.list_caches("pack-").await.unwrap();
+        assert_eq!(
+            listed.len(),
+            150,
+            "listing must continue past a lying total_count until an empty page"
         );
     })
     .await

--- a/tests/hook_client.rs
+++ b/tests/hook_client.rs
@@ -37,7 +37,7 @@ async fn hook_exits_zero_when_daemon_is_unreachable() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("failed to reach daemon"),
+        stderr.contains("did not accept the paths"),
         "error must be reported on stderr, got: {stderr}"
     );
 }

--- a/tests/pathinfo_real.rs
+++ b/tests/pathinfo_real.rs
@@ -75,8 +75,7 @@ fn scratch_store_references_are_recorded() {
     };
 
     // top references dep (and only dep).
-    let references = top_info.references_without_self();
-    assert_eq!(references, vec![dep_info.store_path.clone()]);
+    assert_eq!(top_info.references, vec![dep_info.store_path.clone()]);
 
     // dep references nothing.
     assert!(dep_info.references.is_empty());

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -83,7 +83,7 @@ async fn pushes_paths_end_to_end() {
     assert_eq!(manifest.paths.len(), 3);
 
     // The fixture entry's NAR hash/size match nix's record (this is what
-    // narinfo responses will serve in Phase 4).
+    // narinfo responses serve).
     let fixture_entry = &manifest.paths[&path_hash_of(&fixture)];
     assert_eq!(fixture_entry.nar_hash, expected_hash, "nar_hash mismatch");
     assert_eq!(fixture_entry.nar_size, expected_size, "nar_size mismatch");
@@ -362,7 +362,7 @@ async fn invalid_and_malformed_paths_are_skipped_without_failing_the_drain() {
 
 #[tokio::test]
 async fn accessed_paths_join_the_root_without_store_queries() {
-    // The AccessLog interface (substituter integration, Phase 4): accessed
+    // The AccessLog interface (substituter integration): accessed
     // paths must end up in the root even though they are never queried,
     // chunked, or uploaded. Needs no Nix store at all.
     let fake = FakeGha::start().await;

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -432,6 +432,16 @@ async fn unchunkable_path_is_skipped_without_failing_the_drain() {
     let (_, manifest) = committed_manifest(&fake, &http).await.unwrap();
     assert!(manifest.paths.contains_key(&path_hash_of(&good)));
     assert!(!manifest.paths.contains_key(&path_hash_of(&bad)));
+
+    // The rejected path must not be pinned by the root either: a root
+    // member without a PathEntry is a dangling hash the cache can never
+    // serve.
+    let root = &manifest.roots[TEST_ROOT_KEY];
+    assert!(root.paths.contains(&path_hash_of(&good)));
+    assert!(
+        !root.paths.contains(&path_hash_of(&bad)),
+        "rejected paths must not join the committed root"
+    );
 }
 
 #[tokio::test]

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -397,6 +397,44 @@ async fn accessed_paths_join_the_root_without_store_queries() {
 }
 
 #[tokio::test]
+async fn unchunkable_path_is_skipped_without_failing_the_drain() {
+    // A path that deterministically fails chunking (here: its contents
+    // vanished from disk while staying registered in the store database)
+    // must not abort the whole drain: the healthy path still gets cached
+    // and the drain reports success.
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+    let good = store.add_fixture("chunkable", 29);
+    let bad = store.add_fixture("unchunkable", 31);
+    // Make the bad path unreadable on disk; the DB still lists it.
+    std::process::Command::new("chmod")
+        .arg("-R")
+        .arg("u+w")
+        .arg(&bad)
+        .status()
+        .unwrap();
+    std::fs::remove_dir_all(&bad).unwrap();
+
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let ctx = context(&fake, &http, store.database());
+
+    let stats = ctx
+        .run(to_path_set(&[&good, &bad]), BTreeSet::new(), now_unix())
+        .await
+        .expect("a per-path chunking failure must not fail the drain");
+
+    assert_eq!(stats.failed_chunking, 1);
+    assert_eq!(stats.pushed, 1);
+    assert_eq!(stats.manifest_version, 1);
+
+    let (_, manifest) = committed_manifest(&fake, &http).await.unwrap();
+    assert!(manifest.paths.contains_key(&path_hash_of(&good)));
+    assert!(!manifest.paths.contains_key(&path_hash_of(&bad)));
+}
+
+#[tokio::test]
 async fn redundant_root_refresh_does_not_commit() {
     // The SIGTERM final drain re-runs with the same access-log snapshot a
     // previous drain already committed. When nothing changed but the

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -397,6 +397,40 @@ async fn accessed_paths_join_the_root_without_store_queries() {
 }
 
 #[tokio::test]
+async fn redundant_root_refresh_does_not_commit() {
+    // The SIGTERM final drain re-runs with the same access-log snapshot a
+    // previous drain already committed. When nothing changed but the
+    // root's `updated` clock, no new manifest version must be burned.
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let ctx = context(&fake, &http, StoreDatabase::new("/nonexistent/db.sqlite"));
+
+    let accessed_hash: PathHash = "76yk8b7ny30zl1wsq2vd66j9vrcgrkah".parse().unwrap();
+    let accessed = BTreeSet::from([accessed_hash]);
+
+    let now = now_unix();
+    let first = ctx
+        .run(BTreeSet::new(), accessed.clone(), now)
+        .await
+        .expect("first drain failed");
+    assert_eq!(first.manifest_version, 1);
+
+    // Same snapshot a few seconds later: pure clock refresh, no commit.
+    let second = ctx
+        .run(BTreeSet::new(), accessed, now + 5)
+        .await
+        .expect("second drain failed");
+    assert_eq!(
+        second.manifest_version, 0,
+        "a drain that would only bump the root clock must not commit"
+    );
+
+    let (version, manifest) = committed_manifest(&fake, &http).await.unwrap();
+    assert_eq!(version, 1, "no second manifest version");
+    assert_eq!(manifest.roots[TEST_ROOT_KEY].updated, now);
+}
+
+#[tokio::test]
 async fn identical_content_across_paths_shares_chunks() {
     // Chunk-level dedup across store paths: two different paths with the
     // same blob content must not store the blob twice.

--- a/tests/serve_daemon.rs
+++ b/tests/serve_daemon.rs
@@ -272,6 +272,52 @@ async fn idle_exit_drains_and_returns() {
 }
 
 #[tokio::test]
+async fn idle_exit_waits_for_in_flight_work() {
+    // The idle timer only sees the *start* of work, so an operation longer
+    // than --idle-exit (a long drain, a large NAR download holding the
+    // activity guard) must count as in-flight work; otherwise the daemon
+    // exits mid-operation and severs it.
+    let test = async {
+        let fake = FakeGha::start().await;
+        let http = reqwest::Client::new();
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("hook.sock");
+
+        let daemon = Daemon::bind(
+            &socket,
+            Some(Duration::from_millis(200)),
+            pipeline_context(&fake, &http, StoreDatabase::new("/nonexistent/db.sqlite")),
+            AccessLog::new(),
+            ManifestStore::new(),
+        )
+        .expect("binding daemon failed");
+
+        // Simulates a long substituter request: the hook's guard is held
+        // far past the idle timeout.
+        let hook = daemon.activity_hook();
+        let handle = tokio::spawn(daemon.run(std::future::pending()));
+        let guard = hook();
+
+        tokio::time::sleep(Duration::from_millis(800)).await;
+        assert!(
+            !handle.is_finished(),
+            "daemon must not idle-exit while work is in flight"
+        );
+
+        drop(guard);
+        let result = tokio::time::timeout(Duration::from_secs(10), handle)
+            .await
+            .expect("daemon must idle-exit once the work is done")
+            .expect("daemon task panicked");
+        // Final drain over an empty buffer succeeds even with a broken db.
+        assert_eq!(result.expect("final drain failed").pushed, 0);
+    };
+    tokio::time::timeout(Duration::from_secs(30), test)
+        .await
+        .expect("test timed out");
+}
+
+#[tokio::test]
 async fn failed_drain_keeps_paths_buffered_for_retry() {
     // A drain that cannot reach the store database must not lose the
     // buffered paths: they stay queued for a later retry.

--- a/tests/serve_daemon.rs
+++ b/tests/serve_daemon.rs
@@ -537,6 +537,78 @@ async fn substituter_serves_paths_pushed_by_daemon_drains() {
         .expect("test timed out: deadlock or hung server");
 }
 
+#[tokio::test]
+async fn serve_becomes_ready_while_cache_api_stalls() {
+    // A stalled GHA cache API at startup must not block the daemon's
+    // listeners: the action polls /nix-cache-info for only 30s and then
+    // hard-fails the job, even though cache unavailability is designed to
+    // degrade to "substitute nothing". The manifest load must therefore
+    // happen concurrently with (not before) binding the listeners.
+    let test = async {
+        let Some(store) = ScratchStore::create() else {
+            return;
+        };
+        // The store database only exists once something was added.
+        store.add_fixture("stall-ready", 151);
+
+        // A cache API that accepts connections but never responds.
+        let stall = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let stall_addr = stall.local_addr().unwrap();
+        let stall_task = tokio::spawn(async move {
+            let mut held = Vec::new();
+            loop {
+                let Ok((stream, _)) = stall.accept().await else {
+                    return;
+                };
+                held.push(stream);
+            }
+        });
+
+        // A free port for the substituter (bind-and-release).
+        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let listen = probe.local_addr().unwrap().to_string();
+        drop(probe);
+
+        let socket = store_socket_path(&store);
+        let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_hestia"))
+            .args(["serve", "--listen", &listen, "--socket"])
+            .arg(&socket)
+            .arg("--db-path")
+            .arg(store.db_path())
+            .env("ACTIONS_RESULTS_URL", format!("http://{stall_addr}"))
+            .env("ACTIONS_RUNTIME_TOKEN", "test-token")
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawning hestia serve failed");
+
+        // The substituter must answer readiness probes well within the
+        // action's 30s budget despite the stalled manifest load.
+        let http = reqwest::Client::new();
+        let url = format!("http://{listen}/nix-cache-info");
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let mut ready = false;
+        while std::time::Instant::now() < deadline {
+            if let Ok(response) = http.get(&url).send().await
+                && response.status() == 200
+            {
+                ready = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            ready,
+            "substituter must become ready while the cache API stalls"
+        );
+
+        child.kill().await.expect("killing hestia serve failed");
+        stall_task.abort();
+    };
+    tokio::time::timeout(Duration::from_secs(60), test)
+        .await
+        .expect("test timed out");
+}
+
 /// Socket path inside the scratch store's tempdir (cleaned up with it).
 fn store_socket_path(store: &ScratchStore) -> PathBuf {
     store.db_path().parent().unwrap().join("hestia-hook.sock")

--- a/tests/serve_daemon.rs
+++ b/tests/serve_daemon.rs
@@ -357,6 +357,47 @@ async fn failed_drain_keeps_paths_buffered_for_retry() {
 }
 
 #[tokio::test]
+async fn shutdown_closes_idle_connections_and_rejects_late_adds() {
+    // Connection tasks must not outlive the daemon: an idle client gets
+    // EOF at shutdown instead of a forever-open socket, and an Add after
+    // shutdown began must be rejected (an ACKed path that misses the
+    // final drain would be silently dropped at process exit).
+    let test = async {
+        let fake = FakeGha::start().await;
+        let http = reqwest::Client::new();
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("hook.sock");
+
+        let daemon = RunningDaemon::start(
+            socket.clone(),
+            None,
+            pipeline_context(&fake, &http, StoreDatabase::new("/nonexistent/db.sqlite")),
+        )
+        .await;
+
+        use tokio::io::AsyncReadExt as _;
+        let mut idle = tokio::net::UnixStream::connect(&socket)
+            .await
+            .expect("connecting to hook socket failed");
+
+        daemon.stop().await.expect("final drain failed");
+
+        let mut buffer = [0u8; 64];
+        let result = tokio::time::timeout(Duration::from_secs(5), idle.read(&mut buffer))
+            .await
+            .expect("idle connection must be closed at shutdown");
+        // EOF or a reset both mean "closed"; data would be a protocol bug.
+        match result {
+            Ok(read) => assert_eq!(read, 0, "idle connection must see EOF, not data"),
+            Err(err) => assert_eq!(err.kind(), std::io::ErrorKind::ConnectionReset),
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(30), test)
+        .await
+        .expect("test timed out");
+}
+
+#[tokio::test]
 async fn bind_refuses_to_take_over_a_live_daemons_socket() {
     // A second daemon (or a failed second startup) must not unlink the
     // socket of a running daemon: that would silently sever every later

--- a/tests/serve_daemon.rs
+++ b/tests/serve_daemon.rs
@@ -386,6 +386,54 @@ async fn oversized_hook_request_is_rejected_with_bounded_memory() {
 }
 
 #[tokio::test]
+async fn non_utf8_hook_request_gets_a_malformed_request_response() {
+    // Clients on the hook socket are not necessarily hestia: a stray
+    // process can write arbitrary bytes. Invalid UTF-8 must reach the
+    // documented "malformed request" error response instead of tearing the
+    // connection down without an answer.
+    let test = async {
+        let fake = FakeGha::start().await;
+        let http = reqwest::Client::new();
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("hook.sock");
+
+        let daemon = RunningDaemon::start(
+            socket.clone(),
+            None,
+            pipeline_context(&fake, &http, StoreDatabase::new("/nonexistent/db.sqlite")),
+        )
+        .await;
+
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+        let mut stream = tokio::net::UnixStream::connect(&socket)
+            .await
+            .expect("connecting to hook socket failed");
+        // Invalid UTF-8 (0xC3 with no continuation byte), newline-terminated.
+        stream
+            .write_all(b"\xc3garbage\n")
+            .await
+            .expect("writing garbage failed");
+
+        let mut response = vec![0u8; 4096];
+        let read = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut response))
+            .await
+            .expect("daemon must answer, not hang")
+            .expect("reading response failed");
+        let text = String::from_utf8_lossy(&response[..read]);
+        assert!(
+            text.contains("\"ok\":false") && text.contains("malformed request"),
+            "non-UTF-8 garbage must get the malformed-request error, got: {text:?}"
+        );
+
+        drop(stream);
+        let _ = daemon.stop().await;
+    };
+    tokio::time::timeout(Duration::from_secs(30), test)
+        .await
+        .expect("test timed out");
+}
+
+#[tokio::test]
 async fn drain_cli_binary_reports_stats_and_exits_zero() {
     let Some(store) = ScratchStore::create() else {
         return;

--- a/tests/serve_daemon.rs
+++ b/tests/serve_daemon.rs
@@ -357,6 +357,40 @@ async fn failed_drain_keeps_paths_buffered_for_retry() {
 }
 
 #[tokio::test]
+async fn bind_refuses_to_take_over_a_live_daemons_socket() {
+    // A second daemon (or a failed second startup) must not unlink the
+    // socket of a running daemon: that would silently sever every later
+    // hook and drain client from it.
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("hook.sock");
+
+    let daemon = RunningDaemon::start(
+        socket.clone(),
+        None,
+        pipeline_context(&fake, &http, StoreDatabase::new("/nonexistent/db.sqlite")),
+    )
+    .await;
+
+    let second = Daemon::bind(
+        &socket,
+        None,
+        pipeline_context(&fake, &http, StoreDatabase::new("/nonexistent/db.sqlite")),
+        AccessLog::new(),
+        ManifestStore::new(),
+    );
+    assert!(
+        second.is_err(),
+        "binding over a live daemon's socket must fail"
+    );
+
+    let status = daemon.request(&Request::Status).await;
+    assert_eq!(status.buffered, Some(0));
+    let _ = daemon.stop().await;
+}
+
+#[tokio::test]
 async fn oversized_hook_request_is_rejected_with_bounded_memory() {
     // The hook socket is reachable by anything that can open the socket
     // file (and clients are not necessarily hestia: a stray process can

--- a/tests/serve_daemon.rs
+++ b/tests/serve_daemon.rs
@@ -357,6 +357,36 @@ async fn failed_drain_keeps_paths_buffered_for_retry() {
 }
 
 #[tokio::test]
+async fn bind_creates_a_private_socket_directory() {
+    // The default socket path lives under world-writable /tmp and the
+    // protocol has no authentication: the directory hestia creates must
+    // not be accessible to other local users.
+    use std::os::unix::fs::PermissionsExt as _;
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("private").join("hook.sock");
+
+    let daemon = RunningDaemon::start(
+        socket.clone(),
+        None,
+        pipeline_context(&fake, &http, StoreDatabase::new("/nonexistent/db.sqlite")),
+    )
+    .await;
+
+    let mode = std::fs::metadata(socket.parent().unwrap())
+        .unwrap()
+        .permissions()
+        .mode();
+    assert_eq!(
+        mode & 0o777,
+        0o700,
+        "socket directory must be private to the daemon's user"
+    );
+    let _ = daemon.stop().await;
+}
+
+#[tokio::test]
 async fn shutdown_closes_idle_connections_and_rejects_late_adds() {
     // Connection tasks must not outlive the daemon: an idle client gets
     // EOF at shutdown instead of a forever-open socket, and an Add after

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -346,12 +346,6 @@ async fn narinfo_matches_nix_path_info_oracle() {
                     .to_string_lossy()
                     .into_owned()
             })
-            .filter(|name| {
-                // The oracle includes the self-reference for toFile paths;
-                // narinfo convention is to list it too, but hestia stores
-                // references without self (the manifest drops self-edges).
-                *name != top.file_name().unwrap().to_string_lossy()
-            })
             .collect();
         oracle_refs.sort();
         let mut actual_refs: Vec<String> = narinfo["References"]

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -775,8 +775,8 @@ async fn transient_blob_failure_is_retried_transparently() {
         let manifest = push_paths(&fake, &http, &store, &[&fixture]).await;
         let substituter = RunningSubstituter::start(&fake, &http, &store).await;
 
-        // Request the NAR directly (not via narinfo) so the background
-        // prefetch cannot race with the injected failure.
+        // Request the NAR directly: the narinfo round-trip is irrelevant
+        // here, the injected failure targets the pack Range read.
         let entry = &manifest.paths[&path_hash_of(&fixture)];
         let nar_url = format!("nar/{}.nar", entry.nar_hash.to_hex());
 

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -17,7 +17,7 @@ use hestia::manifest::{Hash32, Manifest, PathHash};
 use hestia::pipeline::{AccessLog, now_unix};
 use hestia::substituter::{ManifestStore, Substituter};
 
-use support::common::{TEST_ROOT_KEY, pipeline_context, to_path_set};
+use support::common::{TEST_ROOT_KEY, pipeline_context, store_entry, to_path_set};
 use support::fake_gha::FakeGha;
 use support::store::ScratchStore;
 
@@ -840,6 +840,121 @@ async fn nar_downloads_record_access_without_a_narinfo_hit() {
             substituter.access_log.snapshot().contains(&path_hash),
             "a served NAR must be recorded as an access (GC liveness signal)"
         );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn concurrent_gc_repack_triggers_manifest_reload() {
+    timed(async {
+        // A nightly `hestia gc` repack moves live chunks into a new pack,
+        // commits the manifest, and deletes the old pack — while a running
+        // daemon still serves the pre-repack view. The NAR handler must
+        // reload the manifest on the pack miss and serve from the new pack
+        // instead of 404ing every affected path for the rest of the job.
+        let Some(store) = ScratchStore::create() else {
+            return;
+        };
+        let fixture = store.add_fixture("repack-reload", 157);
+
+        let fake = FakeGha::start().await;
+        let http = reqwest::Client::new();
+        let manifest = push_paths(&fake, &http, &store, &[&fixture]).await;
+        let twirp = fake.twirp(&http);
+
+        // Substituter serving the pre-repack manifest, wired with the same
+        // reload hook hestia serve installs.
+        let manifest_store = ManifestStore::new();
+        manifest_store.set(manifest.clone());
+        let reload_store = manifest_store.clone();
+        let reload_twirp = twirp.clone();
+        let reload_http = http.clone();
+        let substituter = Substituter::new(
+            store.database().store_dir().clone(),
+            manifest_store.clone(),
+            AccessLog::new(),
+            twirp.clone(),
+            http.clone(),
+        )
+        .with_manifest_reload(std::sync::Arc::new(move || {
+            let twirp = reload_twirp.clone();
+            let http = reload_http.clone();
+            let manifest_store = reload_store.clone();
+            Box::pin(async move {
+                let save = hestia::gha::savemutable::SaveMutable::new(
+                    &twirp,
+                    &http,
+                    hestia::pipeline::MANIFEST_PREFIX,
+                );
+                if let Ok(Some(entry)) = save.load().await {
+                    manifest_store.set_version_if_newer(
+                        hestia::pipeline::decode_manifest_or_empty(&entry.data),
+                        entry.index,
+                    );
+                }
+            })
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, substituter.into_router())
+                .await
+                .unwrap();
+        });
+
+        // Simulate the gc repack: copy the pack bytes into a new pack (one
+        // padding byte appended so the content hash changes; chunk offsets
+        // are unaffected), rewrite the manifest, delete the old pack.
+        let old_pack = *manifest.packs.keys().next().expect("one pack uploaded");
+        let url = match twirp
+            .get_download_url(&pack_cache_key(&old_pack), &[])
+            .await
+            .unwrap()
+        {
+            hestia::gha::twirp::DownloadUrl::Hit { url, .. } => url,
+            hestia::gha::twirp::DownloadUrl::Miss => panic!("pack must exist"),
+        };
+        let mut pack_bytes = hestia::gha::blob::get(&http, &url, None)
+            .await
+            .unwrap()
+            .to_vec();
+        pack_bytes.push(0);
+        let new_pack = hestia::manifest::PackHash::digest(&pack_bytes);
+        store_entry(&twirp, &http, &pack_cache_key(&new_pack), &pack_bytes).await;
+
+        let mut repacked = manifest.clone();
+        let info = repacked.packs.remove(&old_pack).unwrap();
+        repacked.packs.insert(new_pack, info);
+        for location in repacked.chunks.values_mut() {
+            assert_eq!(location.pack, old_pack);
+            location.pack = new_pack;
+        }
+        let save = hestia::gha::savemutable::SaveMutable::new(
+            &twirp,
+            &http,
+            hestia::pipeline::MANIFEST_PREFIX,
+        );
+        save.save(|_| Ok(repacked.encode().expect("manifest encodes")))
+            .await
+            .expect("committing the repacked manifest failed");
+        fake.evict(&http, &pack_cache_key(&old_pack)).await;
+
+        // The served view is stale (still points at the deleted pack), but
+        // the NAR request must succeed via the reload.
+        let entry = &manifest.paths[&path_hash_of(&fixture)];
+        let nar_url = format!("{base_url}/nar/{}.nar", entry.nar_hash.to_hex());
+        let response = http.get(&nar_url).send().await.unwrap();
+        assert_eq!(
+            response.status(),
+            200,
+            "a pack deleted by a concurrent gc repack must trigger a manifest \
+             reload, not a 404"
+        );
+        assert_eq!(
+            Hash32::digest(response.bytes().await.unwrap()),
+            entry.nar_hash
+        );
+        server.abort();
     })
     .await;
 }

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -265,8 +265,16 @@ async fn narinfo_miss_is_404() {
         // Misses are not liveness signals.
         assert!(substituter.access_log.snapshot().is_empty());
 
-        // Malformed requests are 404 too (never 500).
-        for path in ["zzz.narinfo", "x", "nar/zzz.nar", "nar/x"] {
+        // Malformed requests are 404 too (never 400/500) — including a
+        // query string the NarQuery extractor cannot deserialize: every
+        // NAR failure must let Nix fall through to the next substituter.
+        for path in [
+            "zzz.narinfo",
+            "x",
+            "nar/zzz.nar",
+            "nar/x",
+            "nar/zzz.nar?hash=a&hash=b",
+        ] {
             let response = substituter.get(&http, path).await;
             assert_eq!(response.status(), 404, "GET /{path}");
         }

--- a/tests/support/common.rs
+++ b/tests/support/common.rs
@@ -19,9 +19,10 @@ use super::fake_gha::FakeGha;
 /// Root key (branch + system) used by all pipeline-driving tests.
 pub const TEST_ROOT_KEY: &str = "main-test-system";
 
-/// Pipeline context against the fake backend. The default upstream filter
-/// passes scratch-store paths because they are unsigned, just like locally
-/// built paths in production.
+/// Pipeline context against the fake backend. Uses the default upstream
+/// key set (production only enables filtering with
+/// --upstream-cache-filter); scratch-store paths pass either way because
+/// they are unsigned, just like locally built paths.
 pub fn pipeline_context(
     fake: &FakeGha,
     http: &reqwest::Client,

--- a/tests/support/fake_gha.rs
+++ b/tests/support/fake_gha.rs
@@ -22,7 +22,10 @@
 //!   connection dropped mid-body (Azure timeout / connection reset).
 //! * `POST /test/stale-lookups/{0|1}`: download lookups hide the newest
 //!   matching entry (eventual consistency: a just-finalized entry is not
-//!   visible yet).
+//!   visible yet). `/test/stale-lookups-for/{n}` limits it to the next
+//!   `n` lookups.
+//! * `POST /test/dead-sigs/{n}`: the next `n` signed URLs are minted
+//!   already expired (transfers on them get 403).
 //! * `POST /test/exhaust-quota-after/{n}`: the next `n` CreateCacheEntry
 //!   calls succeed, every later one gets a `resource_exhausted` Twirp error
 //!   (the 10 GB repository cache quota is full).
@@ -86,9 +89,13 @@ struct Inner {
     creates_until_quota: Option<u64>,
     /// Number of upcoming blob GETs whose connection gets dropped mid-body.
     blob_read_failures: u64,
-    /// When set, download lookups pretend the newest matching entry does
+    /// While > 0, download lookups pretend the newest matching entry does
     /// not exist yet (simulates the real service's eventual consistency).
-    stale_lookups: bool,
+    /// Decremented per lookup; `u64::MAX` is effectively "until turned off".
+    stale_lookups_remaining: u64,
+    /// Number of upcoming signed URLs that are minted already-expired
+    /// (simulates a SAS URL that expires between issuance and use).
+    dead_sigs_remaining: u64,
 }
 
 impl Inner {
@@ -103,7 +110,11 @@ impl Inner {
     fn new_sig(&mut self) -> String {
         self.next_sig += 1;
         let sig = format!("sig{}", self.next_sig);
-        self.valid_sigs.insert(sig.clone());
+        if self.dead_sigs_remaining > 0 {
+            self.dead_sigs_remaining -= 1;
+        } else {
+            self.valid_sigs.insert(sig.clone());
+        }
         sig
     }
 
@@ -239,9 +250,12 @@ async fn twirp_download_url(State(state): State<AppState>, body: Bytes) -> Respo
         matching.sort_by_key(|e| std::cmp::Reverse(e.created_at));
         // Eventual-consistency injection: the newest entry is not visible
         // yet, so the lookup returns the previous one (or misses).
-        let skip = usize::from(inner.stale_lookups);
+        let skip = usize::from(inner.stale_lookups_remaining > 0);
         matching.get(skip).copied().cloned()
     });
+    if inner.stale_lookups_remaining > 0 && inner.stale_lookups_remaining < u64::MAX {
+        inner.stale_lookups_remaining -= 1;
+    }
 
     match matched {
         None => Json(json!({ "ok": false })).into_response(),
@@ -533,8 +547,21 @@ async fn test_fail_blob_reads(State(state): State<AppState>, Path(reads): Path<u
 }
 
 async fn test_stale_lookups(State(state): State<AppState>, Path(on): Path<u8>) -> Response {
-    state.inner.lock().unwrap().stale_lookups = on != 0;
+    state.inner.lock().unwrap().stale_lookups_remaining = if on != 0 { u64::MAX } else { 0 };
     Json(json!({ "stale_lookups": on != 0 })).into_response()
+}
+
+async fn test_stale_lookups_for(
+    State(state): State<AppState>,
+    Path(lookups): Path<u64>,
+) -> Response {
+    state.inner.lock().unwrap().stale_lookups_remaining = lookups;
+    Json(json!({ "stale_lookups_remaining": lookups })).into_response()
+}
+
+async fn test_dead_sigs(State(state): State<AppState>, Path(sigs): Path<u64>) -> Response {
+    state.inner.lock().unwrap().dead_sigs_remaining = sigs;
+    Json(json!({ "dead_sigs_remaining": sigs })).into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -572,7 +599,8 @@ impl FakeGha {
             twirp_calls_until_401: None,
             creates_until_quota: None,
             blob_read_failures: 0,
-            stale_lookups: false,
+            stale_lookups_remaining: 0,
+            dead_sigs_remaining: 0,
         }));
         let state = AppState {
             inner: Arc::clone(&inner),
@@ -598,6 +626,11 @@ impl FakeGha {
             )
             .route("/test/fail-blob-reads/{reads}", post(test_fail_blob_reads))
             .route("/test/stale-lookups/{on}", post(test_stale_lookups))
+            .route(
+                "/test/stale-lookups-for/{lookups}",
+                post(test_stale_lookups_for),
+            )
+            .route("/test/dead-sigs/{sigs}", post(test_dead_sigs))
             .with_state(state);
 
         let task = tokio::spawn(async move {
@@ -706,6 +739,23 @@ impl FakeGha {
     pub async fn set_stale_lookups(&self, http: &reqwest::Client, on: bool) {
         let url = format!("{}/test/stale-lookups/{}", self.base_url, u8::from(on));
         let response = http.post(&url).send().await.expect("stale-lookups request");
+        assert!(response.status().is_success());
+    }
+
+    /// Like [`Self::set_stale_lookups`], but only for the next `lookups`
+    /// download lookups (lets tests interleave a lagging read with a
+    /// caught-up one inside a single client call).
+    pub async fn set_stale_lookups_for(&self, http: &reqwest::Client, lookups: u64) {
+        let url = format!("{}/test/stale-lookups-for/{lookups}", self.base_url);
+        let response = http.post(&url).send().await.expect("stale-lookups request");
+        assert!(response.status().is_success());
+    }
+
+    /// Mint the next `sigs` signed URLs already expired (a SAS URL that
+    /// dies between issuance and use).
+    pub async fn dead_sigs(&self, http: &reqwest::Client, sigs: u64) {
+        let url = format!("{}/test/dead-sigs/{sigs}", self.base_url);
+        let response = http.post(&url).send().await.expect("dead-sigs request");
         assert!(response.status().is_success());
     }
 }

--- a/tests/support/fake_gha.rs
+++ b/tests/support/fake_gha.rs
@@ -61,7 +61,8 @@ struct Entry {
 }
 
 /// One recorded blob download (used by tests asserting fetch behavior,
-/// e.g. "prefetched chunks are not fetched twice").
+/// e.g. that repeated NAR requests reuse cached chunks instead of
+/// re-reading packs).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlobRequest {
     /// Cache key of the entry the blob belongs to (e.g. `pack-<hex>`).

--- a/tests/support/fake_gha.rs
+++ b/tests/support/fake_gha.rs
@@ -422,6 +422,10 @@ struct ListQuery {
     page: Option<u64>,
     #[serde(default)]
     per_page: Option<u64>,
+    #[serde(default)]
+    sort: Option<String>,
+    #[serde(default)]
+    direction: Option<String>,
 }
 
 fn rest_entry_json(entry: &Entry) -> serde_json::Value {
@@ -444,7 +448,16 @@ async fn rest_list(State(state): State<AppState>, Query(query): Query<ListQuery>
         .iter()
         .filter(|e| e.finalized && e.key.starts_with(&query.key))
         .collect();
-    matching.sort_by_key(|e| std::cmp::Reverse(e.last_accessed_at));
+    // The production client relies on the immutable created_at order for
+    // stable pagination; honoring the parameters here means dropping them
+    // from list_caches would fail tests instead of silently reintroducing
+    // the skip/duplicate pagination hazard.
+    match (query.sort.as_deref(), query.direction.as_deref()) {
+        (Some("created_at"), Some("asc")) => matching.sort_by_key(|e| e.created_at),
+        // GitHub's documented default: last_accessed_at descending (the
+        // mutable LRU order).
+        _ => matching.sort_by_key(|e| std::cmp::Reverse(e.last_accessed_at)),
+    }
 
     let per_page = query.per_page.unwrap_or(30).max(1) as usize;
     let page = query.page.unwrap_or(1).max(1) as usize;

--- a/tests/support/fake_gha.rs
+++ b/tests/support/fake_gha.rs
@@ -13,7 +13,7 @@
 //! Test-only injection endpoints simulate the failure modes GitHub will
 //! throw at us in production:
 //!
-//! * `POST /test/evict/{key}`: LRU eviction of an entry.
+//! * `POST /test/evict?key=...`: LRU eviction of an entry.
 //! * `POST /test/expire-urls`: invalidate all previously issued signed URLs
 //!   (subsequent transfers get 403, like an expired SAS URL).
 //! * `POST /test/expire-token-after/{n}`: the next `n` Twirp calls succeed,
@@ -485,9 +485,9 @@ async fn rest_delete(State(state): State<AppState>, Query(query): Query<ListQuer
 // Test-only injection endpoints
 // ---------------------------------------------------------------------------
 
-async fn test_evict(State(state): State<AppState>, Path(key): Path<String>) -> Response {
+async fn test_evict(State(state): State<AppState>, Query(query): Query<ListQuery>) -> Response {
     let mut inner = state.inner.lock().unwrap();
-    let removed = inner.remove_by_key(&key);
+    let removed = inner.remove_by_key(&query.key);
     Json(json!({ "evicted": removed.len() })).into_response()
 }
 
@@ -573,7 +573,7 @@ impl FakeGha {
                 "/repos/{owner}/{repo}/actions/caches",
                 get(rest_list).delete(rest_delete),
             )
-            .route("/test/evict/{key}", post(test_evict))
+            .route("/test/evict", post(test_evict))
             .route("/test/expire-urls", post(test_expire_urls))
             .route(
                 "/test/expire-token-after/{calls}",
@@ -630,10 +630,24 @@ impl FakeGha {
     }
 
     /// Simulate LRU eviction of `key` (entry and blob disappear).
+    ///
+    /// The key travels as a query parameter (like the real REST delete):
+    /// manifest keys contain `#`, which interpolated into a URL path would
+    /// become a never-transmitted fragment and silently evict nothing.
     pub async fn evict(&self, http: &reqwest::Client, key: &str) {
-        let url = format!("{}/test/evict/{key}", self.base_url);
-        let response = http.post(&url).send().await.expect("evict request");
+        let url = format!("{}/test/evict", self.base_url);
+        let response = http
+            .post(&url)
+            .query(&[("key", key)])
+            .send()
+            .await
+            .expect("evict request");
         assert!(response.status().is_success());
+        let body: serde_json::Value = response.json().await.expect("evict response");
+        assert!(
+            body["evicted"].as_u64().unwrap_or(0) > 0,
+            "evict({key}) removed nothing"
+        );
     }
 
     /// Invalidate all previously issued signed URLs (simulates SAS expiry).

--- a/tests/support/sim.rs
+++ b/tests/support/sim.rs
@@ -2,9 +2,11 @@
 //!
 //! GC logic does not depend on a Nix store: it operates on manifests and
 //! pack blobs. This module fabricates store paths with deterministic
-//! contents and pushes them through the *real* production code (chunker,
-//! pack builder, pack upload, SaveMutable manifest commit) against the fake
-//! GHA backend — no nix tooling required, so these tests run everywhere
+//! contents and pushes them with the real chunker, pack builder, pack
+//! upload, and SaveMutable manifest commit against the fake GHA backend.
+//! (Pack assembly is simplified versus the drain pipeline: one pack per
+//! push via PackBuilder::add, no target-size splitting.) No nix tooling
+//! required, so these tests run everywhere
 //! (including the Nix build sandbox) and a 30-day history simulates in
 //! seconds.
 //!

--- a/tests/support/sim.rs
+++ b/tests/support/sim.rs
@@ -240,7 +240,14 @@ impl SimCache {
                         .map_err(|err| GhaError::InvalidResponse(err.to_string()))?,
                     None => Manifest::new(),
                 };
-                base.merge(delta.clone())
+                // Mirror production's drain commit (pipeline.rs): fold the
+                // drain-start snapshot in as well, because the dedup
+                // decisions above were based on it and `existing` can be a
+                // stale read. This merge is also how a drain racing GC can
+                // resurrect GC-dropped paths, so the GC suite's dangling-
+                // reference checks depend on the sim performing it too.
+                base.merge(current.clone())
+                    .merge(delta.clone())
                     .encode()
                     .map_err(|err| GhaError::InvalidResponse(err.to_string()))
             })


### PR DESCRIPTION
A deep review pass over the whole codebase. 82 commits, grouped roughly by subsystem. The branch was tested as a whole: full test suite, clippy, fmt.

The fixes worth calling out:

- gc: a repack that reproduces an existing pack byte-identically dropped the tier promotion, so consolidation could loop forever re-downloading the same packs every run
- pipeline: every job committed a redundant manifest version at teardown because the final drain re-committed just to bump the root clock
- serve: a stalled cache API at startup blocked the listener binds, which failed the whole job once the action's 30s readiness poll gave up
- action: Intel macOS runners got a confusing HTTP 404 instead of being told there is no release binary for their platform

The rest is smaller stuff: hardening against corrupt cache blobs, bounded caches, shutdown races, stale docs and comments. Each commit message has the details.