### PR TITLE
docs: mark hestia as beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # hestia
 
-> ⚠️ **Alpha software**: APIs, cache format, and behavior may change without
-> notice. Not yet recommended for production CI.
+> ⚠️ **Beta software**: the cache format and behavior are stabilizing, but
+> breaking changes are still possible before 1.0. Suitable for trying in
+> real CI; expect occasional cache resets on upgrades.
 
 Hestia is a Nix binary cache for GitHub Actions. It stores build results in
 the GitHub Actions cache, so later runs download them instead of rebuilding.
@@ -54,7 +55,7 @@ See [Configuration](#configuration) for all action inputs.
 
 |  | **hestia** | **magic-nix-cache** | **cachix** | **attic** |
 |---|---|---|---|---|
-| Status | alpha | maintained | commercial service | self-hosted |
+| Status | beta | maintained | commercial service | self-hosted |
 | Storage | GHA cache (free, 10 GB/repo) | GHA cache (free, 10 GB/repo) | cachix.org | your S3/disk |
 | Accounts / secrets needed | none | none | auth token | server + token |
 | Infrastructure to run | none | none | none | server, database, storage |
@@ -115,7 +116,7 @@ All inputs are optional; the defaults work for the quick start above.
 | Input | Default | Description |
 |---|---|---|
 | `binary` | — | Path to a pre-built hestia binary. Takes precedence over `version`. |
-| `version` | latest release | Release tag to download (e.g. `v0.1.0-alpha.10`). The download is verified against GitHub's build attestations. |
+| `version` | latest release | Release tag to download (e.g. `v0.1.0-beta.1`). The download is verified against GitHub's build attestations. |
 | `github-token` | `${{ github.token }}` | Token for the attestation API lookup. |
 | `listen` | `127.0.0.1:37515` | Substituter listen address. |
 | `socket` | `/tmp/hestia/hook.sock` | Post-build-hook unix socket path. |

--- a/action/README.md
+++ b/action/README.md
@@ -1,7 +1,8 @@
 # hestia-cache action
 
-> ⚠️ **Alpha software**: APIs, cache format, and behavior may change without
-> notice. Not yet recommended for production CI.
+> ⚠️ **Beta software**: the cache format and behavior are stabilizing, but
+> breaking changes are still possible before 1.0. Suitable for trying in
+> real CI; expect occasional cache resets on upgrades.
 
 This action runs [hestia](https://github.com/Mic92/hestia) inside your job,
 turning the GitHub Actions cache into a Nix binary cache.
@@ -74,7 +75,7 @@ integration tests use it.
 | Input | Default | Description |
 |---|---|---|
 | `binary` | — | Path to a pre-built hestia binary. Takes precedence over `version`. |
-| `version` | latest release | Release tag to download (e.g. `v0.1.0-alpha.10`). The download is verified against GitHub's build attestations. |
+| `version` | latest release | Release tag to download (e.g. `v0.1.0-beta.1`). The download is verified against GitHub's build attestations. |
 | `github-token` | `${{ github.token }}` | Token for the attestation API lookup. |
 | `listen` | free port per invocation | Substituter listen address. |
 | `socket` | per-invocation temp path | Post-build-hook unix socket path. |

--- a/action/action.yml
+++ b/action/action.yml
@@ -20,7 +20,7 @@ inputs:
   version:
     description: >
       Hestia release tag to download from GitHub releases
-      (e.g. "v0.1.0-alpha.4"), or "latest" to auto-resolve the newest
+      (e.g. "v0.1.0-beta.1"), or "latest" to auto-resolve the newest
       release.  The downloaded binary is verified against GitHub's build
       provenance attestations before it runs.
     required: false


### PR DESCRIPTION
The cache format and roots model have been stable for several releases
and CI has been dogfooding hestia successfully, so promote the project
from alpha to beta ahead of the v0.1.0-beta.1 release. Update the
README warning, comparison table, and version examples accordingly.
