### PR TITLE
release: bump version to 0.1.0-beta2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hestia"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta2"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hestia"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta2"
 edition = "2024"
 license = "MIT"
 description = "Nix binary cache backed by the GitHub Actions cache (v2 API)"


### PR DESCRIPTION
Version bump for v0.1.0-beta2. Tag will be pushed once this lands.