### PR TITLE
dedup v2: normalize references, BLAKE3 hashes, reset manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ name = "hestia"
 version = "1.0.4"
 dependencies = [
  "axum",
+ "blake3",
  "bytes",
  "ciborium",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ axum = "0.8"
 # Content-defined chunking
 fastcdc = "4"
 
+# Internal content addresses (chunk + pack hashes); faster than SHA-256
+blake3 = "1"
+
 # Stream combinators for NAR event/byte streams
 futures-util = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ To Nix, the daemon looks like a regular binary cache: Nix asks it for paths
 before building them and reports every path it does build. At the end of
 the job, new build results and their runtime dependencies (the full closure,
 nixpkgs packages included) are split into content-defined chunks, packed
-into a few large blobs, and uploaded. Chunks that are already in the cache
-are never uploaded again, and every download is hash-verified before Nix
-gets to see it. The worst thing corrupt or evicted cache data can cause is a
+into a few large blobs, and uploaded. Embedded dependency hashes are
+normalized out before chunking so a chunk stays identical when only a
+reference's hash changed, and restored losslessly on the way back out.
+Chunks that are already in the cache are never uploaded again, and every
+download is hash-verified before Nix gets to see it. The worst thing corrupt or evicted cache data can cause is a
 rebuild, never wrong build inputs.
 
 ### Roots
@@ -156,9 +158,9 @@ when the branch is deleted. In practice this means:
 
 ### What hestia itself enforces
 
-Pack blobs are content-addressed (SHA-256-named, hash-verified on every
-read), and NARs are verified against the manifest's NAR hash before being
-served. Anything that doesn't check out is treated as a cache miss and gets
+Pack blobs are content-addressed (BLAKE3-named, hash-verified on every
+read), and NARs are verified against the manifest's SHA-256 NAR hash
+before being served. Anything that doesn't check out is treated as a cache miss and gets
 rebuilt.
 
 ## Limitations

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,8 +60,9 @@ and idempotent, so the outcome does not depend on who wins.
 
 A `PathEntry` holds what narinfo needs (store path, NAR hash and size,
 references) plus the path's file tree, where each file's contents is a
-list of chunk hashes. Chunk hashes resolve through the `chunks` map to
-a location: which pack, at what offset, how many bytes.
+list of chunk hashes (plus a table of reference rewrites -- see below).
+Chunk hashes resolve through the `chunks` map to a location: which
+pack, at what offset, how many bytes.
 
 ### Packs
 
@@ -69,8 +70,10 @@ Store paths are not cached one entry each. NARs are split into
 content-defined chunks (FastCDC, 16–256 KiB, 64 KiB average), each
 chunk is zstd-compressed individually, and compressed chunks are
 concatenated into pack blobs of about 64 MiB. The pack key is the
-SHA-256 of the blob, so identical packs dedup naturally and a finalized
-pack can be trusted to match its name.
+BLAKE3 of the blob, so identical packs dedup naturally and a finalized
+pack can be trusted to match its name. Chunk and pack hashes use BLAKE3
+(~3x faster than SHA-256 and unconstrained by any Nix format); NAR
+hashes stay SHA-256, since Nix records and verifies those.
 
 This layout buys three things. Chunking dedups across paths and
 versions: a rebuilt package shares most of its chunks with the previous
@@ -79,6 +82,35 @@ keeps every chunk independently extractable: serving one path touches
 only its chunks, fetched with Range reads, not whole packs. And packing
 keeps the entry count low, which matters because both REST list
 operations and the eviction clock work per entry.
+
+### Reference normalization
+
+Store paths embed the 32-character base32 hashes of their references
+(and their own self-reference) in file contents. When a dependency is
+rebuilt its hash changes, so every chunk covering an occurrence churns
+even though nothing else in the file changed.
+
+hestia rewrites those occurrences to zeros before chunking, so the
+stored chunk stays identical across rebuilds. Each occurrence is
+recorded in a per-file position table (`ChunkList::rewrites`: file
+offset + reference index); on NAR reassembly the daemon copies the real
+hash back into each span. The hashes are not stored twice -- they come
+from the path's `references` in the `PathEntry`, and a reference's index
+is its position in the sorted, deduplicated reference set, so write and
+read derive identical indices.
+
+Restoring from the position table is chosen over re-scanning each served
+NAR: a benchmark measured 20-30 GB/s against under 1 GB/s, and it
+restores losslessly with no chance of a sentinel colliding with genuine
+content. The write side scans each file once to find the occurrences
+regardless; recording their offsets during that scan is free.
+
+Restoration keys off whether a file's `rewrites` is non-empty, so
+reference-free files pass through untouched (and keep the single-chunk
+zero-copy fast path). Correctness is checked, not assumed: the write
+pipeline re-derives the NAR hash through the same restore path before
+upload, and the substituter re-verifies the full NAR hash before
+serving. Any disagreement is a 404, and Nix falls through.
 
 ### Roots and GC
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -46,7 +46,7 @@
     <text x="660" y="114" class="m" text-anchor="middle">pack-3fa92c&#8230;</text>
     <rect x="560" y="136" width="200" height="36" rx="6" fill="#e6ebf1" stroke="#b9c5d2"/>
     <text x="660" y="158" class="m" text-anchor="middle">pack-b21c07&#8230;</text>
-    <text x="560" y="196" class="ts">named after their SHA-256, about 64 MiB each</text>
+    <text x="560" y="196" class="ts">named after their BLAKE3, about 64 MiB each</text>
   </g>
 
   <!-- Pack interior strip -->

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -21,6 +21,7 @@ use crate::manifest::{
     ChunkHash, ChunkList, ChunkLocation, Directory, FileSystemObject, FileTree, Hash32, PackHash,
     Regular, Symlink,
 };
+use crate::refnorm::RefTable;
 
 /// FastCDC parameters. Pinned: changing them changes every chunk boundary
 /// and therefore invalidates all existing chunks in the cache.
@@ -65,12 +66,15 @@ pub enum Error {
          (corrupt or malicious pack data)"
     )]
     OversizedChunk,
+
+    #[error("reference restore failed: {0}")]
+    Restore(#[from] crate::refnorm::Error),
 }
 
 /// One content-defined chunk of a file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Chunk {
-    /// SHA-256 of the uncompressed chunk data.
+    /// BLAKE3 (truncated) of the uncompressed chunk data.
     pub hash: ChunkHash,
     /// Uncompressed chunk data (zero-copy slice of the source).
     pub data: Bytes,
@@ -185,11 +189,11 @@ impl PackBuilder {
         self.buffer.len() as u64
     }
 
