### PR TITLE
gha: don't retry a read-only token as a version conflict

### DIFF
--- a/src/gha/mod.rs
+++ b/src/gha/mod.rs
@@ -53,6 +53,13 @@ pub enum Error {
 
     #[error("gave up after {attempts} conflicting attempts to save {key}")]
     Conflict { key: String, attempts: u32 },
+
+    #[error(
+        "cache write denied ({reason}): the runtime token is read-only, so nothing can be \
+         cached. Expected for events whose token has no writable cache scopes (check_run, \
+         fork pull_request). The build is unaffected; its paths are rebuilt next time."
+    )]
+    WriteDenied { reason: String },
 }
 
 impl Error {

--- a/src/gha/twirp.rs
+++ b/src/gha/twirp.rs
@@ -62,7 +62,16 @@ pub struct CreateCacheEntryResponse {
     pub ok: bool,
     #[serde(default)]
     pub signed_upload_url: String,
+    /// Why the reservation was refused. A read-only token is denied with
+    /// `ok=false` and this set (not a Twirp error), so it is the only way
+    /// to tell a denial from a genuinely taken key.
+    #[serde(default, alias = "message")]
+    pub msg: String,
 }
+
+/// Prefix the receiver puts on a read-only-token denial. Matches
+/// `CACHE_WRITE_DENIED_PREFIX` in @actions/toolkit.
+pub const CACHE_WRITE_DENIED_PREFIX: &str = "cache write denied:";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FinalizeCacheEntryUploadRequest {
@@ -247,8 +256,13 @@ impl TwirpClient {
                     upload_url: response.signed_upload_url,
                 })
             }
-            // Some backends signal "exists" with ok=false instead of a Twirp
-            // error; treat both the same.
+            // Distinct from a taken key: without this the save loop retries
+            // the denial as a conflict and gives up with a misleading error.
+            Ok(response) if response.msg.starts_with(CACHE_WRITE_DENIED_PREFIX) => {
+                Err(Error::WriteDenied {
+                    reason: response.msg,
+                })
+            }
             Ok(_) => Ok(Reservation::AlreadyExists),
             Err(err) if err.is_already_exists() => Ok(Reservation::AlreadyExists),
             Err(err) => Err(err),
@@ -445,5 +459,18 @@ mod tests {
             msg: error.msg,
         };
         assert!(parsed.is_already_exists());
+    }
+
+    #[test]
+    fn create_cache_entry_response_carries_the_denial_message() {
+        let denied: CreateCacheEntryResponse = serde_json::from_str(
+            r#"{"ok": false, "message": "cache write denied: token has no writable scopes"}"#,
+        )
+        .unwrap();
+        assert!(!denied.ok);
+        assert!(denied.msg.starts_with(CACHE_WRITE_DENIED_PREFIX));
+
+        let taken: CreateCacheEntryResponse = serde_json::from_str(r#"{"ok": false}"#).unwrap();
+        assert!(!taken.msg.starts_with(CACHE_WRITE_DENIED_PREFIX));
     }
 }


### PR DESCRIPTION
CreateCacheEntry refuses a read-only runtime token with HTTP 200,
ok=false and message "cache write denied: token has no writable scopes".
We mapped every ok=false to AlreadyExists, so SaveMutable kept retrying
the denial and eventually failed the drain with "gave up after N
conflicting attempts to save m#4", which points nowhere near the cause.

Check the response message for the "cache write denied:" prefix and
return WriteDenied instead. No point retrying: every reservation in the
job gets the same denial.