### PR TITLE
release: don't re-release on the floating major tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    # Full version tags only; the floating major alias (v1) has no dots and
+    # must not cut a duplicate release for an already-shipped version.
+    tags: ["v*.*.*"]
   # Manual dry runs: build the binaries without creating a release, so the
   # build can be debugged without re-pushing tags.
   workflow_dispatch:


### PR DESCRIPTION

create-release.sh force-moves the vN alias to the latest N.x tag. The
workflow triggered on "v*", so that push drafted a duplicate release for
an already-shipped version. Match "v*.*.*"; the major alias has no dots.