-    /// Finalize: the pack hash is the SHA-256 of the complete blob, which
+    /// Finalize: the pack hash is the BLAKE3 of the complete blob, which
     /// makes packs content-addressed (`pack-{hash}` cache keys).
     pub fn finish(self) -> Pack {
         Pack {
-            hash: Hash32::digest(&self.buffer),
+            hash: PackHash::digest(&self.buffer),
             data: Bytes::from(self.buffer),
             chunks: self.chunks,
         }
@@ -278,7 +282,7 @@ pub fn coalesce_adjacent<T>(
     runs
 }
 
-/// GHA cache key for a pack blob (`pack-<sha256 hex>`).
+/// GHA cache key for a pack blob (`pack-<blake3 hex>`).
 pub fn pack_cache_key(hash: &PackHash) -> String {
     format!("pack-{}", hash.to_hex())
 }
@@ -402,10 +406,16 @@ fn name_to_string(name: &[u8], what: &str) -> Result<String, Error> {
 /// Walk `path` with harmonia's NAR dumper, splitting every regular file into
 /// content-defined chunks.
 ///
+/// Reference occurrences are normalized out of each file with `refs` before
+/// chunking, so chunks stay stable when a dependency's
+/// hash changes; the position table needed to restore them is recorded in
+/// each file's [`ChunkList::rewrites`]. Pass an empty [`RefTable`] to chunk
+/// verbatim.
+///
 /// Returns the file tree (for the manifest `PathEntry`) plus the unique
 /// chunks in pack order. Identical chunks appearing in multiple files are
 /// returned once.
-pub async fn chunk_path(path: impl Into<PathBuf>) -> Result<ChunkedPath, Error> {
+pub async fn chunk_path(path: impl Into<PathBuf>, refs: &RefTable) -> Result<ChunkedPath, Error> {
     let mut events = harmonia_file_nar::dump(path.into());
     let mut builder = TreeBuilder::new();
     let mut chunks: Vec<Chunk> = Vec::new();
@@ -434,9 +444,11 @@ pub async fn chunk_path(path: impl Into<PathBuf>) -> Result<ChunkedPath, Error> 
                 reader,
             } => {
                 let data = reader.into_bytes();
-                let file_chunks = chunk_data(&data);
+                let (normalized, rewrites) = refs.normalize(&data);
+                let file_chunks = chunk_data(&normalized);
                 let list = ChunkList {
                     chunks: file_chunks.iter().map(|chunk| chunk.hash).collect(),
+                    rewrites,
                 };
                 for chunk in file_chunks {
                     if seen.insert(chunk.hash) {
@@ -576,23 +588,26 @@ fn collect_events(
     name: Bytes,
     node: &TreeNode,
     chunks: &BTreeMap<ChunkHash, Bytes>,
+    refs: &RefTable,
     out: &mut Vec<NarEvent<Cursor<Bytes>>>,
 ) -> Result<(), Error> {
     match node {
         FileSystemObject::Regular(regular) => {
-            // Concatenate the file's chunks. Single-chunk files (the common
-            // case) reuse the chunk's Bytes without copying.
-            let data = match regular.contents.chunks.as_slice() {
-                [] => Bytes::new(),
-                [hash] => chunks.get(hash).ok_or(Error::MissingChunk(*hash))?.clone(),
-                hashes => {
-                    let mut data = Vec::new();
-                    for hash in hashes {
-                        let chunk = chunks.get(hash).ok_or(Error::MissingChunk(*hash))?;
-                        data.extend_from_slice(chunk);
-                    }
-                    Bytes::from(data)
+            let rewrites = &regular.contents.rewrites;
+            let data = if rewrites.is_empty() {
+                // Verbatim (v1 or reference-free): reuse chunk Bytes without
+                // copying in the single-chunk common case.
+                match regular.contents.chunks.as_slice() {
+                    [] => Bytes::new(),
+                    [hash] => chunks.get(hash).ok_or(Error::MissingChunk(*hash))?.clone(),
+                    hashes => Bytes::from(concat_chunks(hashes, chunks)?),
                 }
+            } else {
+                // Normalized (v2): reference occurrences must be restored
+                // before the bytes go back into the NAR.
+                let mut data = concat_chunks(&regular.contents.chunks, chunks)?;
+                refs.restore(&mut data, rewrites)?;
+                Bytes::from(data)
             };
             out.push(NarEvent::File {
                 name,
@@ -614,6 +629,7 @@ fn collect_events(
                     Bytes::copy_from_slice(child_name.as_bytes()),
                     &child.0,
                     chunks,
+                    refs,
                     out,
                 )?;
             }
@@ -621,6 +637,19 @@ fn collect_events(
         }
     }
     Ok(())
+}
+
+/// Concatenate a file's chunk data in order.
+fn concat_chunks(
+    hashes: &[ChunkHash],
+    chunks: &BTreeMap<ChunkHash, Bytes>,
+) -> Result<Vec<u8>, Error> {
+    let mut data = Vec::new();
+    for hash in hashes {
+        let chunk = chunks.get(hash).ok_or(Error::MissingChunk(*hash))?;
+        data.extend_from_slice(chunk);
+    }
+    Ok(data)
 }
 
 /// NAR hash and size of a path, computed from its *stored representation*
@@ -633,9 +662,10 @@ fn collect_events(
 pub async fn nar_hash_from_chunks(
     tree: &FileTree<ChunkList>,
     chunks: &BTreeMap<ChunkHash, Bytes>,
+    refs: &RefTable,
 ) -> Result<(Hash32, u64), Error> {
     let mut sink = HashSink::new();
-    write_nar(tree, chunks, &mut sink).await?;
+    write_nar(tree, chunks, refs, &mut sink).await?;
     sink.finish()
 }
 
@@ -650,9 +680,10 @@ pub async fn nar_hash_from_chunks(
 pub async fn nar_from_chunks(
     tree: &FileTree<ChunkList>,
     chunks: &BTreeMap<ChunkHash, Bytes>,
+    refs: &RefTable,
 ) -> Result<Vec<u8>, Error> {
     let mut buffer: Vec<u8> = Vec::new();
-    write_nar(tree, chunks, &mut buffer).await?;
+    write_nar(tree, chunks, refs, &mut buffer).await?;
     Ok(buffer)
 }
 
@@ -661,12 +692,13 @@ pub async fn nar_from_chunks(
 async fn write_nar<W: tokio::io::AsyncWrite + Unpin>(
     tree: &FileTree<ChunkList>,
     chunks: &BTreeMap<ChunkHash, Bytes>,
+    refs: &RefTable,
     sink: &mut W,
 ) -> Result<(), Error> {
     let mut events = Vec::new();
     // The root node's name is ignored by the NAR format (only nested entries
     // carry names), so any value works here.
-    collect_events(Bytes::new(), &tree.0, chunks, &mut events)?;
+    collect_events(Bytes::new(), &tree.0, chunks, refs, &mut events)?;
 
     let mut writer = NarWriter::new(sink);
     for event in events {
@@ -817,7 +849,7 @@ mod tests {
             assert!(builder.add(chunk).unwrap());
         }
         let pack = builder.finish();
-        assert_eq!(pack.hash, Hash32::digest(&pack.data));
+        assert_eq!(pack.hash, PackHash::digest(&pack.data));
         assert_eq!(pack.cache_key(), format!("pack-{}", pack.hash.to_hex()));
 
         // Every chunk must be recoverable from its (offset, compressed_size)
@@ -966,6 +998,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn normalized_path_round_trips_and_dedups() {
+        use crate::manifest::StorePath;
+
+        // Two "builds" of the same file differing only in an embedded
+        // dependency hash: they must chunk to identical normalized chunks
+        // (dedup) yet each reassemble byte-identically to its own original
+        // NAR (correctness).
+        const DEP_A: &str = "0d71ygfwbmy1xjlbj1v027dfmy9cjm9c";
+        const DEP_B: &str = "1a2b3c4d5f6g7h8j9k0lmnpqrsvwxyz1";
+
+        async fn build(dep: &str) -> (ChunkedPath, (Hash32, u64), RefTable) {
+            let dir = tempfile::tempdir().unwrap();
+            let root = dir.path().join("out");
+            std::fs::create_dir_all(&root).unwrap();
+            // Embed the dependency's store-path hash in a binary-ish blob
+            // large enough to span several chunks.
+            let mut content = test_data(400_000, 3).to_vec();
+            let marker = format!("/nix/store/{dep}-libdep.so");
+            content.splice(200_000..200_000, marker.bytes());
+            std::fs::write(root.join("prog"), &content).unwrap();
+
+            let reference: StorePath = format!("{dep}-libdep").parse().unwrap();
+            let refs = RefTable::new(std::slice::from_ref(&reference));
+            let chunked = chunk_path(&root, &refs).await.unwrap();
+            let from_disk = nar_hash_and_size(&root).await.unwrap();
+            (chunked, from_disk, refs)
+        }
+
+        let (a, disk_a, refs_a) = build(DEP_A).await;
+        let (b, disk_b, refs_b) = build(DEP_B).await;
+
+        // Correctness: each reassembles to its own original NAR.
+        assert_eq!(
+            nar_hash_from_chunks(&a.tree, &a.chunk_map(), &refs_a)
+                .await
+                .unwrap(),
+            disk_a
+        );
+        assert_eq!(
+            nar_hash_from_chunks(&b.tree, &b.chunk_map(), &refs_b)
+                .await
+                .unwrap(),
+            disk_b
+        );
+        assert_ne!(disk_a, disk_b, "the two builds are genuinely different");
+
+        // Dedup: the normalized chunk sets are identical despite the
+        // dependency hash differing.
+        let set_a: BTreeSet<ChunkHash> = a.chunks.iter().map(|c| c.hash).collect();
+        let set_b: BTreeSet<ChunkHash> = b.chunks.iter().map(|c| c.hash).collect();
+        assert_eq!(
+            set_a, set_b,
+            "reference normalization must dedup the chunks"
+        );
+    }
+
+    #[tokio::test]
     async fn nar_hash_from_chunks_matches_disk_walk() {
         // Build a small tree on disk, chunk it, then verify that replaying
         // the chunked representation produces the same NAR hash as hashing
@@ -978,11 +1067,12 @@ mod tests {
         std::fs::write(root.join("sub/large"), test_data(700_000, 11)).unwrap();
         std::os::unix::fs::symlink("small", root.join("sub/link")).unwrap();
 
-        let chunked = chunk_path(&root).await.unwrap();
+        let chunked = chunk_path(&root, &RefTable::new(&[])).await.unwrap();
         let from_disk = nar_hash_and_size(&root).await.unwrap();
-        let from_chunks = nar_hash_from_chunks(&chunked.tree, &chunked.chunk_map())
-            .await
-            .unwrap();
+        let from_chunks =
+            nar_hash_from_chunks(&chunked.tree, &chunked.chunk_map(), &RefTable::new(&[]))
+                .await
+                .unwrap();
         assert_eq!(from_chunks, from_disk);
     }
 
@@ -993,11 +1083,12 @@ mod tests {
         let file = dir.path().join("single");
         std::fs::write(&file, test_data(200_000, 12)).unwrap();
 
-        let chunked = chunk_path(&file).await.unwrap();
+        let chunked = chunk_path(&file, &RefTable::new(&[])).await.unwrap();
         let from_disk = nar_hash_and_size(&file).await.unwrap();
-        let from_chunks = nar_hash_from_chunks(&chunked.tree, &chunked.chunk_map())
-            .await
-            .unwrap();
+        let from_chunks =
+            nar_hash_from_chunks(&chunked.tree, &chunked.chunk_map(), &RefTable::new(&[]))
+                .await
+                .unwrap();
         assert_eq!(from_chunks, from_disk);
     }
 
@@ -1012,8 +1103,8 @@ mod tests {
         std::fs::write(root.join("nested/blob"), test_data(400_000, 21)).unwrap();
         std::os::unix::fs::symlink("file", root.join("link")).unwrap();
 
-        let chunked = chunk_path(&root).await.unwrap();
-        let nar = nar_from_chunks(&chunked.tree, &chunked.chunk_map())
+        let chunked = chunk_path(&root, &RefTable::new(&[])).await.unwrap();
+        let nar = nar_from_chunks(&chunked.tree, &chunked.chunk_map(), &RefTable::new(&[]))
             .await
             .unwrap();
 
@@ -1025,9 +1116,10 @@ mod tests {
         assert_eq!(nar, from_disk, "synthesized NAR must match the disk walk");
 
         // And it agrees with the hash helper used by the write pipeline.
-        let (hash, size) = nar_hash_from_chunks(&chunked.tree, &chunked.chunk_map())
-            .await
-            .unwrap();
+        let (hash, size) =
+            nar_hash_from_chunks(&chunked.tree, &chunked.chunk_map(), &RefTable::new(&[]))
+                .await
+                .unwrap();
         assert_eq!(Hash32::digest(&nar), hash);
         assert_eq!(nar.len() as u64, size);
     }
@@ -1039,12 +1131,12 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         std::fs::write(root.join("file"), test_data(100_000, 22)).unwrap();
 
-        let chunked = chunk_path(&root).await.unwrap();
+        let chunked = chunk_path(&root, &RefTable::new(&[])).await.unwrap();
         let mut chunks = chunked.chunk_map();
         chunks.pop_first().unwrap();
 
         assert!(matches!(
-            nar_from_chunks(&chunked.tree, &chunks).await,
+            nar_from_chunks(&chunked.tree, &chunks, &RefTable::new(&[])).await,
             Err(Error::MissingChunk(_))
         ));
     }
@@ -1056,11 +1148,11 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         std::fs::write(root.join("file"), test_data(100_000, 13)).unwrap();
 
-        let chunked = chunk_path(&root).await.unwrap();
+        let chunked = chunk_path(&root, &RefTable::new(&[])).await.unwrap();
         let mut chunks = chunked.chunk_map();
         let (missing_hash, _) = chunks.pop_first().unwrap();
 
-        let result = nar_hash_from_chunks(&chunked.tree, &chunks).await;
+        let result = nar_hash_from_chunks(&chunked.tree, &chunks, &RefTable::new(&[])).await;
         match result {
             Err(Error::MissingChunk(hash)) => assert_eq!(hash, missing_hash),
             other => panic!("expected MissingChunk error, got {other:?}"),

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -53,7 +53,7 @@ use crate::gha::savemutable::{MutableEntry, SaveMutable};
 use crate::gha::twirp::{DownloadUrl, TwirpClient};
 use crate::gha::{Error as GhaError, blob};
 use crate::manifest::{
-    ChunkHash, ChunkLocation, FileSystemObject, Hash32, Manifest, PackHash, PackInfo, PathHash,
+    Blake3Pack, ChunkHash, ChunkLocation, FileSystemObject, Manifest, PackHash, PackInfo, PathHash,
 };
 use crate::pipeline::{MANIFEST_PREFIX, now_unix, upload_pack};
 
@@ -135,7 +135,7 @@ fn parse_manifest_index(prefix: &str, key: &str) -> Option<u64> {
     (suffix == index.to_string()).then_some(index)
 }
 
-/// Parse a `pack-<sha256 hex>` cache key back into the pack hash.
+/// Parse a `pack-<blake3 hex>` cache key back into the pack hash.
 fn parse_pack_key(key: &str) -> Option<PackHash> {
     let hex = key.strip_prefix("pack-")?;
     if hex.len() != 64 {
@@ -151,7 +151,7 @@ fn parse_pack_key(key: &str) -> Option<PackHash> {
     for (i, byte) in bytes.iter_mut().enumerate() {
         *byte = u8::from_str_radix(hex.get(2 * i..2 * i + 2)?, 16).ok()?;
     }
-    Some(Hash32(bytes))
+    Some(Blake3Pack(bytes))
 }
 
 /// What the GitHub REST API reports about one `pack-*` cache entry.
@@ -235,7 +235,7 @@ pub struct GcPlan {
     /// Manifest packs that become garbage once the commit lands
     /// (fully dead packs + repack sources).
     pub delete_packs: Vec<PackHash>,
-    /// Cache keys of hestia packs (`pack-<sha256>`) present in GitHub but
+    /// Cache keys of hestia packs (`pack-<blake3>`) present in GitHub but
     /// referenced by no manifest, old enough to be sure no in-flight push
     /// still wants them. Keys that merely share the `pack-` prefix belong
     /// to other workflows and are never touched.
@@ -1315,7 +1315,7 @@ pub async fn run(args: &GcArgs) -> ExitCode {
 mod tests {
     use super::*;
     use crate::manifest::{
-        ChunkList, Directory, FileTree, PathEntry, Regular, Root, StorePath, StorePathHash,
+        ChunkList, Directory, FileTree, Hash32, PathEntry, Regular, Root, StorePath, StorePathHash,
     };
 
     /// Reference clock for all tests (an arbitrary fixed point in time).
@@ -1334,7 +1334,7 @@ mod tests {
     }
 
     fn pack_hash(seed: u8) -> PackHash {
-        Hash32::digest([b'p', seed])
+        PackHash::digest([b'p', seed])
     }
 
     /// Build a single-file tree referencing the given chunks.
@@ -1346,6 +1346,7 @@ mod tests {
                     executable: false,
                     contents: ChunkList {
                         chunks: chunks.iter().map(|seed| chunk_hash(*seed)).collect(),
+                        ..Default::default()
                     },
                 }))),
             )]),
@@ -1468,7 +1469,7 @@ mod tests {
 
     #[test]
     fn pack_key_round_trips() {
-        let hash = Hash32::digest(b"some pack");
+        let hash = PackHash::digest(b"some pack");
         assert_eq!(parse_pack_key(&pack_cache_key(&hash)), Some(hash));
         assert_eq!(parse_pack_key("pack-nothex"), None);
         assert_eq!(parse_pack_key("pack-"), None);
@@ -2136,7 +2137,7 @@ mod tests {
     fn fake_repack_output(plan: &GcPlan) -> RepackOutput {
         let mut output = RepackOutput::default();
         for (job_index, job) in plan.repack_jobs.iter().enumerate() {
-            let new_pack = Hash32::digest([b'N', job_index as u8]);
+            let new_pack = PackHash::digest([b'N', job_index as u8]);
             let mut offset = 0u64;
             for copy in &job.copies {
                 output.locations.insert(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod manifest;
 pub mod pathinfo;
 pub mod pipeline;
 pub mod protocol;
+pub mod refnorm;
 pub mod serve;
 pub mod substituter;
 pub mod upstream;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -30,10 +30,24 @@ pub enum Error {
     InvalidEncoding(String),
 }
 
+/// Full SHA-256 digest of `data`. Used for NAR hashes, which Nix records
+/// and hestia must reproduce byte-for-byte.
+fn sha256_digest(data: &[u8]) -> [u8; 32] {
+    *harmonia_utils_hash::Sha256::digest(data).digest_bytes()
+}
+
+/// Full BLAKE3 digest of `data`. Used for hestia's internal content
+/// addresses (chunk and pack hashes): ~3x faster than SHA-256 and not
+/// constrained by any Nix format.
+fn blake3_digest(data: &[u8]) -> [u8; 32] {
+    *blake3::hash(data).as_bytes()
+}
+
 /// Generates a fixed-size hash digest type: CBOR byte-string serialization,
-/// hex display, SHA-256 (truncated to the type's length) construction.
+/// hex display, and construction via `$digest` (truncated to the type's
+/// length).
 macro_rules! hash_newtype {
-    ($(#[$doc:meta])* $name:ident, $len:expr) => {
+    ($(#[$doc:meta])* $name:ident, $len:expr, $digest:path) => {
         $(#[$doc])*
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub struct $name(pub [u8; $len]);
@@ -42,11 +56,11 @@ macro_rules! hash_newtype {
             /// Hash length in bytes.
             pub const LEN: usize = $len;
 
-            /// SHA-256 of `data`, truncated to [`Self::LEN`] bytes.
+            /// Digest of `data`, truncated to [`Self::LEN`] bytes.
             pub fn digest(data: impl AsRef<[u8]>) -> Self {
-                let digest = harmonia_utils_hash::Sha256::digest(data);
+                let digest = $digest(data.as_ref());
                 let mut bytes = [0u8; $len];
-                bytes.copy_from_slice(&digest.digest_bytes()[..$len]);
+                bytes.copy_from_slice(&digest[..$len]);
                 Self(bytes)
             }
 
@@ -97,23 +111,32 @@ macro_rules! hash_newtype {
 }
 
 hash_newtype!(
-    /// A full 32-byte SHA-256 digest (pack hash or NAR hash).
+    /// A full 32-byte SHA-256 digest. Used for NAR hashes only.
     Hash32,
-    32
+    32,
+    sha256_digest
 );
 
 hash_newtype!(
-    /// A SHA-256 digest truncated to 16 bytes.
+    /// A full 32-byte BLAKE3 digest, used for pack content addresses.
+    Blake3Pack,
+    32,
+    blake3_digest
+);
+
+hash_newtype!(
+    /// A BLAKE3 digest truncated to 16 bytes.
     ///
     /// Used for chunk hashes: 128 bits keeps collisions out of reach
     /// (birthday bound 2^64 chunks) while halving the dominant cost of the
     /// manifest, which stores one hash per chunk.
-    Hash16,
-    16
+    Blake3Chunk,
+    16,
+    blake3_digest
 );
 
-pub type ChunkHash = Hash16;
-pub type PackHash = Hash32;
+pub type ChunkHash = Blake3Chunk;
+pub type PackHash = Blake3Pack;
 pub type NarHash = Hash32;
 
 impl Hash32 {
@@ -183,6 +206,19 @@ impl<'de> Deserialize<'de> for PathHash {
 pub struct ChunkList {
     #[serde(default)]
     pub chunks: Vec<ChunkHash>,
+    /// Reference occurrences rewritten to a sentinel before chunking. Empty
+    /// for reference-free files. Offsets are relative to the file content;
+    /// indices point into the path's sorted reference set (see
+    /// [`crate::refnorm`]).
+    #[serde(default)]
+    pub rewrites: Vec<Rewrite>,
+}
+
+/// One reference occurrence normalized out of a file's content.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Rewrite {
+    pub offset: u64,
+    pub ref_index: u32,
 }
 
 /// Where one chunk lives inside a pack blob.
@@ -513,6 +549,8 @@ impl<'de> Deserialize<'de> for Blob {
 struct WireChunkList {
     #[serde(default)]
     chunks: Vec<u64>,
+    #[serde(default)]
+    rewrites: Vec<Rewrite>,
 }
 
 /// Columnar wire representation.
@@ -686,6 +724,7 @@ impl Manifest {
                 let entry = entry.clone().map_contents(&mut |list: &ChunkList| {
                     Ok::<_, Error>(WireChunkList {
                         chunks: list.chunks.iter().map(|hash| chunk_index[hash]).collect(),
+                        rewrites: list.rewrites.clone(),
                     })
                 })?;
                 Ok((*hash, entry))
@@ -716,13 +755,13 @@ impl Manifest {
             .chunk_hashes
             .0
             .chunks_exact(ChunkHash::LEN)
-            .map(|bytes| Hash16(bytes.try_into().expect("chunks_exact yields exact lengths")))
+            .map(|bytes| Blake3Chunk(bytes.try_into().expect("chunks_exact yields exact lengths")))
             .collect();
         let pack_table: Vec<PackHash> = wire
             .pack_hashes
             .0
             .chunks_exact(PackHash::LEN)
-            .map(|bytes| Hash32(bytes.try_into().expect("chunks_exact yields exact lengths")))
+            .map(|bytes| Blake3Pack(bytes.try_into().expect("chunks_exact yields exact lengths")))
             .collect();
         let chunk_at = |index: u64| {
             chunk_table
@@ -794,6 +833,7 @@ impl Manifest {
                             .iter()
                             .map(|&index| chunk_at(index))
                             .collect::<Result<Vec<_>, Error>>()?,
+                        rewrites: list.rewrites.clone(),
                     })
                 })?;
                 Ok((hash, entry))
@@ -816,7 +856,10 @@ mod tests {
     pub(crate) fn leaf_tree(chunks: Vec<ChunkHash>) -> FileTree<ChunkList> {
         FileTree(FileSystemObject::Regular(Regular {
             executable: false,
-            contents: ChunkList { chunks },
+            contents: ChunkList {
+                chunks,
+                ..Default::default()
+            },
         }))
     }
 
@@ -857,7 +900,7 @@ mod tests {
         let mut manifest = Manifest::new();
         let chunk_a = ChunkHash::digest(b"chunk a");
         let chunk_b = ChunkHash::digest(b"chunk b");
-        let pack = Hash32::digest(b"pack");
+        let pack = PackHash::digest(b"pack");
 
         manifest.paths.insert(
             path_hash(1),
@@ -879,6 +922,7 @@ mod tests {
                                         executable: true,
                                         contents: ChunkList {
                                             chunks: vec![chunk_a, chunk_b],
+                                            ..Default::default()
                                         },
                                     }))),
                                 )]),
@@ -951,7 +995,7 @@ mod tests {
         // expected bytes"). The columnar hash blobs exceed that on any
         // real manifest, so use enough chunks to cross the threshold.
         let mut manifest = sample_manifest();
-        let pack = Hash32::digest(b"big pack");
+        let pack = PackHash::digest(b"big pack");
         for i in 0u32..1000 {
             manifest.chunks.insert(
                 ChunkHash::digest(i.to_le_bytes()),
@@ -1118,9 +1162,9 @@ mod tests {
     }
 
     #[test]
-    fn truncated_digest_is_a_sha256_prefix() {
-        let full = Hash32::digest(b"same input");
-        let truncated = Hash16::digest(b"same input");
+    fn truncated_chunk_digest_is_a_blake3_prefix() {
+        let full = Blake3Pack::digest(b"same input");
+        let truncated = ChunkHash::digest(b"same input");
         assert_eq!(truncated.0[..], full.0[..16]);
     }
 
@@ -1234,7 +1278,7 @@ mod tests {
 
     #[test]
     fn merge_dedups_packs_and_chunks() {
-        let pack = Hash32::digest(b"pack");
+        let pack = PackHash::digest(b"pack");
         let chunk = ChunkHash::digest(b"chunk");
 
         let mut a = Manifest::new();
@@ -1428,13 +1472,19 @@ mod tests {
             (0u8..6).prop_map(|seed| Hash32::digest([seed]))
         }
 
+        fn arb_pack_hash() -> impl Strategy<Value = PackHash> {
+            (0u8..6).prop_map(|seed| PackHash::digest([seed]))
+        }
+
         fn arb_chunk_hash() -> impl Strategy<Value = ChunkHash> {
             (0u8..6).prop_map(|seed| ChunkHash::digest([seed]))
         }
 
         fn arb_chunk_list() -> impl Strategy<Value = ChunkList> {
-            proptest::collection::vec(arb_chunk_hash(), 0..3)
-                .prop_map(|chunks| ChunkList { chunks })
+            proptest::collection::vec(arb_chunk_hash(), 0..3).prop_map(|chunks| ChunkList {
+                chunks,
+                ..Default::default()
+            })
         }
 
         fn arb_path_entry() -> impl Strategy<Value = PathEntry> {
@@ -1481,7 +1531,7 @@ mod tests {
         }
 
         fn arb_chunk_location() -> impl Strategy<Value = ChunkLocation> {
-            (arb_hash32(), 0u64..1000, 1u32..1000, 1u32..1000, 0u32..5).prop_map(
+            (arb_pack_hash(), 0u64..1000, 1u32..1000, 1u32..1000, 0u32..5).prop_map(
                 |(pack, offset, compressed_size, uncompressed_size, repacks_survived)| {
                     ChunkLocation {
                         pack,
@@ -1523,7 +1573,7 @@ mod tests {
             (
                 proptest::collection::btree_map(arb_path_hash(), arb_path_entry(), 0..4),
                 proptest::collection::btree_map(arb_chunk_hash(), arb_chunk_location(), 0..4),
-                proptest::collection::btree_map(arb_hash32(), arb_pack_info(), 0..3),
+                proptest::collection::btree_map(arb_pack_hash(), arb_pack_info(), 0..3),
                 proptest::collection::btree_map("[a-z]{1,4}", arb_root(), 0..3),
             )
                 .prop_map(|(paths, chunks, packs, roots)| Manifest {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -27,12 +27,18 @@ use crate::gha::twirp::{DownloadUrl, Reservation, TwirpClient};
 use crate::manifest::{Manifest, PackInfo, PathEntry, PathHash, Root};
 use crate::pathinfo::{Error as PathInfoError, Lookup, PathInfo, StoreDatabase};
 use crate::protocol::DrainStats;
+use crate::refnorm::RefTable;
 use crate::substituter::ManifestStore;
 use crate::upstream::UpstreamFilter;
 use futures_util::{StreamExt as _, TryStreamExt as _};
 
-/// SaveMutable family prefix for the manifest ("m" → keys `m#1`, `m#2`, …).
-pub const MANIFEST_PREFIX: &str = "m";
+/// SaveMutable family prefix for the manifest ("m2" → keys `m2#1`, `m2#2`,
+/// …). Bumped from "m" when reference normalization changed the chunk
+/// format: the pre-existing `m#N` sequence chunked NARs verbatim, so those
+/// chunks would never dedup against normalized ones. A fresh namespace
+/// ignores the old manifest outright rather than carrying dead entries
+/// forward; its orphaned packs age out through GC and eviction.
+pub const MANIFEST_PREFIX: &str = "m2";
 
 /// Compressed bytes per pack before a new pack is started.
 pub const PACK_TARGET_SIZE: u64 = 64 * 1024 * 1024;
@@ -358,7 +364,12 @@ impl PipelineContext {
                 // deterministic failure would then keep every later drain --
                 // including the final shutdown drain -- from caching
                 // anything at all.
-                let chunked = match chunk_path(&path).await {
+                // Normalize reference occurrences out before chunking so
+                // chunks stay stable across dependency-hash changes; the
+                // path's own references drive both normalization and the
+                // read-side restore.
+                let refs = RefTable::new(&info.references);
+                let chunked = match chunk_path(&path, &refs).await {
                     Ok(chunked) => chunked,
                     Err(err) => {
                         eprintln!("hestia: NOT uploading {path}: chunking failed: {err}");
@@ -372,7 +383,7 @@ impl PipelineContext {
                 // the NAR hash Nix recorded for this path. A mismatch means
                 // hestia would serve corrupt data; never upload it.
                 let (nar_hash, nar_size) =
-                    match nar_hash_from_chunks(&chunked.tree, &chunk_map).await {
+                    match nar_hash_from_chunks(&chunked.tree, &chunk_map, &refs).await {
                         Ok(result) => result,
                         Err(err) => {
                             eprintln!("hestia: NOT uploading {path}: NAR replay failed: {err}");

--- a/src/refnorm.rs
+++ b/src/refnorm.rs
@@ -1,0 +1,241 @@
+//! Reference normalization.
+//!
+//! Store paths embed the 32-char base32 hashes of their references (and
+//! their own self-reference) in file contents. When a dependency is
+//! rebuilt its hash changes, so every chunk covering an occurrence churns
+//! even when nothing else changed, defeating cross-rebuild chunk dedup.
+//!
+//! v2 rewrites those occurrences to zeros before chunking, so the stored
+//! chunk is identical across rebuilds, and records each occurrence in a
+//! per-file position table ([`Rewrite`]). [`RefTable::restore`] copies the
+//! real hash back on NAR reassembly. The hashes come from the path's
+//! `references` (already in the `PathEntry`); a reference's index is its
+//! position in the sorted, deduplicated set, so write and read derive
+//! identical indices from the same list.
+
+use bytes::Bytes;
+
+use crate::manifest::{Rewrite, StorePath};
+
+/// Length of a base32-encoded store path hash.
+pub const HASH_LEN: usize = 32;
+
+/// Written over a reference occurrence; the value is irrelevant (the
+/// position table restores the real bytes), zeros compress best.
+const SENTINEL: [u8; HASH_LEN] = [0u8; HASH_LEN];
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("rewrite references index {index} but the path has {len} references")]
+    IndexOutOfRange { index: usize, len: usize },
+
+    #[error("rewrite at offset {offset} does not fit in {len}-byte file content")]
+    OffsetOutOfRange { offset: usize, len: usize },
+}
+
+/// Sorted, deduplicated reference hashes for one path, plus a first-byte
+/// bitmap and 4-byte prefix index for fast scanning. The vector position is
+/// the [`Rewrite::ref_index`].
+#[derive(Debug, Clone)]
+pub struct RefTable {
+    hashes: Vec<[u8; HASH_LEN]>,
+    first: [bool; 256],
+    prefix: std::collections::HashMap<[u8; 4], Vec<usize>>,
+}
+
+impl RefTable {
+    pub fn new(references: &[StorePath]) -> Self {
+        let mut hashes: Vec<[u8; HASH_LEN]> = references
+            .iter()
+            .map(|path| {
+                let text = path.hash().to_string();
+                debug_assert_eq!(text.len(), HASH_LEN);
+                let mut buf = [0u8; HASH_LEN];
+                buf.copy_from_slice(text.as_bytes());
+                buf
+            })
+            .collect();
+        hashes.sort_unstable();
+        hashes.dedup();
+
+        let mut first = [false; 256];
+        let mut prefix: std::collections::HashMap<[u8; 4], Vec<usize>> = Default::default();
+        for (index, hash) in hashes.iter().enumerate() {
+            first[hash[0] as usize] = true;
+            prefix
+                .entry(hash[..4].try_into().expect("slice is 4 bytes"))
+                .or_default()
+                .push(index);
+        }
+
+        Self {
+            hashes,
+            first,
+            prefix,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.hashes.is_empty()
+    }
+
+    fn match_at(&self, window: &[u8]) -> Option<usize> {
+        let key: [u8; 4] = window[..4].try_into().expect("slice is 4 bytes");
+        self.prefix
+            .get(&key)?
+            .iter()
+            .copied()
+            .find(|&index| self.hashes[index] == window)
+    }
+
+    /// Replace every reference-hash occurrence with the sentinel, returning
+    /// the normalized bytes and the position table to restore them. Offsets
+    /// index the file content, identical in normalized and original bytes
+    /// (the sentinel is hash-length).
+    pub fn normalize(&self, data: &[u8]) -> (Bytes, Vec<Rewrite>) {
+        if self.is_empty() || data.len() < HASH_LEN {
+            return (Bytes::copy_from_slice(data), Vec::new());
+        }
+        let mut out = Vec::with_capacity(data.len());
+        let mut rewrites = Vec::new();
+        let mut i = 0;
+        while i + HASH_LEN <= data.len() {
+            if self.first[data[i] as usize]
+                && let Some(index) = self.match_at(&data[i..i + HASH_LEN])
+            {
+                rewrites.push(Rewrite {
+                    offset: out.len() as u64,
+                    ref_index: index as u32,
+                });
+                out.extend_from_slice(&SENTINEL);
+                i += HASH_LEN;
+                continue;
+            }
+            out.push(data[i]);
+            i += 1;
+        }
+        out.extend_from_slice(&data[i..]);
+        (Bytes::from(out), rewrites)
+    }
+
+    /// Undo [`Self::normalize`]: copy each recorded reference hash back into
+    /// the concatenated (normalized) file content.
+    pub fn restore(&self, data: &mut [u8], rewrites: &[Rewrite]) -> Result<(), Error> {
+        for rewrite in rewrites {
+            let index = rewrite.ref_index as usize;
+            let hash = self.hashes.get(index).ok_or(Error::IndexOutOfRange {
+                index,
+                len: self.hashes.len(),
+            })?;
+            let offset = rewrite.offset as usize;
+            let end = offset
+                .checked_add(HASH_LEN)
+                .filter(|&end| end <= data.len())
+                .ok_or(Error::OffsetOutOfRange {
+                    offset,
+                    len: data.len(),
+                })?;
+            data[offset..end].copy_from_slice(hash);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_path(hash32: &str, name: &str) -> StorePath {
+        format!("{hash32}-{name}")
+            .parse()
+            .expect("valid store path")
+    }
+
+    const GLIBC_A: &str = "0d71ygfwbmy1xjlbj1v027dfmy9cjm9c";
+    const GLIBC_B: &str = "1a2b3c4d5f6g7h8j9k0lmnpqrsvwxyz1";
+    const SELF: &str = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+
+    fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
+    }
+
+    #[test]
+    fn round_trip_restores_original() {
+        let refs = vec![
+            store_path(GLIBC_A, "glibc-2.40"),
+            store_path(SELF, "hello-1.0"),
+        ];
+        let table = RefTable::new(&refs);
+
+        let mut content = b"prefix ".to_vec();
+        content.extend_from_slice(GLIBC_A.as_bytes());
+        content.extend_from_slice(b"/lib and self ");
+        content.extend_from_slice(SELF.as_bytes());
+        content.extend_from_slice(b" suffix padding past the hash-length bound");
+
+        let (normalized, rewrites) = table.normalize(&content);
+        assert_eq!(rewrites.len(), 2);
+        assert!(!contains(&normalized, GLIBC_A.as_bytes()));
+        assert!(!contains(&normalized, SELF.as_bytes()));
+
+        let mut restored = normalized.to_vec();
+        table.restore(&mut restored, &rewrites).unwrap();
+        assert_eq!(restored, content);
+    }
+
+    #[test]
+    fn normalization_is_hash_independent() {
+        // Two builds differing only in a dependency's hash normalize to
+        // identical bytes: the dedup win.
+        let build_a = RefTable::new(&[store_path(GLIBC_A, "glibc")]);
+        let build_b = RefTable::new(&[store_path(GLIBC_B, "glibc")]);
+
+        let mut a = b"header ".to_vec();
+        a.extend_from_slice(GLIBC_A.as_bytes());
+        a.extend_from_slice(b" trailer bytes beyond the hash window");
+        let mut b = b"header ".to_vec();
+        b.extend_from_slice(GLIBC_B.as_bytes());
+        b.extend_from_slice(b" trailer bytes beyond the hash window");
+
+        let (na, ra) = build_a.normalize(&a);
+        let (nb, rb) = build_b.normalize(&b);
+        assert_eq!(na, nb);
+        assert_eq!(ra, rb);
+    }
+
+    #[test]
+    fn empty_table_is_a_noop() {
+        let table = RefTable::new(&[]);
+        let data = b"no references here, just content bytes to scan".to_vec();
+        let (normalized, rewrites) = table.normalize(&data);
+        assert_eq!(normalized.as_ref(), data.as_slice());
+        assert!(rewrites.is_empty());
+    }
+
+    #[test]
+    fn restore_rejects_out_of_range() {
+        let table = RefTable::new(&[store_path(GLIBC_A, "x")]);
+        let mut data = vec![0u8; 10];
+        assert!(matches!(
+            table.restore(
+                &mut data,
+                &[Rewrite {
+                    offset: 0,
+                    ref_index: 0
+                }]
+            ),
+            Err(Error::OffsetOutOfRange { .. })
+        ));
+        let mut data = vec![0u8; 64];
+        assert!(matches!(
+            table.restore(
+                &mut data,
+                &[Rewrite {
+                    offset: 0,
+                    ref_index: 5
+                }]
+            ),
+            Err(Error::IndexOutOfRange { .. })
+        ));
+    }
+}

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -47,6 +47,7 @@ use crate::manifest::{
     ChunkHash, ChunkLocation, FileSystemObject, Hash32, Manifest, PackHash, PathEntry, PathHash,
 };
 use crate::pipeline::AccessLog;
+use crate::refnorm::RefTable;
 
 /// Priority advertised in /nix-cache-info. Lower wins: 30 puts hestia ahead
 /// of cache.nixos.org (40), so Nix asks the local cache first and only falls
@@ -670,9 +671,13 @@ async fn nar(
     let tree = entry.tree.clone();
     let nar_size = entry.nar_size;
     let expected_hash = entry.nar_hash;
+    // Reference occurrences normalized out on the write side (dedup v2) are
+    // restored from the path's own references; v1 entries carry no rewrites,
+    // so the table is unused for them.
+    let refs = RefTable::new(&entry.references);
     let nar = tokio::task::spawn_blocking(move || {
         use futures_util::FutureExt as _;
-        let nar = nar_from_chunks(&tree, &chunks)
+        let nar = nar_from_chunks(&tree, &chunks, &refs)
             .now_or_never()
             .expect("NAR synthesis into a Vec sink never pends")
             .map_err(|err| format!("NAR synthesis failed: {err}"))?;
@@ -724,7 +729,7 @@ mod tests {
             deriver: None,
             tree: FileTree(FileSystemObject::Regular(Regular {
                 executable: false,
-                contents: ChunkList { chunks: vec![] },
+                contents: ChunkList::default(),
             })),
             last_reachable: 0,
             last_pushed: 0,

--- a/tests/chunker_e2e.rs
+++ b/tests/chunker_e2e.rs
@@ -19,6 +19,7 @@ use bytes::Bytes;
 
 use hestia::chunker::{self, PackBuilder, chunk_path, extract_chunk, flatten_tree};
 use hestia::manifest::{ChunkHash, ChunkLocation, FileSystemObject};
+use hestia::refnorm::RefTable;
 use support::store::{find_real_store_path, nix_path_info_hash, nix_store_dump_hash};
 
 // ---------------------------------------------------------------------------
@@ -65,7 +66,7 @@ fn create_fixture(root: &Path) {
 /// from the pack buffer + manifest-style locations and compare against the
 /// filesystem.
 async fn assert_reconstruction_from_pack(path: &Path) {
-    let chunked = chunk_path(path).await.unwrap();
+    let chunked = chunk_path(path, &RefTable::new(&[])).await.unwrap();
 
     // Build a single pack from the chunks. (The production pipeline goes
     // through compress_chunks + add_compressed and splits packs at the
@@ -148,7 +149,7 @@ async fn fixture_tree_reconstructs_byte_identical_from_pack() {
 
     // Dedup check: the two identical large files must share every chunk, so
     // unique chunks must be far fewer than total chunk references.
-    let chunked = chunk_path(&root).await.unwrap();
+    let chunked = chunk_path(&root, &RefTable::new(&[])).await.unwrap();
     let total_refs: usize = flatten_tree(&chunked.tree)
         .iter()
         .filter_map(|(_, node)| match node {
@@ -181,7 +182,7 @@ async fn single_file_path_chunks_and_reconstructs() {
     let file = dir.path().join("single");
     std::fs::write(&file, vec![7u8; 100_000]).unwrap();
 
-    let chunked = chunk_path(&file).await.unwrap();
+    let chunked = chunk_path(&file, &RefTable::new(&[])).await.unwrap();
     let FileSystemObject::Regular(regular) = &chunked.tree.0 else {
         panic!("root node must be a regular file");
     };
@@ -262,10 +263,11 @@ async fn nar_hash_from_chunks_matches_nix_for_real_store_path() {
         return;
     };
 
-    let chunked = chunk_path(&store_path).await.unwrap();
-    let (hash, size) = chunker::nar_hash_from_chunks(&chunked.tree, &chunked.chunk_map())
-        .await
-        .unwrap();
+    let chunked = chunk_path(&store_path, &RefTable::new(&[])).await.unwrap();
+    let (hash, size) =
+        chunker::nar_hash_from_chunks(&chunked.tree, &chunked.chunk_map(), &RefTable::new(&[]))
+            .await
+            .unwrap();
     assert_eq!(size, expected_size, "NAR size mismatch");
     assert_eq!(hash, expected_hash, "NAR hash mismatch");
 }

--- a/tests/failure_modes.rs
+++ b/tests/failure_modes.rs
@@ -155,7 +155,8 @@ async fn garbage_manifest_blob_is_replaced_not_fatal() {
     let twirp = fake.twirp(&http);
 
     // Plant a manifest blob that is not even valid zstd.
-    store_entry(&twirp, &http, "m#1", b"this is not a manifest at all").await;
+    let m1 = format!("{MANIFEST_PREFIX}#1");
+    store_entry(&twirp, &http, &m1, b"this is not a manifest at all").await;
 
     // Loading must degrade to an empty manifest, not fail.
     let ctx = context(&fake, &http, &store);
@@ -204,7 +205,7 @@ async fn truncated_manifest_blob_is_replaced_not_fatal() {
     let save = SaveMutable::new(&twirp, &http, MANIFEST_PREFIX);
     let valid = save.load().await.unwrap().unwrap().data;
     let truncated = &valid[..valid.len() / 2];
-    store_entry(&twirp, &http, "m#2", truncated).await;
+    store_entry(&twirp, &http, &format!("{MANIFEST_PREFIX}#2"), truncated).await;
 
     // The truncated newest version reads as empty (the older intact m#1 is
     // NOT consulted: SaveMutable always serves the newest version)...
@@ -237,7 +238,8 @@ async fn gc_refuses_to_act_on_a_corrupt_manifest() {
     let http = reqwest::Client::new();
     let twirp = fake.twirp(&http);
 
-    store_entry(&twirp, &http, "m#1", b"garbage manifest").await;
+    let m1 = format!("{MANIFEST_PREFIX}#1");
+    store_entry(&twirp, &http, &m1, b"garbage manifest").await;
     // A hestia-shaped pack key, old enough to pass the min_age guard: if GC
     // misjudged the corrupt manifest as empty and ran its orphan sweep, this
     // is exactly what it would delete.
@@ -261,7 +263,10 @@ async fn gc_refuses_to_act_on_a_corrupt_manifest() {
     // Nothing was deleted.
     let entries = fake.rest(&http).list_caches("").await.unwrap();
     let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
-    assert!(keys.contains(&"m#1"), "corrupt manifest left in place");
+    assert!(
+        keys.contains(&m1.as_str()),
+        "corrupt manifest left in place"
+    );
     assert!(keys.contains(&pack_key.as_str()), "packs left in place");
 }
 
@@ -278,7 +283,13 @@ async fn daemon_starts_and_drains_over_a_corrupt_manifest() {
         let fake = FakeGha::start().await;
         let http = reqwest::Client::new();
         let twirp = fake.twirp(&http);
-        store_entry(&twirp, &http, "m#1", b"garbage manifest").await;
+        store_entry(
+            &twirp,
+            &http,
+            &format!("{MANIFEST_PREFIX}#1"),
+            b"garbage manifest",
+        )
+        .await;
 
         let ctx = context(&fake, &http, &store);
 

--- a/tests/support/sim.rs
+++ b/tests/support/sim.rs
@@ -30,6 +30,7 @@ use hestia::manifest::{
 };
 use hestia::pathinfo::StoreDir;
 use hestia::pipeline::{AccessLog, MANIFEST_PREFIX, upload_pack};
+use hestia::refnorm::RefTable;
 use hestia::substituter::{ManifestStore, Substituter};
 
 use super::fake_gha::FakeGha;
@@ -95,6 +96,7 @@ impl SimPath {
                     executable: false,
                     contents: ChunkList {
                         chunks: file_chunks.iter().map(|chunk| chunk.hash).collect(),
+                        ..Default::default()
                     },
                 }))),
             );
@@ -181,7 +183,7 @@ impl SimCache {
                 .iter()
                 .map(|chunk| (chunk.hash, chunk.data.clone()))
                 .collect();
-            let (nar_hash, nar_size) = nar_hash_from_chunks(&tree, &chunk_map)
+            let (nar_hash, nar_size) = nar_hash_from_chunks(&tree, &chunk_map, &RefTable::new(&[]))
                 .await
                 .expect("nar hash from chunks");
 


### PR DESCRIPTION
Three changes sharing one cache-format reset.

Reference normalization. Store paths embed the 32-char base32 hashes of their references (and self-reference) in file contents; when a dependency is rebuilt its hash changes and every chunk covering an occurrence churns, defeating cross-rebuild dedup. Rewrite those occurrences to zeros before chunking so the stored chunk stays identical across rebuilds, recording each in a per-file position table (ChunkList::rewrites) and restoring the real hash on NAR reassembly. The hashes are not stored twice: they come from the path's references, indexed by position in the sorted, deduplicated set. A position table beats scan-on-read (restore at 20-30 GB/s vs under 1 GB/s to re-scan every served NAR) and is lossless. The write pipeline re-derives the NAR hash through the same restore path before upload and the substituter re-verifies it before serving, so any bug is a 404.

BLAKE3 for internal content addresses. Chunk and pack hashes switch from SHA-256 to BLAKE3 (~3x faster). Hashing was ~30% of drain CPU on the single-threaded producer critical path while compression is parallelized. NAR hashes stay SHA-256, since Nix verifies those.

Cache reset. Both changes alter chunk and pack identity, so old verbatim chunks can never dedup against the new format. Bump the SaveMutable prefix "m" -> "m2" so new daemons ignore the old manifest; orphaned packs age out through GC.