### PR TITLE
docs: document eval-once / build-by-drv-path workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,92 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+  # End-to-end test of the matrix subaction: evaluate the fixture flake
+  # once with nix-eval-jobs, register the drv closures, and hand the
+  # matrix to build jobs that build by drv path without re-evaluating.
+  matrix-eval:
+    runs-on: ubuntu-latest
+    # The build job pushes the package closure to the cache.
+    needs: build
+    permissions:
+      actions: write
+      contents: read
+    outputs:
+      matrix: ${{ steps.eval.outputs.matrix }}
+      any-jobs: ${{ steps.eval.outputs.any-jobs }}
+      manifest-version: ${{ steps.eval.outputs.manifest-version }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: NixOS/nix-installer-action@main
+      # Dogfood substituter, so the nix build below substitutes instead of
+      # compiling (forks without the variables build from source).
+      - name: Start hestia cache (dogfood)
+        if: vars.HESTIA_DOGFOOD == 'true'
+        uses: ./
+      - name: Build hestia
+        run: nix build .# -o hestia-bin
+      # Instance under test on its own port/socket, started last: the
+      # HESTIA_* variables and the post-build-hook then point at it.
+      - uses: ./
+        with:
+          binary: ./hestia-bin/bin/hestia
+          listen: 127.0.0.1:37517
+          socket: /tmp/hestia-matrix/hook.sock
+      - name: Make the fixture derivations unique to this run
+        run: |
+          set -euo pipefail
+          # Fresh derivations every run, so the matrix is never fully cached
+          # and the build jobs below always exercise the drv-path round trip.
+          cp -r tests/fixtures/matrix-checks "$RUNNER_TEMP/matrix-checks"
+          sed -i "s/echo /echo ${{ github.run_id }}-${{ github.run_attempt }} /" \
+            "$RUNNER_TEMP/matrix-checks/flake.nix"
+      - id: eval
+        uses: ./matrix
+        with:
+          flake: path:${{ runner.temp }}/matrix-checks#checks
+          nix-eval-jobs: nix run nixpkgs#nix-eval-jobs --
+      - name: Assert the fixture jobs are in the matrix
+        run: |
+          set -euo pipefail
+          echo '${{ steps.eval.outputs.matrix }}' | jq .
+          test "${{ steps.eval.outputs.any-jobs }}" = "true"
+          names=$(echo '${{ steps.eval.outputs.matrix }}' | jq -r '.include[].name' | sort | paste -sd' ')
+          test "$names" = "small x86_64-linux.fast"
+
+  matrix-build:
+    needs: matrix-eval
+    if: needs.matrix-eval.outputs.any-jobs == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix-eval.outputs.matrix) }}
+    name: matrix-build (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: NixOS/nix-installer-action@main
+      # Dogfood substituter, so the nix build below substitutes instead of
+      # compiling (forks without the variables build from source).
+      - name: Start hestia cache (dogfood)
+        if: vars.HESTIA_DOGFOOD == 'true'
+        uses: ./
+      - name: Build hestia
+        run: nix build .# -o hestia-bin
+      # Instance under test: it must serve the drv closures registered by
+      # the eval job, hence wait-manifest-version.
+      - uses: ./
+        with:
+          binary: ./hestia-bin/bin/hestia
+          listen: 127.0.0.1:37517
+          socket: /tmp/hestia-matrix/hook.sock
+          wait-manifest-version: ${{ needs.matrix-eval.outputs.manifest-version }}
+      # No checkout of the fixture flake and no evaluation: the drv closure
+      # comes out of the cache.
+      - name: Build by drv path
+        run: nix build -L ${{ matrix.installables }}
+
   # End-to-end test of the hestia-cache action on a real runner: install
   # (locally built binary), nix.conf wiring, daemon readiness, post-build-hook
   # capture, manifest commit, and substitution back out of the cache.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ How it differs from [magic-nix-cache]:
   `429 Too Many Requests`.
 - A scheduled garbage-collection workflow keeps your repository inside
   GitHub's 10 GB cache quota by deleting paths no branch uses anymore.
+- A [`matrix` subaction](#build-matrix-eval-once-build-in-parallel) spreads
+  your flake's checks over parallel runners: evaluate once, build each
+  check as its own job.
 
 [magic-nix-cache]: https://github.com/DeterminateSystems/magic-nix-cache
 
@@ -30,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: NixOS/nix-installer-action@main
-      - uses: Mic92/hestia@v1
+      - uses: Mic92/hestia@v2
       - run: nix build .#
 ```
 
@@ -45,7 +48,9 @@ You will also want a daily GC workflow on the default branch to stay within
 the cache quota; copy [`.github/workflows/gc.yml`](.github/workflows/gc.yml)
 for that (its REST cache deletes are what need `actions: write`).
 
-See [Configuration](#configuration) for all action inputs.
+See [Configuration](#configuration) for all action inputs. For building
+each flake check as its own job, see the
+[`matrix` subaction](#build-matrix-eval-once-build-in-parallel).
 
 ## Comparison
 
@@ -126,9 +131,89 @@ All inputs are optional; the defaults work for the quick start above.
 The GC workflow takes one input: `dry-run` (plan only, delete nothing); see
 [`.github/workflows/gc.yml`](.github/workflows/gc.yml).
 
+The `matrix` subaction has its own inputs (`flake`, `nix-eval-jobs`,
+`runner-map`, `attr-prefix`, `skip-unmapped-systems`); see
+[`matrix/action.yml`](matrix/action.yml).
+
 Running the `hestia` binary yourself instead of using the action? See the
 [CLI reference](docs/cli.md). How it all works under the hood:
 [architecture](docs/architecture.md).
+
+## Build matrix (eval once, build in parallel)
+
+`Mic92/hestia/matrix` turns a flake's checks into a GitHub Actions build
+matrix: one runner per check, evaluated only once. The eval job runs
+`nix-eval-jobs`, uploads each check's `.drv` closure to the cache, and
+outputs the matrix of checks that are not cached yet. Each build job then
+fetches its derivation from the cache and builds it by store path — no
+per-job evaluation, no flake changes, and no job at all for checks whose
+results are already cached.
+
+```yaml
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      any-jobs: ${{ steps.matrix.outputs.any-jobs }}
+      manifest-version: ${{ steps.matrix.outputs.manifest-version }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: NixOS/nix-installer-action@main
+      - uses: Mic92/hestia@v2
+      - id: matrix
+        uses: Mic92/hestia/matrix@v2
+        with:
+          flake: ".#checks"                        # default
+          nix-eval-jobs: "nix run nixpkgs#nix-eval-jobs --"
+          # runner-map: |
+          #   x86_64-linux=ubuntu-24.04
+          #   aarch64-darwin=macos-14,self-hosted
+
+  build:
+    needs: eval
+    if: needs.eval.outputs.any-jobs == 'true'
+    name: ${{ matrix.name }} (${{ matrix.system }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.eval.outputs.matrix) }}
+    steps:
+      - uses: NixOS/nix-installer-action@main
+      - uses: Mic92/hestia@v2
+        with:
+          wait-manifest-version: ${{ needs.eval.outputs.manifest-version }}
+      - run: nix build -L ${{ matrix.installables }}
+```
+
+Jobs can steer the matrix from their `meta` attributes (read via
+`nix-eval-jobs --meta`, no flake plumbing needed):
+
+```nix
+checks.x86_64-linux.mycheck = pkgs.hello.overrideAttrs (old: {
+  meta = (old.meta or { }) // {
+    hestia.group = "small-checks";        # share one runner with the group
+    hestia.os = [ "self-hosted" "big" ];  # override the runner labels
+  };
+});
+```
+
+Notes:
+
+* Build jobs substitute the derivation and its inputs (drvs and sources)
+  from the cache. Dependency *outputs* are not part of that closure; they
+  come from the normal cache flow (earlier builds or upstream
+  substituters), so shared uncached dependencies are rebuilt by every
+  matrix job that needs them.
+* Input sources (fetched tarballs, patched srcs) count against the cache
+  quota. `upstream-cache-filter` does not skip them, because sources carry
+  no upstream signature.
+* Each matrix row also carries `attr`, so `nix build .#${{ matrix.attr }}`
+  works as a per-job-eval fallback.
+* GitHub limits a matrix to 256 jobs and a step output to 1 MB.
+
+Template repository with this workflow:
+[Mic92/hestia-drv-test](https://github.com/Mic92/hestia-drv-test).
 
 ## Security
 

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,14 @@ inputs:
       stay on upstream caches).
     required: false
     default: "false"
+  wait-manifest-version:
+    description: >
+      Wait up to 60s at daemon startup until the cache manifest has at least
+      this version. Matrix build jobs pass the eval job's `manifest-version`
+      output so the just-uploaded drv closures are visible despite GHA cache
+      lookup lag.
+    required: false
+    default: "0"
 
 # If both `binary` and `version` are explicitly empty, the action only
 # captures and exports the cache tokens (ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL).

--- a/action/action.yml
+++ b/action/action.yml
@@ -68,6 +68,14 @@ inputs:
       stay on upstream caches).
     required: false
     default: "false"
