### PR TITLE
docs: drop beta warning and pin examples to @v1 for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # hestia
 
-> ⚠️ **Beta software**: the cache format and behavior are stabilizing, but
-> breaking changes are still possible before 1.0. Suitable for trying in
-> real CI; expect occasional cache resets on upgrades.
-
 Hestia is a Nix binary cache for GitHub Actions. It stores build results in
 the GitHub Actions cache, so later runs download them instead of rebuilding.
 There is nothing to set up: no accounts, no secrets, no server to run. Add
@@ -34,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
-      - uses: Mic92/hestia/action@main
+      - uses: Mic92/hestia/action@v1
       - run: nix build .#
 ```
 
@@ -55,7 +51,7 @@ See [Configuration](#configuration) for all action inputs.
 
 |  | **hestia** | **magic-nix-cache** | **cachix** | **attic** |
 |---|---|---|---|---|
-| Status | beta | maintained | commercial service | self-hosted |
+| Status | stable | maintained | commercial service | self-hosted |
 | Storage | GHA cache (free, 10 GB/repo) | GHA cache (free, 10 GB/repo) | cachix.org | your S3/disk |
 | Accounts / secrets needed | none | none | auth token | server + token |
 | Infrastructure to run | none | none | none | server, database, storage |
@@ -116,7 +112,7 @@ All inputs are optional; the defaults work for the quick start above.
 | Input | Default | Description |
 |---|---|---|
 | `binary` | — | Path to a pre-built hestia binary. Takes precedence over `version`. |
-| `version` | latest release | Release tag to download (e.g. `v0.1.0-beta.1`). The download is verified against GitHub's build attestations. |
+| `version` | latest release | Release tag to download (e.g. `v1.0.0`). The download is verified against GitHub's build attestations. |
 | `github-token` | `${{ github.token }}` | Token for the attestation API lookup. |
 | `listen` | `127.0.0.1:37515` | Substituter listen address. |
 | `socket` | `/tmp/hestia/hook.sock` | Post-build-hook unix socket path. |

--- a/action/README.md
+++ b/action/README.md
@@ -1,9 +1,5 @@
 # hestia-cache action
 
-> ⚠️ **Beta software**: the cache format and behavior are stabilizing, but
-> breaking changes are still possible before 1.0. Suitable for trying in
-> real CI; expect occasional cache resets on upgrades.
-
 This action runs [hestia](https://github.com/Mic92/hestia) inside your job,
 turning the GitHub Actions cache into a Nix binary cache.
 
@@ -37,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
-      - uses: Mic92/hestia/action@main
+      - uses: Mic92/hestia/action@v1
       - run: nix build .#
 ```
 
@@ -50,7 +46,7 @@ to trust release binaries, pass a path instead:
 
 ```yaml
       - run: nix build github:Mic92/hestia -o hestia-bin
-      - uses: Mic92/hestia/action@main
+      - uses: Mic92/hestia/action@v1
         with:
           binary: ./hestia-bin/bin/hestia
 ```
@@ -62,7 +58,7 @@ action only exports the cache API tokens and starts nothing (`version`
 defaults to `latest` when omitted, so a bare invocation starts a daemon):
 
 ```yaml
-      - uses: Mic92/hestia/action@main
+      - uses: Mic92/hestia/action@v1
         with:
           version: ""
 ```
@@ -75,7 +71,7 @@ integration tests use it.
 | Input | Default | Description |
 |---|---|---|
 | `binary` | — | Path to a pre-built hestia binary. Takes precedence over `version`. |
-| `version` | latest release | Release tag to download (e.g. `v0.1.0-beta.1`). The download is verified against GitHub's build attestations. |
+| `version` | latest release | Release tag to download (e.g. `v1.0.0`). The download is verified against GitHub's build attestations. |
 | `github-token` | `${{ github.token }}` | Token for the attestation API lookup. |
 | `listen` | free port per invocation | Substituter listen address. |
 | `socket` | per-invocation temp path | Post-build-hook unix socket path. |

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -74,6 +74,12 @@ git pull --ff-only origin main
 git tag "$tag"
 git push origin "$tag"
 
+# Move the floating major-version tag (e.g. v1) so README's `@v1` ref
+# always tracks the latest 1.x release, matching GitHub Actions convention.
+major_tag="v${version%%.*}"
+git tag -f "$major_tag"
+git push -f origin "$major_tag"
+
 echo "waiting for the release workflow..."
 # The run may take a moment to appear after the tag push.
 run_id=""


### PR DESCRIPTION
Now that 1.0 is tagged, drop the beta warning from both READMEs and point the usage examples at `@v1` instead of `@main`, so users track a stable action ref. Status in the comparison table and the `version` input example are updated to match.

`bin/create-release.sh` now also force-pushes the floating `vMAJOR` tag alongside the exact version tag (GitHub Actions convention). The `v1` tag has already been pushed at the v1.0.0 commit.