### PR TITLE
action: move to repo root for Marketplace eligibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: NixOS/nix-installer-action@main
       - name: Start hestia cache (dogfood)
         if: vars.HESTIA_DOGFOOD == 'true'
-        uses: ./action
+        uses: ./
       - name: Run flake checks
         run: nix flake check --print-build-logs
       # No-op after the flake checks; asserts the closures the dependent
@@ -61,10 +61,10 @@ jobs:
       # compiling. Must run before the token-only invocation below.
       - name: Start hestia cache (dogfood)
         if: vars.HESTIA_DOGFOOD == 'true'
-        uses: ./action
+        uses: ./
       # Explicitly empty binary/version: token-capture-only mode (must
       # stay tested). version defaults to "latest" when omitted.
-      - uses: ./action
+      - uses: ./
         with:
           version: ""
       - name: Assert cache tokens are visible to shell steps
@@ -121,11 +121,11 @@ jobs:
       # GC needs to read manifests.
       - name: Start hestia cache (dogfood)
         if: vars.HESTIA_DOGFOOD == 'true'
-        uses: ./action
+        uses: ./
       # Token-capture-only mode when dogfooding is off (forks). Explicitly
       # empty version: it defaults to "latest" when omitted, which would
       # start an unwanted daemon.
-      - uses: ./action
+      - uses: ./
         if: vars.HESTIA_DOGFOOD != 'true'
         with:
           version: ""
@@ -157,12 +157,12 @@ jobs:
       # compiling (forks without the variables build from source).
       - name: Start hestia cache (dogfood)
         if: vars.HESTIA_DOGFOOD == 'true'
-        uses: ./action
+        uses: ./
       - name: Build hestia
         run: nix build .# -o hestia-bin
       # Instance under test on its own port/socket, started last: the
       # HESTIA_* variables and the post-build-hook then point at it.
-      - uses: ./action
+      - uses: ./
         with:
           binary: ./hestia-bin/bin/hestia
           listen: 127.0.0.1:37516

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -47,11 +47,11 @@ jobs:
       # needs the cache API tokens, not the daemon).
       - name: Install hestia (released binary)
         if: vars.HESTIA_DOGFOOD == 'true'
-        uses: ./action
+        uses: ./
       - name: Build hestia
         if: vars.HESTIA_DOGFOOD != 'true'
         run: nix build .# -o hestia-bin
-      - uses: ./action
+      - uses: ./
         if: vars.HESTIA_DOGFOOD != 'true'
         with:
           # Explicitly empty: token-capture-only mode (version defaults to

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -47,7 +47,7 @@ jobs:
         # unwinding and symbol names.
         run: nix develop --command env CARGO_PROFILE_RELEASE_DEBUG=2 cargo build --release
       - name: Start hestia cache
-        uses: ./action
+        uses: ./
         with:
           binary: target/release/hestia
       - name: Install perf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       # toolchain changes.
       - name: Start hestia cache (dogfood)
         if: vars.HESTIA_DOGFOOD == 'true'
-        uses: ./action
+        uses: ./
       - name: Build release binary
         run: nix build .#
       - name: Prepare release asset
@@ -102,7 +102,7 @@ jobs:
           ## Usage
 
           \`\`\`yaml
-          - uses: Mic92/hestia/action@${tag}
+          - uses: Mic92/hestia@${tag}
             with:
               version: ${tag}
           \`\`\`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
-      - uses: Mic92/hestia/action@v1
+      - uses: Mic92/hestia@v1
       - run: nix build .#
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,6 @@ inputs:
 
 runs:
   using: node24
-  # Deprecated entry point; see deprecated-main.js.
-  main: deprecated-main.js
-  post: deprecated-post.js
+  # Implementation lives in action/ so the deprecated subdir entry can reuse it.
+  main: action/main.js
+  post: action/post.js

--- a/action/README.md
+++ b/action/README.md
@@ -1,5 +1,10 @@
 # hestia-cache action
 
+> ⚠️ **Deprecated path**: this action moved to the repository root. Reference
+> it as `Mic92/hestia@<ref>` instead of `Mic92/hestia/action@<ref>`. The
+> subdirectory copy keeps working for one release cycle and emits a
+> deprecation warning.
+
 This action runs [hestia](https://github.com/Mic92/hestia) inside your job,
 turning the GitHub Actions cache into a Nix binary cache.
 

--- a/action/deprecated-main.js
+++ b/action/deprecated-main.js
@@ -1,0 +1,11 @@
+// Deprecated Mic92/hestia/action entry point. The action moved to the repo
+// root so it can be listed on the GitHub Marketplace. Warn, then run the
+// real implementation.
+
+'use strict';
+
+console.log(
+  '::warning::Mic92/hestia/action is deprecated; use Mic92/hestia instead'
+);
+
+require('./main.js');

--- a/action/deprecated-post.js
+++ b/action/deprecated-post.js
@@ -1,0 +1,5 @@
+// Post step for the deprecated Mic92/hestia/action path. See deprecated-main.js.
+
+'use strict';
+
+require('./post.js');


### PR DESCRIPTION

Marketplace only lists actions whose metadata file is at the repo root.
Add a root action.yml that reuses action/*.js via subpath, and turn the
old action/ entry into a shim that warns and forwards to the same code.