+  wait-manifest-version:
+    description: >
+      Wait up to 60s at daemon startup until the cache manifest has at least
+      this version. Matrix build jobs pass the eval job's `manifest-version`
+      output so the just-uploaded drv closures are visible despite GHA cache
+      lookup lag.
+    required: false
+    default: "0"
 
 # If both `binary` and `version` are explicitly empty, the action only
 # captures and exports the cache tokens (ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL).

--- a/action/main.js
+++ b/action/main.js
@@ -359,6 +359,10 @@ function serveFlags() {
   if (getInput('no-closure') === 'true') {
     flags.push('--no-closure');
   }
+  const waitManifestVersion = getInput('wait-manifest-version');
+  if (waitManifestVersion && waitManifestVersion !== '0') {
+    flags.push('--wait-manifest-version', waitManifestVersion);
+  }
   return flags;
 }
 

--- a/matrix/action.yml
+++ b/matrix/action.yml
@@ -1,0 +1,81 @@
+name: hestia-matrix
+description: >
+  Evaluate a flake once with nix-eval-jobs and emit a GitHub Actions build
+  matrix; derivation closures are uploaded to the hestia cache so build jobs
+  can run `nix build <drvPath>^*` without re-evaluating. Requires the main
+  Mic92/hestia action earlier in the same job.
+
+inputs:
+  flake:
+    description: Flake installable passed to nix-eval-jobs.
+    required: false
+    default: ".#checks"
+  nix-eval-jobs:
+    description: >
+      nix-eval-jobs command, split on whitespace; extra arguments may be
+      appended. Override to pin a specific build, e.g.
+      "nix run nixpkgs#nix-eval-jobs -- --workers 4".
+    required: false
+    default: "nix-eval-jobs"
+  runner-map:
+    description: >
+      Runner label overrides, one `system=label[,label...]` per line.
+      Unlisted systems keep the defaults (ubuntu-24.04, ubuntu-24.04-arm,
+      macos-13, macos-14).
+    required: false
+    default: ""
+  attr-prefix:
+    description: Prefix prepended (dot-joined) to every attr in the matrix.
+    required: false
+    default: ""
+  skip-unmapped-systems:
+    description: Skip jobs whose system has no runner mapping instead of failing.
+    required: false
+    default: "false"
+
+outputs:
+  matrix:
+    description: >
+      JSON build matrix of not-yet-cached jobs: `{ "include": [ { name,
+      system, os, attr, drvPath, installables }, ... ] }`.
+    value: ${{ steps.matrix.outputs.matrix }}
+  any-jobs:
+    description: '"true" when the matrix has at least one job.'
+    value: ${{ steps.matrix.outputs.any-jobs }}
+  manifest-version:
+    description: >
+      Cache manifest version that contains the registered drv closures.
+      Pass to the main hestia action's `wait-manifest-version` input in
+      build jobs.
+    value: ${{ steps.matrix.outputs.manifest-version }}
+
+runs:
+  using: composite
+  steps:
+    - id: matrix
+      shell: bash
+      env:
+        FLAKE: ${{ inputs.flake }}
+        NIX_EVAL_JOBS: ${{ inputs.nix-eval-jobs }}
+        RUNNER_MAP: ${{ inputs.runner-map }}
+        ATTR_PREFIX: ${{ inputs.attr-prefix }}
+        SKIP_UNMAPPED: ${{ inputs.skip-unmapped-systems }}
+      run: |
+        set -euo pipefail
+        if [ -z "${HESTIA_BIN:-}" ] || [ -z "${HESTIA_SOCKET:-}" ]; then
+          echo "::error::Mic92/hestia must run before Mic92/hestia/matrix in this job"
+          exit 1
+        fi
+        args=(matrix --flake "$FLAKE" --socket "$HESTIA_SOCKET" --nix-eval-jobs "$NIX_EVAL_JOBS")
+        while IFS= read -r mapping; do
+          if [ -n "$mapping" ]; then
+            args+=(--runner "$mapping")
+          fi
+        done <<< "$RUNNER_MAP"
+        if [ -n "$ATTR_PREFIX" ]; then
+          args+=(--attr-prefix "$ATTR_PREFIX")
+        fi
+        if [ "$SKIP_UNMAPPED" = "true" ]; then
+          args+=(--skip-unmapped-systems)
+        fi
+        "$HESTIA_BIN" "${args[@]}"

--- a/nix/crane.nix
+++ b/nix/crane.nix
@@ -13,7 +13,13 @@
   staticTarget ? null,
 }:
 let
