### PR TITLE
manifest: union roots per workflow run instead of by time

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ detected (override with `--system`). Anything reachable from a root survives
 garbage collection; everything else is deleted once it falls out of the push
 grace period.
 
+Matrix jobs of one workflow run share their root: their closures are
+unioned, however far apart the jobs finish. A new run replaces the root, so
+old closures become collectable.
+
 Pull requests get their own roots (`123/merge-x86_64-linux`), so a PR cannot
 evict paths the default branch still needs. Roots that stop being updated
 (merged PRs, deleted branches) expire after `--root-ttl` (14 days by

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,4 +54,5 @@ Always exits 0 (a failing post-build-hook would fail the build).
 | `GITHUB_REPOSITORY` | gc | `owner/repo`, set automatically in workflows. |
 | `GITHUB_API_URL` | gc | REST API base URL (override for GHES). |
 | `GITHUB_REF_NAME` | serve | Default for `--branch`. |
+| `GITHUB_RUN_ID` | serve | Roots written by the same workflow run merge by union (matrix legs); different runs replace each other's root. |
 | `OUT_PATHS` | hook | Set by Nix when invoking the post-build-hook. |

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1344,6 +1344,7 @@ mod tests {
                 Root {
                     paths: paths.iter().map(|seed| path_hash(*seed)).collect(),
                     updated,
+                    run_id: None,
                 },
             );
             self
@@ -2116,6 +2117,7 @@ mod tests {
             Root {
                 paths: [path_hash(1), path_hash(3)].into_iter().collect(),
                 updated: NOW,
+                run_id: None,
             },
         );
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -15,10 +15,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub use harmonia_file_core::{Directory, FileSystemObject, FileTree, Regular, Symlink};
 pub use harmonia_store_path::{StorePath, StorePathHash};
 
-/// Window inside which two root updates are considered concurrent and get
-/// unioned instead of newest-wins (10 minutes).
-pub(crate) const ROOT_UNION_WINDOW_SECS: u64 = 600;
-
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("failed to encode manifest: {0}")]
@@ -269,6 +265,10 @@ pub struct Root {
     /// When this root was last replaced (unix seconds).
     #[serde(default)]
     pub updated: u64,
+    /// Workflow run that wrote this root (`$GITHUB_RUN_ID`); `None` for
+    /// local builds and manifests written before this field existed.
+    #[serde(default)]
+    pub run_id: Option<String>,
 }
 
 /// The top-level manifest document.
