### PR TITLE
docs: explain the architecture with diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ detected (override with `--system`). Anything reachable from a root survives
 garbage collection; everything else is deleted once it falls out of the push
 grace period.
 
+Matrix jobs of one workflow run share their root: their closures are
+unioned, however far apart the jobs finish. A new run replaces the root, so
+old closures become collectable.
+
 Pull requests get their own roots (`123/merge-x86_64-linux`), so a PR cannot
 evict paths the default branch still needs. Roots that stop being updated
 (merged PRs, deleted branches) expire after `--root-ttl` (14 days by

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ The GC workflow takes one input: `dry-run` (plan only, delete nothing); see
 [`.github/workflows/gc.yml`](.github/workflows/gc.yml).
 
 Running the `hestia` binary yourself instead of using the action? See the
-[CLI reference](docs/cli.md).
+[CLI reference](docs/cli.md). How it all works under the hood:
+[architecture](docs/architecture.md).
 
 ## Security
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,100 @@
+# Architecture
+
+hestia turns the GitHub Actions cache into a Nix binary cache. On paper
+that is a poor fit: entries are write-once, keys can never be
+overwritten, and anything idle for a week gets evicted. Most of the
+design below exists to work around those three constraints.
+
+## Runtime view
+
+One daemon runs per job (`hestia serve`, started by the action's main
+step). It speaks to Nix on two channels: a unix socket for paths the
+job builds, and an HTTP listener serving the Nix binary cache protocol.
+
+### Serving
+
+![serving cached paths back to Nix](serve.svg)
+
+The action puts the daemon first in `extra-substituters`, so Nix asks
+it before cache.nixos.org. A narinfo hit answers straight from the
+manifest. A NAR request is more involved: the daemon fetches the path's
+chunks from pack blobs with HTTP Range reads, reassembles the NAR, and
+verifies its hash before the first byte leaves the process. Any failure
+along the way (evicted pack, missing chunk, hash mismatch) becomes a
+404 and Nix quietly falls through to the next substituter; the daemon
+would rather serve nothing than something corrupt.
+
+### Pushing
+
+![caching built paths](push.svg)
+
+Nix runs `hestia hook` after every successful build; the hook forwards
+the built paths over the unix socket and the daemon buffers them in
+memory. Uploads happen on drain: the action's post step, the idle
+timeout, or SIGTERM. A drain takes the buffered paths plus everything
+the substituter served, chunks the new ones, uploads packs, and commits
+a new manifest version.
+
+## Storage view
+
+![manifest and pack layout](architecture.svg)
+
+hestia creates only two kinds of cache entry: the manifest, and pack
+blobs.
+
+### Manifest
+
+The manifest is a single zstd-compressed CBOR document describing
+everything hestia has stored: four maps over paths, chunks, packs, and
+GC roots. The wire form is columnar (hash tables plus parallel arrays)
+to keep repeated 32-byte hashes from bloating the encoding; the
+in-memory form is plain B-tree maps optimized for merging.
+
+The cache is write-once, but the manifest must change. SaveMutable (a
+pattern borrowed from go-actions-cache) fakes mutability with a key
+sequence `m#1`, `m#2`, …: the highest index is the current version, and
+a writer claims the next index by reserving it. When two drains race,
+one loses the reservation, reloads the winner's version, merges its own
+changes on top, and tries again. All manifest merges are commutative
+and idempotent, so the outcome does not depend on who wins.
+
+A `PathEntry` holds what narinfo needs (store path, NAR hash and size,
+references) plus the path's file tree, where each file's contents is a
+list of chunk hashes. Chunk hashes resolve through the `chunks` map to
+a location: which pack, at what offset, how many bytes.
+
+### Packs
+
+Store paths are not cached one entry each. NARs are split into
+content-defined chunks (FastCDC, 16–256 KiB, 64 KiB average), each
+chunk is zstd-compressed individually, and compressed chunks are
+concatenated into pack blobs of about 64 MiB. The pack key is the
+SHA-256 of the blob, so identical packs dedup naturally and a finalized
+pack can be trusted to match its name.
+
+This layout buys three things. Chunking dedups across paths and
+versions: a rebuilt package shares most of its chunks with the previous
+build, so only the changed chunks are new bytes. Per-chunk compression
+keeps every chunk independently extractable: serving one path touches
+only its chunks, fetched with Range reads, not whole packs. And packing
+keeps the entry count low, which matters because both REST list
+operations and the eviction clock work per entry.
+
+### Roots and GC
+
+What stays alive is decided by roots, one per branch and system (e.g.
+`main-x86_64-linux`). Every drain rewrites its root to the paths the
+job pushed or accessed. Roots from the same workflow run merge by
+union, so matrix legs accumulate into one closure no matter how far
+apart they finish; a later run replaces the root, which is what lets
+old closures die. The full GC story (mark, sweep, repack, eviction
+touching) lives at the top of `src/gc.rs`.
+
+### Crash safety
+
+Order of operations does the heavy lifting. Packs are uploaded before
+the manifest version that references them, so a manifest never points
+at a blob that was never finalized. A crash between the two leaves an
+orphaned pack, which GC's orphan scan deletes later. The reverse
+hazard, GitHub evicting a pack the manifest still references, is
+handled at read time (404 → next substituter) and reconciled by GC.

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 660" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 1 L 9 5 L 0 9 z" fill="#5b6b7a"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 1 L 9 5 L 0 9 z" fill="#c2603e"/>
+    </marker>
+  </defs>
+
+  <style>
+    .h1 { font-size: 15px; font-weight: 600; fill: #2b3a49; }
+    .h2 { font-size: 13px; font-weight: 600; fill: #ffffff; }
+    .t  { font-size: 12px; fill: #3d4c5c; }
+    .ts { font-size: 11px; fill: #6b7a89; }
+    .m  { font-size: 11.5px; font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; fill: #34424f; }
+    .ms { font-size: 10.5px; font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; fill: #6b7a89; }
+    .mw { font-size: 11.5px; font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; fill: #ffffff; }
+    .edge { stroke: #5b6b7a; stroke-width: 1.4; fill: none; }
+    .edge-accent { stroke: #c2603e; stroke-width: 1.6; fill: none; }
+  </style>
+
+  <!-- ======================= GHA cache container ======================= -->
+  <rect x="20" y="20" width="1000" height="270" rx="10" fill="#f4f6f9" stroke="#cdd6e0"/>
+  <text x="40" y="48" class="h1">GitHub Actions cache &#8212; write-once blobs, LRU-evicted</text>
+
+  <!-- SaveMutable family -->
+  <text x="40" y="80" class="t">manifest versions (SaveMutable family &#8220;m&#8221;)</text>
+  <g>
+    <rect x="40"  y="92" width="74" height="36" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+    <text x="77"  y="114" class="m" text-anchor="middle">m#1</text>
+    <rect x="122" y="92" width="74" height="36" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+    <text x="159" y="114" class="m" text-anchor="middle">m#2</text>
+    <text x="222" y="114" class="t" text-anchor="middle">&#8230;</text>
+    <rect x="248" y="92" width="86" height="36" rx="6" fill="#3f5e85" stroke="#33506f"/>
+    <text x="291" y="114" class="mw" text-anchor="middle">m#N</text>
+    <text x="291" y="146" class="ts" text-anchor="middle">current = highest index</text>
+    <text x="60" y="170" class="ts">writers race for m#N+1;</text>
+    <text x="60" y="184" class="ts">the loser re-merges and retries</text>
+  </g>
+
+  <!-- Pack blobs -->
+  <text x="560" y="80" class="t">pack blobs (content-addressed, immutable)</text>
+  <g>
+    <rect x="560" y="92" width="200" height="36" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+    <text x="660" y="114" class="m" text-anchor="middle">pack-3fa92c&#8230;</text>
+    <rect x="560" y="136" width="200" height="36" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+    <text x="660" y="158" class="m" text-anchor="middle">pack-b21c07&#8230;</text>
+    <text x="560" y="196" class="ts">named after their SHA-256, about 64 MiB each</text>
+  </g>
+
+  <!-- Pack interior strip -->
+  <g>
+    <text x="560" y="232" class="t">a pack is just concatenated zstd frames, each fetchable on its own</text>
+    <rect x="560" y="242" width="100" height="30" fill="#dde7ee" stroke="#b9c5d2"/>
+    <rect x="660" y="242" width="150" height="30" fill="#f2d9cd" stroke="#c2603e" stroke-width="1.5"/>
+    <rect x="810" y="242" width="70"  height="30" fill="#dde7ee" stroke="#b9c5d2"/>
+    <rect x="880" y="242" width="120" height="30" fill="#dde7ee" stroke="#b9c5d2"/>
+    <text x="610" y="261" class="ms" text-anchor="middle">zstd(chunk)</text>
+    <text x="735" y="261" class="ms" text-anchor="middle">zstd(chunk)</text>
+    <text x="845" y="261" class="ms" text-anchor="middle">&#8230;</text>
+    <text x="940" y="261" class="ms" text-anchor="middle">zstd(chunk)</text>
+    <text x="660" y="285" class="ts">offset</text>
+    <line x1="660" y1="272" x2="660" y2="276" stroke="#c2603e" stroke-width="1.5"/>
+  </g>
+
+  <!-- manifest decode arrow -->
+  <path class="edge" d="M 291 128 C 291 220, 290 280, 290 318" marker-end="url(#arrow)"/>
+  <text x="310" y="260" class="ts">decode (zstd + CBOR)</text>
+
+  <!-- ======================= Manifest container ======================= -->
+  <rect x="20" y="320" width="1000" height="320" rx="10" fill="#fbfcfd" stroke="#cdd6e0"/>
+  <text x="40" y="348" class="h1">Manifest &#8212; one document, four maps</text>
+
+  <!-- roots table -->
+  <g>
+    <rect x="150" y="366" width="320" height="24" rx="4" fill="#3f5e85"/>
+    <text x="160" y="383" class="h2">roots &#8212; branch-system &#8594; Root</text>
+    <rect x="150" y="390" width="320" height="58" fill="#ffffff" stroke="#cdd6e0"/>
+    <text x="160" y="408" class="m">main-x86_64-linux</text>
+    <text x="160" y="424" class="ms">paths: {a1f9&#8230;, 77be&#8230;}  updated, run_id</text>
+    <text x="160" y="441" class="m">512/merge-aarch64-darwin &#8230;</text>
+  </g>
+
+  <!-- paths table -->
+  <g>
+    <rect x="150" y="470" width="320" height="24" rx="4" fill="#3f5e85"/>
+    <text x="160" y="487" class="h2">paths &#8212; PathHash &#8594; PathEntry</text>
+    <rect x="150" y="494" width="320" height="116" fill="#ffffff" stroke="#cdd6e0"/>
+    <text x="160" y="512" class="m">a1f9&#8230; &#8594; {</text>
+    <text x="174" y="528" class="ms">store_path, nar_hash, nar_size,</text>
+    <text x="174" y="544" class="ms">references: [other store paths],</text>
+    <text x="174" y="560" class="ms">file tree &#8594; [chunk, chunk, &#8230;],</text>
+    <text x="174" y="576" class="ms">last_pushed, last_reachable</text>
+    <text x="160" y="592" class="m">}</text>
+  </g>
+
+  <!-- chunks table -->
+  <g>
+    <rect x="530" y="366" width="330" height="24" rx="4" fill="#3f5e85"/>
+    <text x="540" y="383" class="h2">chunks &#8212; ChunkHash &#8594; ChunkLocation</text>
+    <rect x="530" y="390" width="330" height="92" fill="#ffffff" stroke="#cdd6e0"/>
+    <text x="540" y="408" class="m">c44d&#8230; &#8594; {</text>
+    <text x="554" y="424" class="ms">pack: 3fa92c&#8230;,</text>
+    <text x="554" y="440" class="ms">offset, compressed_size,</text>
+    <text x="554" y="456" class="ms">uncompressed_size, repacks_survived</text>
+    <text x="540" y="473" class="m">}</text>
+  </g>
+
+  <!-- packs table -->
+  <g>
+    <rect x="530" y="504" width="330" height="24" rx="4" fill="#3f5e85"/>
+    <text x="540" y="521" class="h2">packs &#8212; PackHash &#8594; PackInfo</text>
+    <rect x="530" y="528" width="330" height="58" fill="#ffffff" stroke="#cdd6e0"/>
+    <text x="540" y="546" class="m">3fa92c&#8230; &#8594; { size, created, tier }</text>
+    <text x="540" y="566" class="ms">tier 0 = volatile &#8230; higher = stable</text>
+  </g>
+
+  <!-- intra-manifest arrows -->
+  <path class="edge" d="M 290 448 L 290 470" marker-end="url(#arrow)"/>
+  <text x="300" y="464" class="ts">pins</text>
+  <path class="edge" d="M 470 552 L 500 552 L 500 436 L 526 436" marker-end="url(#arrow)"/>
+  <path class="edge" d="M 695 482 L 695 504" marker-end="url(#arrow)"/>
+
+  <!-- chunk location -> pack range (accent) -->
+  <path class="edge-accent" d="M 695 366 L 695 280" marker-end="url(#arrow-accent)"/>
+  <text x="710" y="310" class="ts" fill="#c2603e">one chunk = one Range read</text>
+
+</svg>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,4 +54,5 @@ Always exits 0 (a failing post-build-hook would fail the build).
 | `GITHUB_REPOSITORY` | gc | `owner/repo`, set automatically in workflows. |
 | `GITHUB_API_URL` | gc | REST API base URL (override for GHES). |
 | `GITHUB_REF_NAME` | serve | Default for `--branch`. |
+| `GITHUB_RUN_ID` | serve | Roots written by the same workflow run merge by union (matrix legs); different runs replace each other's root. |
 | `OUT_PATHS` | hook | Set by Nix when invoking the post-build-hook. |

--- a/docs/push.svg
+++ b/docs/push.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 360" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 1 L 9 5 L 0 9 z" fill="#5b6b7a"/>
+    </marker>
+  </defs>
+
+  <style>
+    .h1 { font-size: 15px; font-weight: 600; fill: #2b3a49; }
+    .t  { font-size: 12.5px; font-weight: 600; fill: #3d4c5c; }
+    .ts { font-size: 11px; fill: #6b7a89; }
+    .m  { font-size: 11.5px; font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; fill: #34424f; }
+    .edge { stroke: #5b6b7a; stroke-width: 1.4; fill: none; }
+    .lbl { font-size: 11px; fill: #5b6b7a; }
+  </style>
+
+  <!-- Nix -->
+  <rect x="20" y="40" width="270" height="280" rx="10" fill="#f4f6f9" stroke="#cdd6e0"/>
+  <text x="40" y="68" class="h1">Nix</text>
+  <text x="40" y="100" class="t">build succeeds</text>
+  <text x="40" y="118" class="ts">post-build-hook runs</text>
+  <rect x="40" y="128" width="230" height="30" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+  <text x="155" y="147" class="m" text-anchor="middle">hestia hook  ($OUT_PATHS)</text>
+  <text x="40" y="182" class="ts">the hook always exits 0: losing a path</text>
+  <text x="40" y="197" class="ts">is never worth failing the build</text>
+
+  <!-- daemon -->
+  <rect x="370" y="40" width="300" height="280" rx="10" fill="#fbfcfd" stroke="#cdd6e0"/>
+  <text x="390" y="68" class="h1">hestia serve &#8212; per-job daemon</text>
+  <text x="390" y="100" class="t">hook listener (unix socket)</text>
+  <text x="390" y="118" class="ts">buffers built paths in memory</text>
+  <text x="390" y="160" class="t">drain (post step, idle, SIGTERM)</text>
+  <text x="390" y="178" class="ts">everything built or served this job:</text>
+  <rect x="390" y="190" width="260" height="30" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+  <text x="520" y="209" class="m" text-anchor="middle">chunk &#8594; pack &#8594; commit</text>
+  <text x="390" y="242" class="ts">chunks are cut with FastCDC and</text>
+  <text x="390" y="257" class="ts">zstd-compressed; the branch root is</text>
+  <text x="390" y="272" class="ts">updated to pin this job's paths</text>
+
+  <!-- GHA cache -->
+  <rect x="750" y="40" width="270" height="280" rx="10" fill="#f4f6f9" stroke="#cdd6e0"/>
+  <text x="770" y="68" class="h1">GitHub Actions cache</text>
+  <rect x="770" y="90" width="230" height="30" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+  <text x="885" y="109" class="m" text-anchor="middle">m#1 &#8230; m#N+1  (manifest)</text>
+  <rect x="770" y="128" width="230" height="30" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+  <text x="885" y="147" class="m" text-anchor="middle">pack-&#8230;  (chunk blobs)</text>
+  <text x="770" y="196" class="ts">upload = reserve, PUT, finalize;</text>
+  <text x="770" y="211" class="ts">a pack that already exists is</text>
+  <text x="770" y="226" class="ts">simply skipped</text>
+  <text x="770" y="262" class="ts">keys are write-once; racing manifest</text>
+  <text x="770" y="277" class="ts">commits sort themselves out (SaveMutable)</text>
+
+  <!-- edges -->
+  <path class="edge" d="M 290 143 L 366 143" marker-end="url(#arrow)"/>
+  <text x="328" y="133" class="lbl" text-anchor="middle">add paths</text>
+
+  <path class="edge" d="M 670 205 L 746 205" marker-end="url(#arrow)"/>
+  <text x="708" y="181" class="lbl" text-anchor="middle">PUT packs,</text>
+  <text x="708" y="195" class="lbl" text-anchor="middle">commit m#N+1</text>
+</svg>

--- a/docs/serve.svg
+++ b/docs/serve.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 360" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 1 L 9 5 L 0 9 z" fill="#5b6b7a"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 1 L 9 5 L 0 9 z" fill="#c2603e"/>
+    </marker>
+  </defs>
+
+  <style>
+    .h1 { font-size: 15px; font-weight: 600; fill: #2b3a49; }
+    .t  { font-size: 12.5px; font-weight: 600; fill: #3d4c5c; }
+    .ts { font-size: 11px; fill: #6b7a89; }
+    .m  { font-size: 11.5px; font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; fill: #34424f; }
+    .edge { stroke: #5b6b7a; stroke-width: 1.4; fill: none; }
+    .edge-dash { stroke: #8a99a8; stroke-width: 1.4; fill: none; stroke-dasharray: 5 4; }
+    .edge-accent { stroke: #c2603e; stroke-width: 1.6; fill: none; }
+    .lbl { font-size: 11px; fill: #5b6b7a; }
+    .lbla { font-size: 11px; fill: #c2603e; }
+  </style>
+
+  <!-- Nix -->
+  <rect x="20" y="40" width="270" height="280" rx="10" fill="#f4f6f9" stroke="#cdd6e0"/>
+  <text x="40" y="68" class="h1">Nix</text>
+  <text x="40" y="100" class="t">substitution</text>
+  <text x="40" y="118" class="ts">Nix tries this substituter first:</text>
+  <rect x="40" y="128" width="230" height="30" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+  <text x="155" y="147" class="m" text-anchor="middle">http://127.0.0.1:&#60;port&#62;</text>
+  <text x="40" y="182" class="ts">on a 404 Nix simply moves on to the</text>
+  <text x="40" y="197" class="ts">next substituter (cache.nixos.org)</text>
+
+  <!-- daemon -->
+  <rect x="370" y="40" width="300" height="280" rx="10" fill="#fbfcfd" stroke="#cdd6e0"/>
+  <text x="390" y="68" class="h1">hestia serve &#8212; per-job daemon</text>
+  <text x="390" y="100" class="t">substituter (HTTP)</text>
+  <text x="390" y="118" class="ts">narinfo answers come straight from</text>
+  <text x="390" y="133" class="ts">the manifest; every hit is logged</text>
+  <text x="390" y="154" class="ts">NARs are rebuilt from chunks and</text>
+  <text x="390" y="169" class="ts">hash-checked before serving; if</text>
+  <text x="390" y="184" class="ts">anything goes wrong: 404, never bad data</text>
+  <text x="390" y="218" class="ts">accessed paths join this run's GC</text>
+  <text x="390" y="233" class="ts">root at the next drain, keeping</text>
+  <text x="390" y="248" class="ts">downloaded closures alive</text>
+
+  <!-- GHA cache -->
+  <rect x="750" y="40" width="270" height="280" rx="10" fill="#f4f6f9" stroke="#cdd6e0"/>
+  <text x="770" y="68" class="h1">GitHub Actions cache</text>
+  <rect x="770" y="90" width="230" height="30" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+  <text x="885" y="109" class="m" text-anchor="middle">m#1 &#8230; m#N  (manifest)</text>
+  <rect x="770" y="128" width="230" height="30" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
+  <text x="885" y="147" class="m" text-anchor="middle">pack-&#8230;  (chunk blobs)</text>
+  <text x="770" y="196" class="ts">Twirp hands out signed Azure URLs;</text>
+  <text x="770" y="211" class="ts">chunks arrive via Range GETs, in</text>
+  <text x="770" y="226" class="ts">parallel across packs</text>
+
+  <!-- edges -->
+  <path class="edge-dash" d="M 746 84 L 674 84" marker-end="url(#arrow)"/>
+  <text x="708" y="74" class="lbl" text-anchor="middle">load m#N</text>
+
+  <path class="edge" d="M 290 122 L 366 122" marker-end="url(#arrow)"/>
+  <text x="328" y="112" class="lbl" text-anchor="middle">narinfo, nar</text>
+  <path class="edge-accent" d="M 366 164 L 290 164" marker-end="url(#arrow-accent)"/>
+  <text x="328" y="182" class="lbla" text-anchor="middle">verified NAR</text>
+
+  <path class="edge" d="M 670 122 L 746 122" marker-end="url(#arrow)"/>
+  <text x="708" y="112" class="lbl" text-anchor="middle">Range GET</text>
+  <path class="edge-accent" d="M 746 144 L 670 144" marker-end="url(#arrow-accent)"/>
+  <text x="708" y="162" class="lbla" text-anchor="middle">chunk bytes</text>
+</svg>

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1344,6 +1344,7 @@ mod tests {
                 Root {
                     paths: paths.iter().map(|seed| path_hash(*seed)).collect(),
                     updated,
+                    run_id: None,
                 },
             );
             self
@@ -2116,6 +2117,7 @@ mod tests {
             Root {
                 paths: [path_hash(1), path_hash(3)].into_iter().collect(),
                 updated: NOW,
+                run_id: None,
             },
         );
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -15,10 +15,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub use harmonia_file_core::{Directory, FileSystemObject, FileTree, Regular, Symlink};
 pub use harmonia_store_path::{StorePath, StorePathHash};
 
-/// Window inside which two root updates are considered concurrent and get
-/// unioned instead of newest-wins (10 minutes).
-pub(crate) const ROOT_UNION_WINDOW_SECS: u64 = 600;
-
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("failed to encode manifest: {0}")]
@@ -269,6 +265,10 @@ pub struct Root {
     /// When this root was last replaced (unix seconds).
     #[serde(default)]
     pub updated: u64,
+    /// Workflow run that wrote this root (`$GITHUB_RUN_ID`); `None` for
+    /// local builds and manifests written before this field existed.
+    #[serde(default)]
+    pub run_id: Option<String>,
 }
 
 /// The top-level manifest document.
@@ -381,15 +381,16 @@ impl PackInfo {
 impl Root {
     /// Merge two versions of the same root.
     ///
-    /// Roots updated within [`ROOT_UNION_WINDOW_SECS`] of each other are
-    /// concurrent (e.g. matrix jobs of one workflow): union their paths.
-    /// Otherwise the newer root replaces the older one -- that is what makes
-    /// old closures unreachable and therefore collectable.
+    /// Roots from the same workflow run are concurrent (matrix legs of one
+    /// workflow, which can drain hours apart): union their paths.
+    /// Otherwise the newer root replaces the older one -- that is what
+    /// makes old closures unreachable and therefore collectable.
     fn merge(a: Self, b: Self) -> Self {
-        if a.updated.abs_diff(b.updated) <= ROOT_UNION_WINDOW_SECS {
+        if a.run_id.is_some() && a.run_id == b.run_id {
             Root {
                 paths: a.paths.into_iter().chain(b.paths).collect(),
                 updated: a.updated.max(b.updated),
+                run_id: a.run_id,
             }
         } else if a.updated > b.updated {
             a
@@ -929,6 +930,7 @@ mod tests {
             Root {
                 paths: BTreeSet::from([path_hash(1), path_hash(2)]),
                 updated: 5000,
+                run_id: None,
             },
         );
         manifest
@@ -1288,25 +1290,41 @@ mod tests {
     }
 
     #[test]
-    fn merge_roots_unions_within_window_replaces_outside() {
-        let make_root = |paths: &[u8], updated: u64| Root {
+    fn merge_roots_unions_same_run_replaces_other_runs() {
+        let make_root = |paths: &[u8], updated: u64, run_id: Option<&str>| Root {
             paths: paths.iter().map(|&seed| path_hash(seed)).collect(),
             updated,
+            run_id: run_id.map(str::to_string),
         };
 
-        // Within 10 minutes: union (concurrent matrix jobs).
-        let merged = Root::merge(make_root(&[1, 2], 1000), make_root(&[3], 1000 + 599));
+        // Same workflow run: union, however far apart the drains are.
+        let merged = Root::merge(
+            make_root(&[1, 2], 1000, Some("run-1")),
+            make_root(&[3], 1000 + 7200, Some("run-1")),
+        );
         assert_eq!(merged.paths.len(), 3);
-        assert_eq!(merged.updated, 1599);
+        assert_eq!(merged.updated, 8200);
+        assert_eq!(merged.run_id.as_deref(), Some("run-1"));
 
-        // Outside 10 minutes: newer replaces older (old closure dies).
-        let merged = Root::merge(make_root(&[1, 2], 1000), make_root(&[3], 1000 + 601));
+        // Different run: newer replaces, even seconds later.
+        let merged = Root::merge(
+            make_root(&[1, 2], 1000, Some("run-1")),
+            make_root(&[3], 1001, Some("run-2")),
+        );
         assert_eq!(merged.paths.len(), 1);
         assert!(merged.paths.contains(&path_hash(3)));
 
-        // Order independence of replacement.
-        let merged = Root::merge(make_root(&[3], 1000 + 601), make_root(&[1, 2], 1000));
+        // No run id (local builds): never union.
+        let merged = Root::merge(make_root(&[1, 2], 1000, None), make_root(&[3], 1001, None));
         assert_eq!(merged.paths.len(), 1);
+
+        // Order independence of replacement.
+        let merged = Root::merge(
+            make_root(&[3], 1001, Some("run-2")),
+            make_root(&[1, 2], 1000, Some("run-1")),
+        );
+        assert_eq!(merged.paths.len(), 1);
+        assert!(merged.paths.contains(&path_hash(3)));
     }
 
     #[test]
@@ -1332,6 +1350,7 @@ mod tests {
             Root {
                 paths: BTreeSet::from([path_hash(1), path_hash(98)]), // 98: evicted root member
                 updated: 0,
+                run_id: None,
             },
         );
 
@@ -1360,6 +1379,7 @@ mod tests {
             Root {
                 paths: BTreeSet::from([path_hash(1)]),
                 updated: 0,
+                run_id: None,
             },
         );
         assert_eq!(manifest.reachable().len(), 2);
@@ -1379,6 +1399,7 @@ mod tests {
             Root {
                 paths: BTreeSet::from([path_hash(1)]),
                 updated: 0,
+                run_id: None,
             },
         );
 
@@ -1485,8 +1506,17 @@ mod tests {
             (
                 proptest::collection::btree_set(arb_path_hash(), 0..4),
                 0u64..3000,
+                prop_oneof![
+                    Just(None),
+                    Just(Some("run-1".to_string())),
+                    Just(Some("run-2".to_string())),
+                ],
             )
-                .prop_map(|(paths, updated)| Root { paths, updated })
+                .prop_map(|(paths, updated, run_id)| Root {
+                    paths,
+                    updated,
+                    run_id,
+                })
         }
 
         fn arb_manifest() -> impl Strategy<Value = Manifest> {
@@ -1504,10 +1534,11 @@ mod tests {
                 })
         }
 
-        /// Manifest without roots: `Root::merge`'s concurrency window makes
-        /// root merging inherently order-dependent for 3+ way merges (a
-        /// documented limitation), so the associativity law is stated for
-        /// the path/chunk/pack maps only.
+        /// Manifest without roots: `Root::merge` mixes union (same run)
+        /// and replacement (different run), which is inherently
+        /// order-dependent for 3+ way merges (a documented limitation), so
+        /// the associativity law is stated for the path/chunk/pack maps
+        /// only.
         fn arb_rootless_manifest() -> impl Strategy<Value = Manifest> {
             arb_manifest().prop_map(|mut manifest| {
                 manifest.roots.clear();

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -177,6 +177,8 @@ pub struct PipelineContext {
     pub expand_closure: bool,
     /// Manifest root key, e.g. `main-x86_64-linux`.
     pub root_key: String,
+    /// Workflow run id (`$GITHUB_RUN_ID`); see [`Root::merge`].
+    pub run_id: Option<String>,
     /// SaveMutable family prefix (always [`MANIFEST_PREFIX`] in production;
     /// tests use distinct prefixes to isolate scenarios).
     pub manifest_prefix: String,
@@ -507,15 +509,18 @@ impl PipelineContext {
             Root {
                 paths: root_paths,
                 updated: now,
+                run_id: self.run_id.clone(),
             },
         );
 
         // Skip commits that would only refresh the root's `updated` clock:
         // the access log is never cleared and the SIGTERM final drain runs
         // unconditionally, so otherwise every job that substituted a path
-        // burns a redundant manifest version at teardown. Only skip while
-        // the committed clock is recent: it drives root-TTL liveness in GC
-        // and must still be refreshed on long-lived daemons.
+        // burns a redundant manifest version at teardown. Only skip when
+        // the committed root comes from this very run: a CI job lives far
+        // shorter than the root TTL, so the stale clock cannot expire the
+        // root. Without a run id (local builds) always commit, because the
+        // clock drives root-TTL liveness in GC.
         let refresh_only = {
             let mut probe = current.clone().merge(delta.clone());
             match (
@@ -523,8 +528,7 @@ impl PipelineContext {
                 current.roots.get(&self.root_key),
             ) {
                 (Some(probed), Some(committed))
-                    if now.saturating_sub(committed.updated)
-                        <= crate::manifest::ROOT_UNION_WINDOW_SECS =>
+                    if self.run_id.is_some() && committed.run_id == self.run_id =>
                 {
                     probed.updated = committed.updated;
                     probe == current

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -555,6 +555,9 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         upstream,
         expand_closure: !args.no_closure,
         root_key: root_key.clone(),
+        run_id: std::env::var("GITHUB_RUN_ID")
+            .ok()
+            .filter(|id| !id.is_empty()),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         pack_target_size: pipeline::PACK_TARGET_SIZE,
         // Replaced by Daemon::bind with the daemon's shared ManifestStore.

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -538,9 +538,10 @@ async fn narinfo_hits_join_the_root_at_next_drain() {
         );
 
         // A later drain (no new pushed paths) replaces the root with
-        // pushed ∪ accessed. Use a timestamp outside the root union window so
-        // the new root *replaces* the old one instead of merging with it.
-        let ctx = pipeline_context(&fake, &http, store.database());
+        // pushed ∪ accessed. A different run id makes the new root
+        // *replace* the old one instead of merging with it.
+        let mut ctx = pipeline_context(&fake, &http, store.database());
+        ctx.run_id = Some("another-run".to_string());
         let later = now_unix() + 3600;
         let stats = ctx
             .run(BTreeSet::new(), substituter.access_log.snapshot(), later)

--- a/tests/support/common.rs
+++ b/tests/support/common.rs
@@ -45,6 +45,7 @@ pub fn pipeline_context_with(
         upstream: UpstreamFilter::default(),
         expand_closure: true,
         root_key: TEST_ROOT_KEY.to_string(),
+        run_id: Some("test-run".to_string()),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         pack_target_size: PACK_TARGET_SIZE,
         publish: None,

--- a/tests/support/sim.rs
+++ b/tests/support/sim.rs
@@ -230,6 +230,7 @@ impl SimCache {
             Root {
                 paths: closure.iter().map(SimPath::path_hash).collect(),
                 updated: now,
+                run_id: None,
             },
         );
 


### PR DESCRIPTION
Adds docs/architecture.md: how the daemon sits between Nix and the GHA cache (serve and push dataflows) and how data is laid out (SaveMutable manifest versions, the four manifest maps, packs as concatenated zstd frames). Three hand-drawn SVGs, linked from the README.