-  src = craneLib.cleanCargoSource ../.;
+  # Cargo sources plus the nix fixtures the integration tests evaluate.
+  src = lib.cleanSourceWith {
+    src = ../.;
+    filter =
+      path: type: (lib.hasInfix "/tests/fixtures" path) || (craneLib.filterCargoSources path type);
+    name = "source";
+  };
 
   staticArgs = lib.optionalAttrs (staticTarget != null) (
     let
@@ -121,8 +127,11 @@ in
     // {
       inherit cargoArtifacts;
       # The integration tests drive real nix tooling (scratch stores,
-      # signing, nix copy) inside the sandbox.
-      nativeBuildInputs = [ pkgs.nix ];
+      # signing, nix copy, nix-eval-jobs) inside the sandbox.
+      nativeBuildInputs = [
+        pkgs.nix
+        pkgs.nix-eval-jobs
+      ];
       # nix needs a writable HOME.
       preBuild = ''
         export HOME="$(mktemp -d)"

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -12,6 +12,7 @@
       cargo
       cargo-watch
       cargo-nextest
+      nix-eval-jobs
     ];
 
     buildInputs = with pkgs; [

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,9 @@ pub struct Cli {
 pub enum Command {
     /// Run the per-job daemon: hook listener + substituter HTTP server.
     Serve(ServeArgs),
+    /// Evaluate a flake with nix-eval-jobs and emit a GitHub Actions build
+    /// matrix (drv closures registered for upload).
+    Matrix(MatrixArgs),
     /// Send $OUT_PATHS from a Nix post-build-hook to the daemon.
     Hook(HookArgs),
     /// Tell the daemon to upload pending paths and commit the manifest.
@@ -74,6 +77,45 @@ pub struct ServeArgs {
     /// Nix store database to read path metadata from.
     #[arg(long, default_value = crate::pathinfo::DEFAULT_DB_PATH)]
     pub db_path: PathBuf,
+
+    /// Wait up to 60s at startup until the loaded manifest's version is at
+    /// least this (0 = don't wait). Build jobs pass the version committed
+    /// by an eval job so its drv closures are visible despite GHA cache
+    /// lookup lag.
+    #[arg(long, value_name = "N", default_value_t = 0)]
+    pub wait_manifest_version: u64,
+}
+
+#[derive(Args, Debug)]
+pub struct MatrixArgs {
+    /// Flake installable passed to nix-eval-jobs.
+    #[arg(long, default_value = ".#checks")]
+    pub flake: String,
+
+    /// nix-eval-jobs command, split on whitespace; extra arguments may be
+    /// appended (e.g. "nix run nixpkgs#nix-eval-jobs -- --workers 4").
+    #[arg(long, default_value = "nix-eval-jobs", value_name = "CMD")]
+    pub nix_eval_jobs: String,
+
+    /// Runner mapping override: <system>=<label>[,<label>...]. Repeatable.
+    #[arg(long = "runner", value_name = "SYSTEM=LABELS")]
+    pub runners: Vec<String>,
+
+    /// Skip jobs whose system has no runner mapping instead of failing.
+    #[arg(long)]
+    pub skip_unmapped_systems: bool,
+
+    /// Prefix prepended (dot-joined) to every attr in the matrix.
+    #[arg(long, default_value = "")]
+    pub attr_prefix: String,
+
+    /// Unix socket path of the running daemon.
+    #[arg(long, default_value = DEFAULT_SOCKET)]
+    pub socket: PathBuf,
+
+    /// Maximum time to wait for the drv upload to finish, in seconds.
+    #[arg(long, value_name = "SECONDS", default_value_t = 300)]
+    pub drain_timeout: u64,
 }
 
 #[derive(Args, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod gc;
 pub mod gha;
 pub mod hook;
 pub mod manifest;
+pub mod matrix;
 pub mod pathinfo;
 pub mod pipeline;
 pub mod protocol;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,14 @@ use std::process::ExitCode;
 use clap::Parser;
 
 use hestia::cli::{Cli, Command};
-use hestia::{drain, gc, hook, serve};
+use hestia::{drain, gc, hook, matrix, serve};
 
 #[tokio::main]
 async fn main() -> ExitCode {
     let cli = Cli::parse();
     match cli.command {
         Command::Serve(args) => serve::run(&args).await,
+        Command::Matrix(args) => matrix::run(&args).await,
         Command::Hook(args) => hook::run(&args).await,
         Command::Drain(args) => drain::run(&args).await,
         Command::Gc(args) => gc::run(&args).await,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,0 +1,592 @@
+//! `hestia matrix`: evaluate a flake once and emit a GitHub Actions build
+//! matrix.
+//!
+//! Runs nix-eval-jobs over the flake, registers the resulting `.drv` paths
+//! with the daemon, triggers a drain, and prints a matrix of not-yet-cached
+//! jobs; build jobs then run `nix build <drvPath>^*` without re-evaluating.
+//! The output shape matches nix-github-actions' `mkGithubMatrix`.
+
+use std::collections::BTreeMap;
+use std::io::Write as _;
+use std::process::{ExitCode, Stdio};
+use std::time::Duration;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::cli::MatrixArgs;
+use crate::protocol::{self, Request};
+
+/// Runner labels used when `--runner` does not override a system. Matches
+/// nix-github-actions' `githubPlatforms` so migrations keep their runners.
+const DEFAULT_RUNNERS: &[(&str, &str)] = &[
+    ("x86_64-linux", "ubuntu-24.04"),
+    ("aarch64-linux", "ubuntu-24.04-arm"),
+    ("x86_64-darwin", "macos-13"),
+    ("aarch64-darwin", "macos-14"),
+];
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to run {command}: {source}")]
+    Spawn {
+        command: String,
+        source: std::io::Error,
+    },
+
+    #[error("{command} exited with {status}")]
+    EvalFailed {
+        command: String,
+        status: std::process::ExitStatus,
+    },
+
+    #[error("evaluation failed:\n{0}")]
+    Eval(String),
+
+    #[error("malformed nix-eval-jobs output line: {reason}: {line}")]
+    Malformed { reason: String, line: String },
+
+    #[error(
+        "no runner mapping for system {0}; add --runner {0}=<label> or \
+         --skip-unmapped-systems"
+    )]
+    UnmappedSystem(String),
+
+    #[error("invalid --runner value {0:?}; expected <system>=<label>[,<label>...]")]
+    RunnerSpec(String),
+
+    #[error("group {group:?} mixes systems {a} and {b}; a matrix job runs on one runner")]
+    MixedSystems { group: String, a: String, b: String },
+
+    #[error("group {group:?} mixes runner labels {a:?} and {b:?}")]
+    MixedRunners {
+        group: String,
+        a: Vec<String>,
+        b: Vec<String>,
+    },
+
+    #[error("cannot write to $GITHUB_OUTPUT: {0}")]
+    Output(std::io::Error),
+}
+
+/// One job as reported by nix-eval-jobs (the fields hestia cares about).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvalJob {
+    pub attr: String,
+    pub drv_path: String,
+    pub system: String,
+    pub is_cached: bool,
+    /// `meta.hestia.os`: per-job runner label override.
+    pub runner_override: Option<Vec<String>>,
+    /// `meta.hestia.group`: jobs sharing a group share one matrix row.
+    pub group: Option<String>,
+}
+
+/// Parse nix-eval-jobs JSON-lines output. Evaluation errors (lines carrying
+/// an `error` field) fail the whole run: a matrix silently missing checks
+/// is worse than a failed eval job.
+pub fn parse_jobs(output: &str) -> Result<Vec<EvalJob>, Error> {
+    let mut jobs = Vec::new();
+    let mut errors = Vec::new();
+    for line in output.lines().filter(|line| !line.trim().is_empty()) {
+        let value: Value = serde_json::from_str(line).map_err(|err| Error::Malformed {
+            reason: err.to_string(),
+            line: line.to_string(),
+        })?;
+        let attr = value["attr"].as_str().unwrap_or("<unknown>").to_string();
+        if let Some(error) = value["error"].as_str() {
+            errors.push(format!("{attr}: {error}"));
+            continue;
+        }
+        let field = |name: &str| -> Result<String, Error> {
+            value[name]
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| Error::Malformed {
+                    reason: format!("missing field {name:?}"),
+                    line: line.to_string(),
+                })
+        };
+        let hestia_meta = &value["meta"]["hestia"];
+        jobs.push(EvalJob {
+            attr,
+            drv_path: field("drvPath")?,
+            system: field("system")?,
+            is_cached: value["isCached"].as_bool().unwrap_or(false),
+            runner_override: parse_labels(&hestia_meta["os"]),
+            group: hestia_meta["group"].as_str().map(str::to_string),
+        });
+    }
+    if !errors.is_empty() {
+        return Err(Error::Eval(errors.join("\n")));
+    }
+    Ok(jobs)
+}
+
+/// `meta.hestia.os`: a single label string or a list of labels.
+fn parse_labels(value: &Value) -> Option<Vec<String>> {
+    match value {
+        Value::String(label) => Some(vec![label.clone()]),
+        Value::Array(labels) => Some(
+            labels
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
+/// system → runner labels, defaults overridden by `--runner` flags.
+pub type RunnerMap = BTreeMap<String, Vec<String>>;
+
+pub fn runner_map(overrides: &[String]) -> Result<RunnerMap, Error> {
+    let mut map: RunnerMap = DEFAULT_RUNNERS
+        .iter()
+        .map(|(system, label)| ((*system).to_string(), vec![(*label).to_string()]))
+        .collect();
+    for spec in overrides {
+        let (system, labels) = spec
+            .split_once('=')
+            .ok_or_else(|| Error::RunnerSpec(spec.clone()))?;
+        let labels: Vec<String> = labels
+            .split(',')
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
+            .map(str::to_string)
+            .collect();
+        if system.trim().is_empty() || labels.is_empty() {
+            return Err(Error::RunnerSpec(spec.clone()));
+        }
+        map.insert(system.trim().to_string(), labels);
+    }
+    Ok(map)
+}
+
+/// One matrix row (one build job).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MatrixRow {
+    pub name: String,
+    pub system: String,
+    pub os: Vec<String>,
+    /// Full attribute path (first member for grouped rows), for the
+    /// `nix build .#$attr` fallback mode.
+    pub attr: String,
+    /// Derivation path (first member for grouped rows).
+    #[serde(rename = "drvPath")]
+    pub drv_path: String,
+    /// Space-separated `<drvPath>^*` list, ready for `nix build`.
+    pub installables: String,
+}
+
+/// Turn eval jobs into matrix rows: dedup by drvPath, drop cached jobs,
+/// resolve runners, and collapse `meta.hestia.group` members into one row.
+pub fn build_rows(
+    jobs: &[EvalJob],
+    runners: &RunnerMap,
+    skip_unmapped: bool,
+    attr_prefix: &str,
+) -> Result<Vec<MatrixRow>, Error> {
+    let mut seen_drvs = std::collections::BTreeSet::new();
+    let mut rows: Vec<MatrixRow> = Vec::new();
+    // Group name → index into `rows`, so members merge into one row while
+    // rows keep the eval order of their first member.
+    let mut group_index: BTreeMap<String, usize> = BTreeMap::new();
+
+    for job in jobs {
+        if !seen_drvs.insert(job.drv_path.clone()) || job.is_cached {
+            continue;
+        }
+        let os = match &job.runner_override {
+            Some(labels) => labels.clone(),
+            None => match runners.get(&job.system) {
+                Some(labels) => labels.clone(),
+                None if skip_unmapped => continue,
+                None => return Err(Error::UnmappedSystem(job.system.clone())),
+            },
+        };
+        let attr = prefixed(attr_prefix, &job.attr);
+        let installable = format!("{}^*", job.drv_path);
+
+        // A grouped job whose group already has a row merges into it.
+        if let Some(group) = &job.group
+            && let Some(&index) = group_index.get(group)
+        {
+            let row = &mut rows[index];
+            if row.system != job.system {
+                return Err(Error::MixedSystems {
+                    group: group.clone(),
+                    a: row.system.clone(),
+                    b: job.system.clone(),
+                });
+            }
+            if row.os != os {
+                return Err(Error::MixedRunners {
+                    group: group.clone(),
+                    a: row.os.clone(),
+                    b: os,
+                });
+            }
+            row.installables.push(' ');
+            row.installables.push_str(&installable);
+            continue;
+        }
+
+        if let Some(group) = &job.group {
+            group_index.insert(group.clone(), rows.len());
+        }
+        rows.push(MatrixRow {
+            name: job.group.clone().unwrap_or_else(|| attr.clone()),
+            system: job.system.clone(),
+            os,
+            attr,
+            drv_path: job.drv_path.clone(),
+            installables: installable,
+        });
+    }
+    Ok(rows)
+}
+
+fn prefixed(prefix: &str, attr: &str) -> String {
+    if prefix.is_empty() {
+        attr.to_string()
+    } else {
+        format!("{}.{attr}", prefix.trim_end_matches('.'))
+    }
+}
+
+/// The step outputs: `matrix`, `any-jobs`, `manifest-version`.
+pub fn outputs(rows: &[MatrixRow], manifest_version: u64) -> Vec<(String, String)> {
+    let matrix = serde_json::json!({ "include": rows });
+    vec![
+        ("matrix".to_string(), matrix.to_string()),
+        ("any-jobs".to_string(), (!rows.is_empty()).to_string()),
+        ("manifest-version".to_string(), manifest_version.to_string()),
+    ]
+}
+
+/// Register the drv paths with the daemon and drain, returning the
+/// committed manifest version. Never fatal: the matrix still works without
+/// a reachable daemon (`nix build .#$attr` mode), so a warning beats
+/// failing the eval job.
+async fn register_and_drain(args: &MatrixArgs, drv_paths: Vec<String>) -> u64 {
+    if drv_paths.is_empty() {
+        return 0;
+    }
+    let count = drv_paths.len();
+    let request = Request::Add { paths: drv_paths };
+    if let Err(err) = protocol::roundtrip(&args.socket, &request).await {
+        eprintln!(
+            "hestia matrix: cannot register {count} drv path(s) with the daemon at {}: {err} \
+             (matrix is still emitted; drv closures will not be cached)",
+            args.socket.display()
+        );
+        return 0;
+    }
+    let drain = protocol::roundtrip(&args.socket, &Request::Drain);
+    match tokio::time::timeout(Duration::from_secs(args.drain_timeout), drain).await {
+        Ok(Ok(response)) => {
+            let stats = response.stats.unwrap_or_default();
+            eprintln!("hestia matrix: {}", crate::drain::summarize(&stats));
+            stats.manifest_version
+        }
+        Ok(Err(err)) => {
+            eprintln!("hestia matrix: drain failed: {err} (matrix is still emitted)");
+            0
+        }
+        Err(_) => {
+            eprintln!(
+                "hestia matrix: daemon still draining after {}s; outcome unknown \
+                 (matrix is still emitted)",
+                args.drain_timeout
+            );
+            0
+        }
+    }
+}
+
+/// Run nix-eval-jobs and return its stdout (stderr is passed through).
+async fn run_nix_eval_jobs(args: &MatrixArgs) -> Result<String, Error> {
+    // Whitespace-split command string: covers "nix run ... --" style
+    // wrappers and extra flags without a separate repeatable argument.
+    let mut words = args.nix_eval_jobs.split_whitespace();
+    let program = words.next().unwrap_or("nix-eval-jobs");
+    let mut command = tokio::process::Command::new(program);
+    command
+        .args(words)
+        .arg("--flake")
+        .arg(&args.flake)
+        .arg("--check-cache-status")
+        .arg("--meta")
+        // checks/hydraJobs are plain nested attrsets; without forced
+        // recursion nix-eval-jobs finds no derivations in them.
+        .arg("--force-recurse")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    let output = command.output().await.map_err(|source| Error::Spawn {
+        command: args.nix_eval_jobs.clone(),
+        source,
+    })?;
+    if !output.status.success() {
+        return Err(Error::EvalFailed {
+            command: args.nix_eval_jobs.clone(),
+            status: output.status,
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Print the outputs; under GitHub Actions also append them to
+/// `$GITHUB_OUTPUT`.
+fn emit_outputs(outputs: &[(String, String)]) -> Result<(), Error> {
+    for (name, value) in outputs {
+        println!("{name}={value}");
+    }
+    if let Ok(path) = std::env::var("GITHUB_OUTPUT")
+        && !path.is_empty()
+    {
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&path)
+            .map_err(Error::Output)?;
+        for (name, value) in outputs {
+            writeln!(file, "{name}={value}").map_err(Error::Output)?;
+        }
+    }
+    Ok(())
+}
+
+pub async fn run(args: &MatrixArgs) -> ExitCode {
+    match run_inner(args).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("hestia matrix: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run_inner(args: &MatrixArgs) -> Result<(), Error> {
+    let stdout = run_nix_eval_jobs(args).await?;
+    let jobs = parse_jobs(&stdout)?;
+    let runners = runner_map(&args.runners)?;
+    let rows = build_rows(
+        &jobs,
+        &runners,
+        args.skip_unmapped_systems,
+        &args.attr_prefix,
+    )?;
+
+    // Register every distinct drv (cached outputs included: their drv may
+    // still be missing from the cache) so build jobs can substitute the
+    // drv closure.
+    let mut drv_paths: Vec<String> = jobs.iter().map(|job| job.drv_path.clone()).collect();
+    drv_paths.sort();
+    drv_paths.dedup();
+    let manifest_version = register_and_drain(args, drv_paths).await;
+
+    eprintln!(
+        "hestia matrix: {} job(s) to build ({} evaluated)",
+        rows.len(),
+        jobs.len()
+    );
+    emit_outputs(&outputs(&rows, manifest_version))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job(attr: &str, system: &str) -> EvalJob {
+        EvalJob {
+            attr: attr.to_string(),
+            drv_path: format!("/nix/store/{attr}-{system}.drv"),
+            system: system.to_string(),
+            is_cached: false,
+            runner_override: None,
+            group: None,
+        }
+    }
+
+    fn default_runners() -> RunnerMap {
+        runner_map(&[]).unwrap()
+    }
+
+    #[test]
+    fn parses_jobs_meta_and_cache_status() {
+        let output = concat!(
+            r#"{"attr":"x86_64-linux.a","drvPath":"/nix/store/a.drv","system":"x86_64-linux","isCached":false,"meta":{"hestia":{"group":"small","os":"self-hosted"}}}"#,
+            "\n",
+            r#"{"attr":"x86_64-linux.b","drvPath":"/nix/store/b.drv","system":"x86_64-linux","isCached":true,"meta":{"hestia":{"os":["self-hosted","big"]}}}"#,
+            "\n",
+        );
+        let jobs = parse_jobs(output).unwrap();
+        assert_eq!(jobs.len(), 2);
+        assert_eq!(jobs[0].group.as_deref(), Some("small"));
+        assert_eq!(
+            jobs[0].runner_override,
+            Some(vec!["self-hosted".to_string()])
+        );
+        assert!(!jobs[0].is_cached);
+        assert!(jobs[1].is_cached);
+        assert_eq!(
+            jobs[1].runner_override,
+            Some(vec!["self-hosted".to_string(), "big".to_string()])
+        );
+    }
+
+    #[test]
+    fn eval_errors_fail_the_run_with_the_attr_and_message() {
+        let output = concat!(
+            r#"{"attr":"x86_64-linux.ok","drvPath":"/nix/store/ok.drv","system":"x86_64-linux"}"#,
+            "\n",
+            r#"{"attr":"x86_64-linux.broken","error":"assertion failed"}"#,
+            "\n",
+        );
+        let err = parse_jobs(output).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("x86_64-linux.broken"), "{message}");
+        assert!(message.contains("assertion failed"), "{message}");
+    }
+
+    #[test]
+    fn malformed_lines_are_rejected() {
+        assert!(matches!(
+            parse_jobs("not json\n"),
+            Err(Error::Malformed { .. })
+        ));
+        assert!(matches!(
+            parse_jobs(r#"{"attr":"a","system":"x86_64-linux"}"#),
+            Err(Error::Malformed { .. })
+        ));
+    }
+
+    #[test]
+    fn cached_jobs_and_duplicate_drvs_are_dropped() {
+        let mut cached = job("cached", "x86_64-linux");
+        cached.is_cached = true;
+        let mut alias = job("a", "x86_64-linux");
+        alias.attr = "alias-of-a".to_string();
+        let jobs = vec![job("a", "x86_64-linux"), alias, cached];
+        let rows = build_rows(&jobs, &default_runners(), false, "").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].attr, "a");
+        assert_eq!(rows[0].os, vec!["ubuntu-24.04"]);
+        assert_eq!(rows[0].installables, format!("{}^*", rows[0].drv_path));
+    }
+
+    #[test]
+    fn runner_map_defaults_overrides_and_meta_os() {
+        let runners = runner_map(&["x86_64-linux=self-hosted, big".to_string()]).unwrap();
+        let mut meta_os = job("c", "x86_64-linux");
+        meta_os.runner_override = Some(vec!["macos-15".to_string()]);
+        let rows = build_rows(
+            &[
+                job("a", "x86_64-linux"),
+                job("b", "aarch64-darwin"),
+                meta_os,
+            ],
+            &runners,
+            false,
+            "",
+        )
+        .unwrap();
+        assert_eq!(rows[0].os, vec!["self-hosted", "big"]);
+        assert_eq!(rows[1].os, vec!["macos-14"]);
+        assert_eq!(rows[2].os, vec!["macos-15"], "meta.hestia.os wins");
+
+        assert!(matches!(
+            runner_map(&["nonsense".to_string()]),
+            Err(Error::RunnerSpec(_))
+        ));
+        assert!(matches!(
+            runner_map(&["riscv64-linux=".to_string()]),
+            Err(Error::RunnerSpec(_))
+        ));
+    }
+
+    #[test]
+    fn unmapped_systems_fail_or_are_skipped() {
+        let jobs = vec![job("a", "riscv64-linux"), job("b", "x86_64-linux")];
+        assert!(matches!(
+            build_rows(&jobs, &default_runners(), false, ""),
+            Err(Error::UnmappedSystem(system)) if system == "riscv64-linux"
+        ));
+        let rows = build_rows(&jobs, &default_runners(), true, "").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].attr, "b");
+    }
+
+    #[test]
+    fn grouped_jobs_share_one_row() {
+        let mut a = job("a", "x86_64-linux");
+        let mut b = job("b", "x86_64-linux");
+        a.group = Some("small".to_string());
+        b.group = Some("small".to_string());
+        let ungrouped = job("c", "x86_64-linux");
+        let rows = build_rows(
+            &[a.clone(), ungrouped, b.clone()],
+            &default_runners(),
+            false,
+            "",
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].name, "small");
+        assert_eq!(rows[0].attr, "a");
+        assert_eq!(rows[0].drv_path, a.drv_path);
+        assert_eq!(
+            rows[0].installables,
+            format!("{}^* {}^*", a.drv_path, b.drv_path)
+        );
+        assert_eq!(rows[1].name, "c");
+    }
+
+    #[test]
+    fn inconsistent_groups_are_rejected() {
+        let mut a = job("a", "x86_64-linux");
+        let mut b = job("b", "aarch64-darwin");
+        a.group = Some("g".to_string());
+        b.group = Some("g".to_string());
+        assert!(matches!(
+            build_rows(&[a.clone(), b], &default_runners(), false, ""),
+            Err(Error::MixedSystems { group, .. }) if group == "g"
+        ));
+
+        let mut c = job("c", "x86_64-linux");
+        c.group = Some("g".to_string());
+        c.runner_override = Some(vec!["self-hosted".to_string()]);
+        assert!(matches!(
+            build_rows(&[a, c], &default_runners(), false, ""),
+            Err(Error::MixedRunners { group, .. }) if group == "g"
+        ));
+    }
+
+    #[test]
+    fn attr_prefix_is_joined_with_a_dot() {
+        assert_eq!(prefixed("checks", "a"), "checks.a");
+        assert_eq!(prefixed("checks.", "a"), "checks.a");
+        assert_eq!(prefixed("", "a"), "a");
+    }
+
+    #[test]
+    fn outputs_are_matrix_any_jobs_and_manifest_version() {
+        let rows = build_rows(&[job("a", "x86_64-linux")], &default_runners(), false, "").unwrap();
+        let outputs = outputs(&rows, 7);
+        assert_eq!(outputs[1], ("any-jobs".to_string(), "true".to_string()));
+        assert_eq!(
+            outputs[2],
+            ("manifest-version".to_string(), "7".to_string())
+        );
+        let matrix: Value = serde_json::from_str(&outputs[0].1).unwrap();
+        assert_eq!(matrix["include"][0]["name"], "a");
+        assert_eq!(matrix["include"][0]["drvPath"], rows[0].drv_path);
+        assert_eq!(matrix["include"][0]["os"][0], "ubuntu-24.04");
+
+        let empty = super::outputs(&[], 0);
+        assert_eq!(empty[1].1, "false");
+        assert_eq!(empty[2].1, "0");
+    }
+}

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -435,6 +435,42 @@ async fn load_published_manifest(
     }
 }
 
