### PR TITLE
serve: detect read-only cache token upfront and skip uploads

### DIFF
--- a/src/gha/twirp.rs
+++ b/src/gha/twirp.rs
@@ -75,6 +75,8 @@ pub struct CreateCacheEntryResponse {
 /// `CACHE_WRITE_DENIED_PREFIX` in @actions/toolkit.
 pub const CACHE_WRITE_DENIED_PREFIX: &str = "cache write denied:";
 
+const WRITE_PROBE_KEY: &str = "hestia-write-probe-v1";
+
 /// Finalize retries when the freshly uploaded entry is not yet visible.
 const FINALIZE_MAX_ATTEMPTS: u32 = 5;
 const FINALIZE_RETRY_DELAY: Duration = Duration::from_secs(2);
@@ -271,6 +273,18 @@ impl TwirpClient {
             }
             Ok(_) => Ok(Reservation::AlreadyExists),
             Err(err) if err.is_already_exists() => Ok(Reservation::AlreadyExists),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Whether the runtime token may write to the cache. Scopes are not
+    /// advertised, so the only way to know is to attempt a reservation. The
+    /// key is fixed so a writable token reserves it at most once (later
+    /// probes hit already_exists); it is never finalized and expires.
+    pub async fn probe_writable(&self) -> Result<bool, Error> {
+        match self.create_cache_entry(WRITE_PROBE_KEY).await {
+            Ok(_) => Ok(true),
+            Err(Error::WriteDenied { .. }) => Ok(false),
             Err(err) => Err(err),
         }
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -16,6 +16,7 @@
 //!    SaveMutable handles write conflicts by re-merging.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -210,6 +211,11 @@ pub struct PipelineContext {
     /// Compressed bytes per pack ([`PACK_TARGET_SIZE`] in production; tests
     /// use small values to exercise pack splitting).
     pub pack_target_size: u64,
+    /// Runtime token has no writable cache scope (`check_run`, fork
+    /// `pull_request`); the write pipeline is skipped so a drain is a clean
+    /// no-op instead of failing at the first reservation. Set by a
+    /// background probe at startup ([`crate::serve`]).
+    pub read_only: Arc<AtomicBool>,
     /// Where committed manifests are published for the substituter.
     ///
     /// Read-your-writes: the cache service's lookups are eventually
@@ -280,6 +286,10 @@ impl PipelineContext {
         };
 
         if paths.is_empty() && accessed.is_empty() {
+            return Ok(stats);
+        }
+
+        if self.read_only.load(Ordering::Relaxed) {
             return Ok(stats);
         }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -34,6 +34,7 @@ use std::collections::BTreeSet;
 use std::future::Future;
 use std::path::Path;
 use std::process::ExitCode;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -546,6 +547,9 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         .unwrap_or_else(|| "local".to_string());
     let system = args.system.clone().unwrap_or_else(pipeline::current_system);
 
+    // Set by the write probe spawned once the listeners are bound (below).
+    let read_only = Arc::new(AtomicBool::new(false));
+
     let store_dir = store.store_dir().clone();
     let root_key = pipeline::root_key(&branch, &system);
     let pipeline = PipelineContext {
@@ -560,6 +564,7 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
             .filter(|id| !id.is_empty()),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         pack_target_size: pipeline::PACK_TARGET_SIZE,
+        read_only: read_only.clone(),
         // Replaced by Daemon::bind with the daemon's shared ManifestStore.
         publish: None,
     };
@@ -641,6 +646,31 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
             load_published_manifest(&twirp, &http, &manifest_store).await;
         })
     };