@@ -381,15 +381,16 @@ impl PackInfo {
 impl Root {
     /// Merge two versions of the same root.
     ///
-    /// Roots updated within [`ROOT_UNION_WINDOW_SECS`] of each other are
-    /// concurrent (e.g. matrix jobs of one workflow): union their paths.
-    /// Otherwise the newer root replaces the older one -- that is what makes
-    /// old closures unreachable and therefore collectable.
+    /// Roots from the same workflow run are concurrent (matrix legs of one
+    /// workflow, which can drain hours apart): union their paths.
+    /// Otherwise the newer root replaces the older one -- that is what
+    /// makes old closures unreachable and therefore collectable.
     fn merge(a: Self, b: Self) -> Self {
-        if a.updated.abs_diff(b.updated) <= ROOT_UNION_WINDOW_SECS {
+        if a.run_id.is_some() && a.run_id == b.run_id {
             Root {
                 paths: a.paths.into_iter().chain(b.paths).collect(),
                 updated: a.updated.max(b.updated),
+                run_id: a.run_id,
             }
         } else if a.updated > b.updated {
             a
@@ -929,6 +930,7 @@ mod tests {
             Root {
                 paths: BTreeSet::from([path_hash(1), path_hash(2)]),
                 updated: 5000,
+                run_id: None,
             },
         );
         manifest
@@ -1288,25 +1290,41 @@ mod tests {
     }
 
     #[test]
-    fn merge_roots_unions_within_window_replaces_outside() {
-        let make_root = |paths: &[u8], updated: u64| Root {
+    fn merge_roots_unions_same_run_replaces_other_runs() {
+        let make_root = |paths: &[u8], updated: u64, run_id: Option<&str>| Root {
             paths: paths.iter().map(|&seed| path_hash(seed)).collect(),
             updated,
+            run_id: run_id.map(str::to_string),
         };
 
-        // Within 10 minutes: union (concurrent matrix jobs).
-        let merged = Root::merge(make_root(&[1, 2], 1000), make_root(&[3], 1000 + 599));
+        // Same workflow run: union, however far apart the drains are.
+        let merged = Root::merge(
+            make_root(&[1, 2], 1000, Some("run-1")),
+            make_root(&[3], 1000 + 7200, Some("run-1")),
+        );
         assert_eq!(merged.paths.len(), 3);
-        assert_eq!(merged.updated, 1599);
+        assert_eq!(merged.updated, 8200);
+        assert_eq!(merged.run_id.as_deref(), Some("run-1"));
 
-        // Outside 10 minutes: newer replaces older (old closure dies).
-        let merged = Root::merge(make_root(&[1, 2], 1000), make_root(&[3], 1000 + 601));
+        // Different run: newer replaces, even seconds later.
+        let merged = Root::merge(
+            make_root(&[1, 2], 1000, Some("run-1")),
+            make_root(&[3], 1001, Some("run-2")),
+        );
         assert_eq!(merged.paths.len(), 1);
         assert!(merged.paths.contains(&path_hash(3)));
 
-        // Order independence of replacement.
-        let merged = Root::merge(make_root(&[3], 1000 + 601), make_root(&[1, 2], 1000));
+        // No run id (local builds): never union.
+        let merged = Root::merge(make_root(&[1, 2], 1000, None), make_root(&[3], 1001, None));
         assert_eq!(merged.paths.len(), 1);
+
+        // Order independence of replacement.
+        let merged = Root::merge(
+            make_root(&[3], 1001, Some("run-2")),
+            make_root(&[1, 2], 1000, Some("run-1")),
+        );
+        assert_eq!(merged.paths.len(), 1);
+        assert!(merged.paths.contains(&path_hash(3)));
     }
 
     #[test]
@@ -1332,6 +1350,7 @@ mod tests {
             Root {
                 paths: BTreeSet::from([path_hash(1), path_hash(98)]), // 98: evicted root member
                 updated: 0,
+                run_id: None,
             },
         );
 
@@ -1360,6 +1379,7 @@ mod tests {
             Root {
                 paths: BTreeSet::from([path_hash(1)]),
                 updated: 0,
+                run_id: None,
             },
         );
         assert_eq!(manifest.reachable().len(), 2);
@@ -1379,6 +1399,7 @@ mod tests {
             Root {
                 paths: BTreeSet::from([path_hash(1)]),
                 updated: 0,
+                run_id: None,
             },
         );
 
@@ -1485,8 +1506,17 @@ mod tests {
             (
                 proptest::collection::btree_set(arb_path_hash(), 0..4),
                 0u64..3000,
+                prop_oneof![
+                    Just(None),
+                    Just(Some("run-1".to_string())),
+                    Just(Some("run-2".to_string())),
+                ],
             )
-                .prop_map(|(paths, updated)| Root { paths, updated })
+                .prop_map(|(paths, updated, run_id)| Root {
+                    paths,
+                    updated,
+                    run_id,
+                })
         }
 
         fn arb_manifest() -> impl Strategy<Value = Manifest> {
@@ -1504,10 +1534,11 @@ mod tests {
                 })
         }
 
-        /// Manifest without roots: `Root::merge`'s concurrency window makes
-        /// root merging inherently order-dependent for 3+ way merges (a
-        /// documented limitation), so the associativity law is stated for
-        /// the path/chunk/pack maps only.
+        /// Manifest without roots: `Root::merge` mixes union (same run)
+        /// and replacement (different run), which is inherently
+        /// order-dependent for 3+ way merges (a documented limitation), so
+        /// the associativity law is stated for the path/chunk/pack maps
+        /// only.
         fn arb_rootless_manifest() -> impl Strategy<Value = Manifest> {
             arb_manifest().prop_map(|mut manifest| {
                 manifest.roots.clear();

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -177,6 +177,8 @@ pub struct PipelineContext {
     pub expand_closure: bool,
     /// Manifest root key, e.g. `main-x86_64-linux`.
     pub root_key: String,
+    /// Workflow run id (`$GITHUB_RUN_ID`); see [`Root::merge`].
+    pub run_id: Option<String>,
     /// SaveMutable family prefix (always [`MANIFEST_PREFIX`] in production;
     /// tests use distinct prefixes to isolate scenarios).
     pub manifest_prefix: String,
@@ -507,15 +509,18 @@ impl PipelineContext {
             Root {
                 paths: root_paths,
                 updated: now,
+                run_id: self.run_id.clone(),
             },
         );
 
         // Skip commits that would only refresh the root's `updated` clock:
         // the access log is never cleared and the SIGTERM final drain runs
         // unconditionally, so otherwise every job that substituted a path
-        // burns a redundant manifest version at teardown. Only skip while
-        // the committed clock is recent: it drives root-TTL liveness in GC
-        // and must still be refreshed on long-lived daemons.
+        // burns a redundant manifest version at teardown. Only skip when
+        // the committed root comes from this very run: a CI job lives far
+        // shorter than the root TTL, so the stale clock cannot expire the
+        // root. Without a run id (local builds) always commit, because the
+        // clock drives root-TTL liveness in GC.
         let refresh_only = {
             let mut probe = current.clone().merge(delta.clone());
             match (
@@ -523,8 +528,7 @@ impl PipelineContext {
                 current.roots.get(&self.root_key),
             ) {
                 (Some(probed), Some(committed))
-                    if now.saturating_sub(committed.updated)
-                        <= crate::manifest::ROOT_UNION_WINDOW_SECS =>
+                    if self.run_id.is_some() && committed.run_id == self.run_id =>
                 {
                     probed.updated = committed.updated;
                     probe == current

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -555,6 +555,9 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         upstream,
         expand_closure: !args.no_closure,
         root_key: root_key.clone(),
+        run_id: std::env::var("GITHUB_RUN_ID")
+            .ok()
+            .filter(|id| !id.is_empty()),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         pack_target_size: pipeline::PACK_TARGET_SIZE,
         // Replaced by Daemon::bind with the daemon's shared ManifestStore.

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -538,9 +538,10 @@ async fn narinfo_hits_join_the_root_at_next_drain() {
         );
 
         // A later drain (no new pushed paths) replaces the root with
-        // pushed ∪ accessed. Use a timestamp outside the root union window so
-        // the new root *replaces* the old one instead of merging with it.
-        let ctx = pipeline_context(&fake, &http, store.database());
+        // pushed ∪ accessed. A different run id makes the new root
+        // *replace* the old one instead of merging with it.
+        let mut ctx = pipeline_context(&fake, &http, store.database());
+        ctx.run_id = Some("another-run".to_string());
         let later = now_unix() + 3600;
         let stats = ctx
             .run(BTreeSet::new(), substituter.access_log.snapshot(), later)

--- a/tests/support/common.rs
+++ b/tests/support/common.rs
@@ -45,6 +45,7 @@ pub fn pipeline_context_with(
         upstream: UpstreamFilter::default(),
         expand_closure: true,
         root_key: TEST_ROOT_KEY.to_string(),
+        run_id: Some("test-run".to_string()),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         pack_target_size: PACK_TARGET_SIZE,
         publish: None,

--- a/tests/support/sim.rs
+++ b/tests/support/sim.rs
@@ -230,6 +230,7 @@ impl SimCache {
             Root {
                 paths: closure.iter().map(SimPath::path_hash).collect(),
                 updated: now,
+                run_id: None,
             },
         );
 


### PR DESCRIPTION
Matrix legs drain at job end and routinely finish more than 10 minutes apart, so the time-based union window replaced their roots instead of merging them; the faster leg's paths survived on push-TTL alone. Widening the window doesn't work either: on a busy branch a large window unions every successive closure and nothing becomes collectable.

Roots are now tagged with `GITHUB_RUN_ID`: roots from the same workflow run union (however far apart), different runs replace immediately, no run id (local builds, old manifests) never unions. The redundant-commit skip follows the same rule.

Known limit: two *different* workflows on the same branch replace each other's root (they used to union when draining within 10 min). Their paths stay protected by push-TTL as long as the workflow keeps running; if that ever bites, the fix is keying roots per workflow.