+/// How long `--wait-manifest-version` retries the startup manifest load
+/// before giving up, and how long it pauses between attempts.
+const MANIFEST_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+const MANIFEST_WAIT_POLL: Duration = Duration::from_secs(2);
+
+/// Retry `reload` until the served manifest's version reaches
+/// `min_version` or the timeout expires (GHA cache lookups are eventually
+/// consistent: a manifest committed by the eval job moments ago may not be
+/// visible yet when a build job's daemon starts). On timeout the daemon
+/// serves whatever it found; missing paths then surface as cache misses.
+async fn wait_for_manifest_version<Fut: Future<Output = ()>>(
+    manifest_store: &ManifestStore,
+    min_version: u64,
+    reload: impl Fn() -> Fut,
+) {
+    // tokio's clock, not std::time::Instant: respects paused time in tests.
+    let deadline = tokio::time::Instant::now() + MANIFEST_WAIT_TIMEOUT;
+    loop {
+        reload().await;
+        if manifest_store.version() >= min_version {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            eprintln!(
+                "hestia serve: manifest version {} not visible after {}s (have {}); \
+                 serving what was found",
+                min_version,
+                MANIFEST_WAIT_TIMEOUT.as_secs(),
+                manifest_store.version(),
+            );
+            return;
+        }
+        tokio::time::sleep(MANIFEST_WAIT_POLL).await;
+    }
+}
+
 /// Accept errors that do not mean the listener is dead: a queued client
 /// that disconnected before being accepted, or momentary fd/buffer
 /// exhaustion. Treating these as fatal would kill caching for the rest of