+
+    // Detect a read-only token (check_run, fork pull_request) upfront so a
+    // job never chunks a whole closure only to fail at the first
+    // reservation. Spawned like the manifest load so a stalled cache API
+    // cannot delay readiness; it resolves long before the post-step drain.
+    // An unreachable cache is inconclusive: stay writable and let the real
+    // drain surface any genuine failure.
+    {
+        let twirp = twirp.clone();
+        let read_only = read_only.clone();
+        tokio::spawn(async move {
+            match twirp.probe_writable().await {
+                Ok(false) => {
+                    read_only.store(true, Ordering::Relaxed);
+                    eprintln!(
+                        "hestia serve: the runtime token is read-only (expected for check_run \
+                         and fork pull_request events); paths built this job will not be \
+                         cached, but reads from the cache still work"
+                    );
+                }
+                Ok(true) => {}
+                Err(err) => eprintln!("hestia serve: cache write probe inconclusive: {err}"),
+            }
+        });
+    }
 
     eprintln!(
         "hestia serve: hook socket {}, substituter http://{} (root key: {root_key})",

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -8,6 +8,8 @@ mod support;
 
 use std::collections::BTreeSet;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use hestia::manifest::PathHash;
 use hestia::pathinfo::StoreDatabase;
@@ -554,4 +556,55 @@ async fn small_pack_target_splits_a_drain_into_multiple_packs() {
         .expect("manifest committed");
     assert_eq!(manifest.packs.len(), stats.packs_uploaded);
     assert_all_chunks_locatable(&manifest);
+}
+
+/// A read-only runtime token skips the write pipeline entirely: nothing is
+/// reserved, nothing is uploaded, and no manifest is committed. The drain
+/// still succeeds so the post-step never marks the job failed.
+#[tokio::test]
+async fn read_only_token_skips_the_write_pipeline() {
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+    let fixture = store.add_fixture("read-only", 3);
+
+    let fake = FakeGha::start().await;
+    fake.deny_writes();
+    let http = reqwest::Client::new();
+    let ctx = PipelineContext {
+        read_only: Arc::new(AtomicBool::new(true)),
+        ..context(&fake, &http, store.database())
+    };
+
+    let stats = ctx
+        .run(to_path_set(&[&fixture]), BTreeSet::new(), now_unix())
+        .await
+        .expect("read-only drain must succeed");
+
+    assert_eq!(stats.paths_received, 1);
+    assert_eq!(stats.pushed, 0);
+    assert_eq!(stats.packs_uploaded, 0);
+    assert_eq!(stats.manifest_version, 0);
+    assert_eq!(pack_count(&fake, &http).await, 0);
+    assert!(committed_manifest(&fake, &http).await.is_none());
+}
+
+/// The startup probe reports a read-only token against a backend that
+/// denies writes, and a writable one otherwise.
+#[tokio::test]
+async fn write_probe_detects_a_read_only_token() {
+    let http = reqwest::Client::new();
+
+    let writable = FakeGha::start().await;
+    assert!(
+        writable.twirp(&http).probe_writable().await.unwrap(),
+        "a normal backend must probe as writable"
+    );
+
+    let read_only = FakeGha::start().await;
+    read_only.deny_writes();
+    assert!(
+        !read_only.twirp(&http).probe_writable().await.unwrap(),
+        "a write-denying backend must probe as read-only"
+    );
 }

--- a/tests/support/common.rs
+++ b/tests/support/common.rs
@@ -3,6 +3,8 @@
 
 use std::collections::BTreeSet;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use bytes::Bytes;
 
@@ -48,6 +50,7 @@ pub fn pipeline_context_with(
         run_id: Some("test-run".to_string()),
         manifest_prefix: MANIFEST_PREFIX.to_string(),
         pack_target_size: PACK_TARGET_SIZE,
+        read_only: Arc::new(AtomicBool::new(false)),
         publish: None,
     }
 }

--- a/tests/support/fake_gha.rs
+++ b/tests/support/fake_gha.rs
@@ -87,6 +87,9 @@ struct Inner {
     twirp_calls_until_401: Option<u64>,
     /// `Some(n)`: n more CreateCacheEntry calls succeed, then quota errors.
     creates_until_quota: Option<u64>,
+    /// When set, every CreateCacheEntry is refused with a write-denied
+    /// response (models a read-only runtime token: check_run, fork PR).
+    deny_writes: bool,
     /// Number of upcoming blob GETs whose connection gets dropped mid-body.
     blob_read_failures: u64,
     /// While > 0, download lookups pretend the newest matching entry does
@@ -160,6 +163,13 @@ async fn twirp_create(State(state): State<AppState>, body: Bytes) -> Response {
         return twirp_error(StatusCode::BAD_REQUEST, "malformed", "bad json");
     };
     let mut inner = state.inner.lock().unwrap();
+    if inner.deny_writes {
+        return Json(json!({
+            "ok": false,
+            "message": "cache write denied: token has no writable scopes"
+        }))
+        .into_response();
+    }
     // Quota injection: reservations are what the real service rejects when
     // the repository cache is full.
     if let Some(remaining) = &mut inner.creates_until_quota {
@@ -613,6 +623,7 @@ impl FakeGha {
             blob_requests: Vec::new(),
             twirp_calls_until_401: None,
             creates_until_quota: None,
+            deny_writes: false,
             blob_read_failures: 0,
             stale_lookups_remaining: 0,
             stale_lookups_after: 0,
@@ -676,6 +687,12 @@ impl FakeGha {
     /// which lets GC tests simulate days passing.
     pub fn set_clock(&self, unix_seconds: u64) {
         self.inner.lock().unwrap().clock = unix_seconds;
+    }
+
+    /// Refuse every reservation with a write-denied response, modelling a
+    /// read-only runtime token (check_run, fork pull_request).
+    pub fn deny_writes(&self) {
+        self.inner.lock().unwrap().deny_writes = true;
     }
 
     /// Twirp client pointed at this fake.


### PR DESCRIPTION

A runtime token with no writable cache scope (check_run, fork
pull_requests) can read the cache but cannot reserve entries. The daemon
discovered this only at drain time, at the first reservation, after
chunking and verifying the whole closure; the post-step then reported it
as a "drain failed; paths were not cached" warning, indistinguishable
from a real failure.

Probe the token's write scope once at startup. The probe is spawned after
the listeners bind, like the manifest load, so a stalled cache API cannot
delay readiness. On a read-only token the write pipeline is a no-op and
the operator gets one clear message; reads still work, so substitutions
keep being served. An unreachable cache stays writable so the real drain
can surface a genuine failure.