@@ -603,6 +639,11 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         }
     };
 
+    // Narinfo requests block until the startup manifest load (and the
+    // optional --wait-manifest-version wait) finished; otherwise an early
+    // nix build races the load and sees spurious misses.
+    let (manifest_ready_tx, manifest_ready_rx) = tokio::sync::watch::channel(false);
+
     // The substituter HTTP server shares the manifest and access log with
     // the daemon and runs until the daemon exits.
     let substituter = Substituter::new(
@@ -613,6 +654,7 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         http.clone(),
     )
     .with_activity_hook(daemon.activity_hook())
+    .with_manifest_ready(manifest_ready_rx)
     .with_manifest_reload({
         let twirp = twirp.clone();
         let http = http.clone();
@@ -642,8 +684,16 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         let twirp = twirp.clone();
         let http = http.clone();
         let manifest_store = manifest_store.clone();
+        let min_version = args.wait_manifest_version;
         tokio::spawn(async move {
-            load_published_manifest(&twirp, &http, &manifest_store).await;
+            let reload = || {
+                let twirp = twirp.clone();
+                let http = http.clone();
+                let manifest_store = manifest_store.clone();
+                async move { load_published_manifest(&twirp, &http, &manifest_store).await }
+            };
+            wait_for_manifest_version(&manifest_store, min_version, reload).await;
+            let _ = manifest_ready_tx.send(true);
         })
     };
 
@@ -728,6 +778,49 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::manifest::Manifest;
+
+    #[tokio::test(start_paused = true)]
+    async fn manifest_wait_retries_until_the_version_appears() {
+        let store = ManifestStore::new();
+        let attempts = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let reload_store = store.clone();
+        let reload_attempts = attempts.clone();
+        wait_for_manifest_version(&store, 3, || {
+            let store = reload_store.clone();
+            let attempts = reload_attempts.clone();
+            async move {
+                // The version becomes visible on the third attempt.
+                if attempts.fetch_add(1, Ordering::SeqCst) + 1 >= 3 {
+                    store.set_version_if_newer(Manifest::new(), 3);
+                }
+            }
+        })
+        .await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert_eq!(store.version(), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn manifest_wait_gives_up_after_the_timeout() {
+        let store = ManifestStore::new();
+        let attempts = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let reload_attempts = attempts.clone();
+        wait_for_manifest_version(&store, 5, || {
+            let attempts = reload_attempts.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+            }
+        })
+        .await;
+        assert_eq!(store.version(), 0, "nothing was published");
+        let expected = 1 + MANIFEST_WAIT_TIMEOUT.as_secs() / MANIFEST_WAIT_POLL.as_secs();
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            expected,
+            "initial load + one per poll"
+        );
+    }
 
     #[test]
     fn transient_accept_errors_are_classified() {

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -150,6 +150,11 @@ impl ManifestStore {
         Arc::clone(&self.inner.read().expect("manifest lock poisoned"))
     }
 
+    /// SaveMutable version of the served manifest (0 = none loaded yet).
+    pub fn version(&self) -> u64 {
+        self.view().version
+    }
+
     /// Number of paths currently servable.
     pub fn path_count(&self) -> usize {
         self.view().manifest.paths.len()
@@ -445,6 +450,11 @@ pub type ManifestReload =
 /// idle clock once at request start.
 pub type ActivityHook = Arc<dyn Fn() -> Box<dyn Send> + Send + Sync>;
 
+/// Signals that the startup manifest load (including a
+/// `--wait-manifest-version` wait) has finished. Narinfo requests block on
+/// it so an early `nix build` cannot race the load and see spurious misses.
+pub type ManifestReady = tokio::sync::watch::Receiver<bool>;
+
 /// The substituter's shared state and configuration.
 pub struct Substituter {
     store_dir: StoreDir,
@@ -453,6 +463,7 @@ pub struct Substituter {
     fetcher: ChunkFetcher,
     activity_hook: Option<ActivityHook>,
     manifest_reload: Option<ManifestReload>,
+    manifest_ready: Option<ManifestReady>,
 }
 
 impl Substituter {
@@ -470,6 +481,7 @@ impl Substituter {
             fetcher: ChunkFetcher::new(twirp, http),
             activity_hook: None,
             manifest_reload: None,
+            manifest_ready: None,
         }
     }
 
@@ -483,6 +495,22 @@ impl Substituter {
     pub fn with_manifest_reload(mut self, reload: ManifestReload) -> Self {
         self.manifest_reload = Some(reload);
         self
+    }
+
+    /// Install a startup-load gate (see [`ManifestReady`]).
+    pub fn with_manifest_ready(mut self, ready: ManifestReady) -> Self {
+        self.manifest_ready = Some(ready);
+        self
+    }
+
+    /// Block until the startup manifest load finished (no-op without a
+    /// gate, or once it fired).
+    async fn manifest_ready(&self) {
+        if let Some(ready) = &self.manifest_ready {
+            // Only fails if the sender is dropped without sending; serve
+            // treats that as "nothing to wait for".
+            let _ = ready.clone().wait_for(|ready| *ready).await;
+        }
     }
 
     /// Build the axum router serving the binary cache protocol.
@@ -551,6 +579,7 @@ fn narinfo_for_entry(store_dir: &StoreDir, entry: &PathEntry, hash: &str) -> Vec
 
 async fn narinfo(State(state): State<Arc<Substituter>>, Path(file): Path<String>) -> Response {
     let _activity = state.touch();
+    state.manifest_ready().await;
     let Some(hash_str) = file.strip_suffix(".narinfo") else {
         return StatusCode::NOT_FOUND.into_response();
     };
@@ -753,6 +782,38 @@ mod tests {
             Some(&test_path_hash(1))
         );
         assert_eq!(view.by_nar_hash.get(&Hash32::digest([99])), None);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn narinfo_waits_for_the_startup_manifest_load() {
+        let mut manifest = Manifest::new();
+        manifest.paths.insert(test_path_hash(1), test_entry(1));
+        let store = ManifestStore::new();
+        store.set(manifest);
+
+        let (ready_tx, ready_rx) = tokio::sync::watch::channel(false);
+        let state = Arc::new(
+            Substituter::new(
+                StoreDir::default(),
+                store,
+                AccessLog::new(),
+                TwirpClient::new(reqwest::Client::new(), "http://unused", "token"),
+                reqwest::Client::new(),
+            )
+            .with_manifest_ready(ready_rx),
+        );
+
+        let request = tokio::spawn(narinfo(
+            State(state),
+            Path(format!("{}.narinfo", test_path_hash(1))),
+        ));
+        // The gate is closed: the request must still be pending.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(!request.is_finished(), "narinfo answered before the load");
+
+        ready_tx.send(true).unwrap();
+        let response = request.await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[test]

--- a/tests/fixtures/matrix-checks/flake.nix
+++ b/tests/fixtures/matrix-checks/flake.nix
@@ -1,0 +1,47 @@
+# Fixture for the `hestia matrix` end-to-end test (tests/matrix_cli.rs):
+# dependency-free checks so evaluation needs neither nixpkgs nor network.
+{
+  outputs =
+    { ... }:
+    {
+      checks.x86_64-linux = rec {
+        fast = derivation {
+          name = "fast";
+          system = "x86_64-linux";
+          builder = "/bin/sh";
+          args = [
+            "-c"
+            "echo fast > $out"
+          ];
+        };
+        # Same derivation under a second name: must collapse to one job.
+        fast-alias = fast;
+        small-1 =
+          derivation {
+            name = "small-1";
+            system = "x86_64-linux";
+            builder = "/bin/sh";
+            args = [
+              "-c"
+              "echo 1 > $out"
+            ];
+          }
+          // {
+            meta.hestia.group = "small";
+          };
+        small-2 =
+          derivation {
+            name = "small-2";
+            system = "x86_64-linux";
+            builder = "/bin/sh";
+            args = [
+              "-c"
+              "echo 2 > $out"
+            ];
+          }
+          // {
+            meta.hestia.group = "small";
+          };
+      };
+    };
+}

--- a/tests/matrix_cli.rs
+++ b/tests/matrix_cli.rs
@@ -1,0 +1,273 @@
+//! Integration tests for `hestia matrix`: the whole flow from a (fake)
+//! nix-eval-jobs invocation to the emitted matrix and the drv registration
+//! on the daemon socket.
+
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::Path;
+use std::process::Stdio;
+
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::net::UnixListener;
+use tokio::process::Command;
+
+use hestia::protocol::{DrainStats, Request, Response, encode_line};
+
+mod support;
+use support::store::ScratchStore;
+
+const HESTIA_BIN: &str = env!("CARGO_BIN_EXE_hestia");
+
+/// Write a fake nix-eval-jobs that dumps its arguments and prints fixture
+/// JSON lines.
+fn write_fake_nix_eval_jobs(dir: &Path, json_lines: &str) -> std::path::PathBuf {
+    let script = dir.join("fake-nix-eval-jobs");
+    let output = dir.join("nix-eval-jobs.args");
+    std::fs::write(
+        &script,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\ncat <<'EOF'\n{json_lines}\nEOF\n",
+            output.display()
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    script
+}
+
+/// Serve the daemon protocol for one connection per request: Add responds
+/// ok, Drain responds with `manifest_version`. Returns the received
+/// requests.
+async fn fake_daemon(listener: UnixListener, manifest_version: u64) -> Vec<Request> {
+    let mut requests = Vec::new();
+    // hestia matrix opens one connection per roundtrip: Add, then Drain.
+    for _ in 0..2 {
+        let (stream, _) = listener.accept().await.expect("accept failed");
+        let mut stream = BufReader::new(stream);
+        let mut line = String::new();
+        stream.read_line(&mut line).await.unwrap();
+        let request: Request = serde_json::from_str(&line).unwrap();
+        let response = match &request {
+            Request::Add { paths } => Response::ok().with_buffered(paths.len()),
+            Request::Drain => Response::ok().with_stats(DrainStats {
+                manifest_version,
+                ..DrainStats::default()
+            }),
+            Request::Status => Response::ok().with_buffered(0),
+        };
+        requests.push(request);
+        stream
+            .get_mut()
+            .write_all(&encode_line(&response).unwrap())
+            .await
+            .unwrap();
+    }
+    requests
+}
+
+const FIXTURE: &str = concat!(
+    r#"{"attr":"x86_64-linux.a","drvPath":"/nix/store/aaa-a.drv","system":"x86_64-linux","isCached":false}"#,
+    "\n",
+    r#"{"attr":"x86_64-linux.b","drvPath":"/nix/store/bbb-b.drv","system":"x86_64-linux","isCached":true}"#,
+);
+
+#[tokio::test]
+async fn matrix_registers_drvs_and_emits_outputs() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_fake_nix_eval_jobs(dir.path(), FIXTURE);
+    let socket = dir.path().join("hook.sock");
+    let github_output = dir.path().join("github-output");
+    let daemon = tokio::spawn(fake_daemon(UnixListener::bind(&socket).unwrap(), 42));
+
+    let output = Command::new(HESTIA_BIN)
+        .arg("matrix")
+        .arg("--nix-eval-jobs")
+        .arg(format!("{} --workers 4", script.display()))
+        .arg("--socket")
+        .arg(&socket)
+        .args(["--flake", ".#hydraJobs"])
+        .env("GITHUB_OUTPUT", &github_output)
+        .stdin(Stdio::null())
+        .output()
+        .await
+        .expect("failed to spawn hestia binary");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    // nix-eval-jobs got the extra args from the command string, the flake,
+    // and the standard flags.
+    let args = std::fs::read_to_string(dir.path().join("nix-eval-jobs.args")).unwrap();
+    let args: Vec<&str> = args.lines().collect();
+    assert_eq!(
+        args,
+        [
+            "--workers",
+            "4",
+            "--flake",
+            ".#hydraJobs",
+            "--check-cache-status",
+            "--meta",
+            "--force-recurse"
+        ]
+    );
+
+    // Both drvs (cached one included) were registered, then drained.
+    let requests = daemon.await.unwrap();
+    assert_eq!(
+        requests[0],
+        Request::Add {
+            paths: vec![
+                "/nix/store/aaa-a.drv".to_string(),
+                "/nix/store/bbb-b.drv".to_string(),
+            ]
+        }
+    );
+    assert_eq!(requests[1], Request::Drain);
+
+    // Outputs land in $GITHUB_OUTPUT: only the uncached job in the matrix,
+    // and the drain's manifest version.
+    let outputs = std::fs::read_to_string(&github_output).unwrap();
+    assert!(outputs.contains("any-jobs=true"), "{outputs}");
+    assert!(outputs.contains("manifest-version=42"), "{outputs}");
+    let matrix_line = outputs
+        .lines()
+        .find_map(|line| line.strip_prefix("matrix="))
+        .expect("matrix output present");
+    let matrix: serde_json::Value = serde_json::from_str(matrix_line).unwrap();
+    let include = matrix["include"].as_array().unwrap();
+    assert_eq!(include.len(), 1);
+    assert_eq!(include[0]["attr"], "x86_64-linux.a");
+    assert_eq!(include[0]["drvPath"], "/nix/store/aaa-a.drv");
+    assert_eq!(include[0]["os"][0], "ubuntu-24.04");
+    assert_eq!(include[0]["installables"], "/nix/store/aaa-a.drv^*");
+}
+
+#[tokio::test]
+async fn missing_daemon_still_emits_the_matrix() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_fake_nix_eval_jobs(dir.path(), FIXTURE);
+
+    let output = Command::new(HESTIA_BIN)
+        .arg("matrix")
+        .arg("--nix-eval-jobs")
+        .arg(&script)
+        .args(["--socket", "/nonexistent/hestia/hook.sock"])
+        .env_remove("GITHUB_OUTPUT")
+        .output()
+        .await
+        .expect("failed to spawn hestia binary");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(stderr.contains("cannot register"), "{stderr}");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("manifest-version=0"), "{stdout}");
+    assert!(stdout.contains("any-jobs=true"), "{stdout}");
+    assert!(
+        stdout.contains(r#""drvPath":"/nix/store/aaa-a.drv""#),
+        "{stdout}"
+    );
+}
+
+/// End-to-end against the real nix-eval-jobs on a tiny dependency-free
+/// flake: catches drift in the nix-eval-jobs CLI/JSON interface that the
+/// fake-script tests above cannot see.
+#[tokio::test]
+async fn real_nix_eval_jobs_produces_the_matrix() {
+    // No --version flag; --help is the cheapest liveness probe.
+    let eval_jobs_works = std::process::Command::new("nix-eval-jobs")
+        .arg("--help")
+        .output()
+        .is_ok_and(|output| output.status.success());
+    if !eval_jobs_works {
+        eprintln!("skipping: nix-eval-jobs not available");
+        return;
+    }
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+
+    // Checked-in subflake with dependency-free checks (own directory: a
+    // `path:` flake copies its whole directory into the store).
+    let flake_dir =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/matrix-checks");
+
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("hook.sock");
+    let daemon = tokio::spawn(fake_daemon(UnixListener::bind(&socket).unwrap(), 3));
+
+    let output = Command::new(HESTIA_BIN)
+        .arg("matrix")
+        .args(["--nix-eval-jobs", "nix-eval-jobs"])
+        .arg("--flake")
+        .arg(format!("path:{}#checks", flake_dir.display()))
+        .arg("--socket")
+        .arg(&socket)
+        // Hermetic: scratch store, no substituters (so --check-cache-status
+        // stays offline), flakes enabled regardless of the host config.
+        .env("NIX_REMOTE", store.store_uri())
+        .env(
+            "NIX_CONFIG",
+            "experimental-features = nix-command flakes\nsubstituters =\n",
+        )
+        .env_remove("GITHUB_OUTPUT")
+        .output()
+        .await
+        .expect("failed to spawn hestia binary");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stderr: {stderr}\nstdout: {stdout}"
+    );
+
+    // Three distinct drvs registered (the alias collapses).
+    let requests = daemon.await.unwrap();
+    let Request::Add { paths } = &requests[0] else {
+        panic!("expected Add, got {:?}", requests[0]);
+    };
+    assert_eq!(paths.len(), 3, "paths: {paths:?}");
+    assert!(paths.iter().all(|path| path.ends_with(".drv")));
+
+    // Two matrix rows: the plain check and the group.
+    let matrix_line = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("matrix="))
+        .expect("matrix output present");
+    let matrix: serde_json::Value = serde_json::from_str(matrix_line).unwrap();
+    let include = matrix["include"].as_array().unwrap();
+    let names: Vec<&str> = include
+        .iter()
+        .map(|row| row["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, ["x86_64-linux.fast", "small"], "matrix: {matrix}");
+    let group = &include[1];
+    assert_eq!(group["system"], "x86_64-linux");
+    assert_eq!(
+        group["installables"].as_str().unwrap().split(' ').count(),
+        2,
+        "group builds both members: {group}"
+    );
+    assert!(stdout.contains("manifest-version=3"), "{stdout}");
+}
+
+#[tokio::test]
+async fn eval_errors_fail_the_command() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_fake_nix_eval_jobs(
+        dir.path(),
+        r#"{"attr":"x86_64-linux.broken","error":"assertion failed"}"#,
+    );
+
+    let output = Command::new(HESTIA_BIN)
+        .arg("matrix")
+        .arg("--nix-eval-jobs")
+        .arg(&script)
+        .args(["--socket", "/nonexistent/hestia/hook.sock"])
+        .output()
+        .await
+        .expect("failed to spawn hestia binary");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("x86_64-linux.broken"), "{stderr}");
+    assert!(stderr.contains("assertion failed"), "{stderr}");
+}

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -159,6 +159,56 @@ async fn closure_expansion_pushes_dependencies() {
 }
 
 #[tokio::test]
+async fn registered_drv_is_pushed_with_its_input_closure() {
+    // Eval-only jobs register .drv paths from nix-eval-jobs via
+    // `hestia hook`; the drain must cache the drv plus its input closure
+    // so build jobs can run `nix build /nix/store/<hash>-x.drv^*`.
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+    let drv = store.instantiate_drv("eval-only");
+
+    // Oracle: the drv's registered references (input drv + source).
+    let references = match store
+        .database()
+        .query(&drv.to_string_lossy())
+        .expect("store database query failed")
+    {
+        hestia::pathinfo::Lookup::Found(info) => info.references,
+        other => panic!("drv must be valid in the store database, got {other:?}"),
+    };
+    assert!(
+        references.len() >= 2,
+        "drv must reference its input drv and input source, got {references:?}"
+    );
+
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let ctx = context(&fake, &http, store.database());
+
+    let stats = ctx
+        .run(to_path_set(&[&drv]), BTreeSet::new(), now_unix())
+        .await
+        .expect("pipeline run failed");
+
+    assert_eq!(stats.paths_received, 1);
+    assert_eq!(stats.pushed as usize, 1 + references.len());
+
+    let (_, manifest) = committed_manifest(&fake, &http)
+        .await
+        .expect("manifest committed");
+    assert!(manifest.paths.contains_key(&path_hash_of(&drv)));
+    for reference in &references {
+        let path = store.store_dir_path().join(reference.to_string());
+        assert!(
+            manifest.paths.contains_key(&path_hash_of(&path)),
+            "input {reference} must be cached"
+        );
+    }
+    assert_all_chunks_locatable(&manifest);
+}
+
+#[tokio::test]
 async fn no_closure_pushes_only_hooked_paths() {
     let Some(store) = ScratchStore::create() else {
         return;

--- a/tests/support/store.rs
+++ b/tests/support/store.rs
@@ -193,6 +193,43 @@ impl ScratchStore {
         (top, dep)
     }
 
+    /// Instantiate (not build) a derivation whose `.drv` references an
+    /// input derivation and an input source, like an eval-only
+    /// nix-eval-jobs run leaves behind. Returns the `.drv` store path.
+    pub fn instantiate_drv(&self, label: &str) -> PathBuf {
+        let expr = format!(
+            r#"let
+                 dep = derivation {{
+                   name = "{label}-dep";
+                   system = "x86_64-linux";
+                   builder = "/bin/sh";
+                   args = [ "-c" "echo dep > $out" ];
+                 }};
+                 src = builtins.toFile "{label}-src" "source for {label}";
+               in derivation {{
+                 name = "{label}";
+                 system = "x86_64-linux";
+                 builder = "/bin/sh";
+                 args = [ "-c" "cat ${{src}} > $out" ];
+                 inherit dep;
+               }}"#
+        );
+        let output = Command::new("nix-instantiate")
+            .arg("--store")
+            .arg(self.store_uri())
+            .args(["--expr", &expr])
+            .output()
+            .expect("running nix-instantiate failed");
+        assert!(
+            output.status.success(),
+            "nix-instantiate failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        // Newer nix appends a `!<output>` suffix; strip it.
+        let drv = String::from_utf8(output.stdout).unwrap();
+        PathBuf::from(drv.trim().split('!').next().unwrap())
+    }
+
     /// Sign a store path with a freshly generated key of the given name.
     /// Used to simulate upstream (cache.nixos.org) signatures hermetically.
     pub fn sign_path(&self, path: &Path, key_name: &str) {


### PR DESCRIPTION
nix-eval-jobs based setups evaluate once and build each .drv path in a matrix job. Derivations written during evaluation never fire the post-build-hook, so the drvs never reached the cache and build jobs had to re-evaluate. Document registering them explicitly with 'hestia hook' and add a regression test that a registered .drv is uploaded together with its input closure (input drvs and sources), which is what the build jobs need to substitute.