### PR TITLE
chunker: avoid full-file copies during reference normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ dependencies = [
  "harmonia-utils-hash",
  "harmonia-utils-io",
  "harmonia-utils-signature",
+ "memmap2",
  "proptest",
  "serde",
  "serde_json",
@@ -1437,6 +1438,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"

--- a/hestia-core/Cargo.toml
+++ b/hestia-core/Cargo.toml
@@ -30,7 +30,10 @@ futures-util = "0.3"
 thiserror = "2"
 
 # Blob payloads (cheap clones for upload retries)
-bytes = "1"
+bytes = "1.9"
+
+# Copy-on-write mappings for normalizing large files without a full copy
+memmap2 = "0.9"
 
 # Harmonia crates (not on crates.io; pinned to a specific rev)
 harmonia-file-core = { git = "https://github.com/nix-community/harmonia", rev = "bba51756f92a488d440e4c426747fb681abce4a7" }

--- a/hestia-core/src/chunker.rs
+++ b/hestia-core/src/chunker.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Cursor;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task::Poll;
 
@@ -19,7 +19,7 @@ use harmonia_file_nar::{NarByteStream, NarEvent, NarWriter};
 
 use crate::manifest::{
     ChunkHash, ChunkList, ChunkLocation, Directory, FileSystemObject, FileTree, Hash32, PackHash,
-    Regular, Symlink,
+    Regular, Rewrite, Symlink,
 };
 use crate::refnorm::RefTable;
 
@@ -467,6 +467,27 @@ impl TreeBuilder {
     }
 }
 
+/// Files at or above this size are normalized on a copy-on-write mapping of
+/// the on-disk file: only pages containing a reference occurrence get
+/// copied, so a large binary no longer doubles its resident size during
+/// chunking. Below the threshold a plain copy is cheaper than open+mmap.
+const COW_NORMALIZE_THRESHOLD: u64 = 64 * 1024 * 1024;
+
+/// Normalize a file's references on a copy-on-write mapping of its on-disk
+/// contents. `None` when mapping fails or the size no longer matches the
+/// NAR walk's stat (caller falls back to the buffered path).
+fn cow_normalize(path: &Path, size: u64, refs: &RefTable) -> Option<(Bytes, Vec<Rewrite>)> {
+    let file = std::fs::File::open(path).ok()?;
+    if file.metadata().ok()?.len() != size {
+        return None;
+    }
+    // SAFETY: store paths are immutable once registered, so the mapped file
+    // is not truncated or rewritten underneath the mapping.
+    let mut map = unsafe { memmap2::MmapOptions::new().map_copy(&file).ok()? };
+    let rewrites = refs.normalize_in_place(&mut map);
+    Some((Bytes::from_owner(map), rewrites))
+}
+
 /// NAR permits arbitrary bytes in entry names and symlink targets, but the
 /// manifest stores them as UTF-8 (a representation limit); `what` names the
 /// field so the diagnostic points at the right one.
@@ -497,17 +518,28 @@ pub async fn chunk_path_with(
     refs: &RefTable,
     params: ChunkParams,
 ) -> Result<ChunkedPath, Error> {
-    let mut events = harmonia_file_nar::dump(path.into());
+    let root: PathBuf = path.into();
+    let mut events = harmonia_file_nar::dump(root.clone());
     let mut builder = TreeBuilder::new();
     let mut chunks: Vec<Chunk> = Vec::new();
     let mut seen: BTreeSet<ChunkHash> = BTreeSet::new();
+    // On-disk directory currently being walked (for cow_normalize).
+    let mut current_dir = root.clone();
 
     while let Some(event) = events.next().await {
         match event? {
             NarEvent::StartDirectory { name } => {
-                builder.start_directory(name_to_string(&name, "entry name")?);
+                let name = name_to_string(&name, "entry name")?;
+                if !name.is_empty() {
+                    current_dir.push(&name);
+                }
+                builder.start_directory(name);
             }
             NarEvent::EndDirectory => {
+                // The root directory has no name and was never pushed.
+                if current_dir != root {
+                    current_dir.pop();
+                }
                 builder.end_directory()?;
             }
             NarEvent::Symlink { name, target } => {
@@ -521,11 +553,22 @@ pub async fn chunk_path_with(
             NarEvent::File {
                 name,
                 executable,
-                size: _,
+                size,
                 reader,
             } => {
-                let data = reader.into_bytes();
-                let (normalized, rewrites) = refs.normalize(&data);
+                let entry_name = name_to_string(&name, "entry name")?;
+                // Large files with references normalize on a copy-on-write
+                // mapping; everything else uses the event reader's bytes,
+                // which normalize clones without copying when reference-free.
+                let cow = if !refs.is_empty() && size >= COW_NORMALIZE_THRESHOLD {
+                    cow_normalize(&current_dir.join(&entry_name), size, refs)
+                } else {
+                    None
+                };
+                let (normalized, rewrites) = match cow {
+                    Some(normalized) => normalized,
+                    None => refs.normalize(&reader.into_bytes()),
+                };
                 let file_chunks = chunk_data_with(&normalized, params);
                 let list = ChunkList {
                     chunks: file_chunks.iter().map(|chunk| chunk.hash).collect(),
@@ -537,7 +580,7 @@ pub async fn chunk_path_with(
                     }
                 }
                 builder.place(
-                    name_to_string(&name, "entry name")?,
+                    entry_name,
                     FileTree(FileSystemObject::Regular(Regular {
                         executable,
                         contents: list,

--- a/hestia-core/src/chunker.rs
+++ b/hestia-core/src/chunker.rs
@@ -108,13 +108,9 @@ const CHUNK_SEGMENT_SIZE: usize = 16 * 1024 * 1024;
 
 /// Split file contents into content-defined chunks.
 ///
-/// Deterministic: same input, same chunks, independent of core count.
-/// Boundaries depend only on MIN/AVG/MAX_CHUNK_SIZE, the fastcdc version,
-/// and the CHUNK_SEGMENT_SIZE seam cuts.
-///
-/// A multi-segment file chunks across cores, so one big output -- where a
-/// closure's bytes concentrate -- is not stuck on one core (inter-path
-/// concurrency cannot split a single file).
+/// Deterministic: boundaries depend only on the FastCDC parameters and the
+/// CHUNK_SEGMENT_SIZE seam cuts, never on core count. Multi-segment files
+/// chunk across cores so one big output is not stuck on a single core.
 pub fn chunk_data(data: &Bytes) -> Vec<Chunk> {
     chunk_data_with(data, ChunkParams::default())
 }
@@ -224,12 +220,8 @@ impl PackBuilder {
     }
 
     /// Append an already-compressed chunk frame without recompressing it.
-    ///
-    /// Used by the write pipeline (frames freshly produced by
-    /// [`compress_chunks`]; integrity covered by the NAR-hash gate over the
-    /// uncompressed data) and by GC repack (frames Range-read from source
-    /// packs and copied byte-identically after verification via
-    /// [`extract_chunk`]). Returns whether the chunk was actually added
+    /// Used by the write pipeline and GC repack. The caller is responsible
+    /// for verifying the frame. Returns whether the chunk was added
     /// (duplicates are skipped).
     pub fn add_compressed(
         &mut self,
@@ -290,12 +282,10 @@ const CHUNKS_PER_COMPRESS_WORKER: usize = 64;
 
 /// Compress a path's chunks, preserving order.
 ///
-/// zstd is the dominant CPU cost of a drain. The pipeline compresses many
-/// paths concurrently, so small paths stay single-threaded (spawning a
-/// thread pool for tens of chunks costs more than it saves); a large path
-/// -- often a single big output holding most of a closure's bytes -- spans
-/// cores, since inter-path concurrency alone cannot split it.
-/// Blocking: call via `spawn_blocking` from async code.
+/// Small paths stay single-threaded because the pipeline already compresses
+/// many paths concurrently. Large paths span cores since inter-path
+/// concurrency alone cannot split them. Blocking: call via `spawn_blocking`
+/// from async code.
 pub fn compress_chunks(chunks: Vec<Chunk>) -> Result<Vec<CompressedChunk>, Error> {
     let compress_one = |chunk: &Chunk| -> Result<CompressedChunk, Error> {
         Ok(CompressedChunk {
@@ -618,12 +608,6 @@ pub fn flatten_tree(tree: &FileTree<ChunkList>) -> Vec<(String, &TreeNode)> {
     out
 }
 
-// NAR replay (tree + chunk data -> NAR bytes -> hash) is the read-side
-// serialization path: the substituter rebuilds NARs from the manifest tree +
-// fetched chunks exactly like this. Using it on the write side to compute
-// nar_hash means a path's stored representation is proven to reproduce the
-// original NAR before anything is uploaded.
-
 /// Tokio `AsyncWrite` sink that hashes and counts bytes instead of storing
 /// them.
 struct HashSink {
@@ -743,13 +727,10 @@ fn concat_chunks(
     Ok(data)
 }
 
-/// NAR hash and size of a path, computed from its *stored representation*
-/// (file tree + chunk data) by replaying synthesized events through
-/// harmonia's [`NarWriter`].
-///
-/// The write pipeline compares this against the nar_hash recorded in the Nix
-/// database: equality proves the chunked representation reproduces the
-/// original NAR byte-identically, so it is safe to upload and serve.
+/// NAR hash and size computed from the stored representation (file tree +
+/// chunk data). The write pipeline compares this against the nar_hash in
+/// the Nix database: equality proves the chunked representation reproduces
+/// the original NAR before anything is uploaded.
 pub async fn nar_hash_from_chunks(
     tree: &FileTree<ChunkList>,
     chunks: &BTreeMap<ChunkHash, Bytes>,
@@ -760,14 +741,9 @@ pub async fn nar_hash_from_chunks(
     sink.finish()
 }
 
-/// Serialize a complete NAR from a path's *stored representation* (file
-/// tree + chunk data).
-///
-/// This is the read-side code path: the substituter rebuilds NARs from
-/// manifest trees plus fetched chunks with exactly this function. It shares
-/// the event synthesis with [`nar_hash_from_chunks`], which the write
-/// pipeline uses as its integrity gate — so the bytes served here are by
-/// construction the bytes whose hash was verified before upload.
+/// Serialize a complete NAR from the stored representation (file tree +
+/// chunk data). Shares event synthesis with [`nar_hash_from_chunks`], so
+/// the bytes served here are the bytes whose hash was verified on upload.
 pub async fn nar_from_chunks(
     tree: &FileTree<ChunkList>,
     chunks: &BTreeMap<ChunkHash, Bytes>,
@@ -799,18 +775,12 @@ async fn write_nar<W: tokio::io::AsyncWrite + Unpin>(
     Ok(())
 }
 
-/// Decompress and verify one chunk extracted from pack bytes.
+/// Decompress and verify one chunk extracted from pack bytes
+/// (`[offset, offset + compressed_size)`, one Range request).
 ///
-/// `compressed` is the byte slice at `[offset, offset + compressed_size)` of
-/// the pack blob — exactly what a Range request against the pack returns.
-/// The hash check is mandatory: the GHA cache is not trusted storage and a
-/// corrupt chunk must never be served onward.
-///
-/// Decompression is bounded at [`MAX_CHUNK_SIZE`]: no legitimate chunk can
-/// be larger (chunking splits at that bound), so anything bigger is corrupt
-/// or malicious pack data and gets rejected *before* its decompressed
-/// payload is buffered (zstd ratios above 1000:1 would otherwise let a tiny
-/// frame allocate gigabytes).
+/// The GHA cache is not trusted storage. The hash check is mandatory, and
+/// decompression is bounded at [`MAX_CHUNK_SIZE`] so a small malicious
+/// frame cannot allocate gigabytes.
 pub fn extract_chunk(compressed: &[u8], expected: &ChunkHash) -> Result<Vec<u8>, Error> {
     use std::io::Read as _;
     let mut data = Vec::new();
@@ -1041,13 +1011,9 @@ mod tests {
 
     #[test]
     fn extract_chunk_rejects_frames_larger_than_max_chunk_size() {
-        // Pack bytes come from the GHA cache, which is not trusted storage.
-        // No legitimate chunk exceeds MAX_CHUNK_SIZE (chunk_data splits with
-        // that bound), but zstd compresses runs of zeros at ratios well above
-        // 1000:1, so a small corrupt or malicious frame can decompress to a
-        // huge payload. extract_chunk must reject such frames at the size
-        // limit instead of buffering the full decompressed payload in memory
-        // (memory amplification in the substituter and GC repack).
+        // A small corrupt or malicious frame can decompress to a huge
+        // payload. extract_chunk must reject it at the size limit instead
+        // of buffering the full payload in memory.
         let bomb_payload = vec![0u8; 64 * 1024 * 1024];
         let frame = zstd::encode_all(bomb_payload.as_slice(), 3).unwrap();
         assert!(

--- a/hestia-core/src/manifest.rs
+++ b/hestia-core/src/manifest.rs
@@ -345,27 +345,18 @@ impl PathEntry {
         }
         // Deterministic winner: newer push wins, nar_hash as tie-break, the
         // CBOR encoding of the remaining content as the final tie-break.
-        //
-        // The final tie-break must be a *total* order over the entry
-        // content: two entries can tie on (last_pushed, nar_hash) while
-        // differing in metadata (the same output path can be produced by
-        // different derivations, so deriver/ca/references may differ, and
-        // concurrent jobs push within the same second routinely). Without a
-        // total order the merge would not be commutative, and the surviving
-        // entry would depend on which concurrent writer wins the
-        // SaveMutable race. The expensive encoding is computed only on a
-        // (last_pushed, nar_hash) tie.
+        // The final tie-break must be a total order. Entries can tie on
+        // (last_pushed, nar_hash) while differing in metadata, and without
+        // a total order the merge would not be commutative. The expensive
+        // encoding is computed only on a (last_pushed, nar_hash) tie.
         fn content_key(entry: &PathEntry) -> Vec<u8> {
-            // The clocks are folded with max() below; exclude them from the
-            // content tie-break so that folding never changes an entry's
-            // ordering (this keeps the merge associative as well).
+            // Exclude the max()-folded clocks so folding never changes an
+            // entry's ordering (keeps the merge associative).
             let mut content = entry.clone();
             content.last_reachable = 0;
             content.last_pushed = 0;
             let mut encoded = Vec::new();
-            // Serializing to a Vec cannot fail for manifest types (it is
-            // the same code path Manifest::encode uses); a failure would
-            // only weaken the tie-break, never panic.
+            // A serialization failure only weakens the tie-break, never panics.
             let _ = ciborium::into_writer(&content, &mut encoded);
             encoded
         }
@@ -625,14 +616,10 @@ const ZSTD_LEVEL: i32 = 9;
 
 /// Decompression bound for stored manifest blobs.
 ///
-/// The GHA cache is not trusted storage: without a bound, a small zstd
-/// bomb stored as the next manifest version would abort every serve,
-/// drain, and GC inside the allocator -- before the corrupt-manifest
-/// fallback (`decode_manifest_or_empty`) can trigger. Production manifest
-/// CBOR is single-digit megabytes, so 256 MiB is ample headroom while an
-/// over-long stream surfaces as a normal decode error. (A 28 GiB NAR /
-/// 4.4k-path workload measured ~70 MiB of manifest CBOR, so the previous
-/// 64 MiB bound was too tight for large caches.)
+/// The GHA cache is not trusted storage. Without a bound, a small zstd bomb
+/// would abort every serve, drain, and GC in the allocator. A 28 GiB NAR /
+/// 4.4k-path workload measured ~70 MiB of manifest CBOR, so 256 MiB leaves
+/// headroom while an over-long stream surfaces as a normal decode error.
 const MAX_MANIFEST_CBOR_BYTES: u64 = 256 * 1024 * 1024;
 
 impl Manifest {
@@ -1250,16 +1237,11 @@ mod tests {
 
     #[test]
     fn merge_is_commutative_when_push_clock_and_nar_hash_tie() {
-        // Two concurrent CI jobs can push the same store path within the
-        // same second (last_pushed has 1-second granularity) with identical
-        // content (same nar_hash) but different metadata: the same output
-        // path can be produced by different derivations, so deriver (and in
-        // principle ca/references) can differ between the two pushes.
-        //
-        // SaveMutable conflict resolution re-merges in whatever order the
-        // race produces; if the merge result depends on argument order, the
-        // surviving manifest depends on who wins that race -- exactly the
-        // non-determinism the merge rules promise to rule out.
+        // Concurrent CI jobs can push the same store path within the same
+        // second with identical content but different metadata (e.g.
+        // deriver). The merge result must not depend on argument order, or
+        // the surviving manifest would depend on who wins the SaveMutable
+        // race.
         let mut a = sample_path_entry(1);
         let mut b = sample_path_entry(1);
         a.deriver = Some(format!("{}-alpha.drv", path_hash(10)).parse().unwrap());

--- a/hestia-core/src/refnorm.rs
+++ b/hestia-core/src/refnorm.rs
@@ -25,6 +25,14 @@ pub const HASH_LEN: usize = 32;
 /// position table restores the real bytes), zeros compress best.
 const SENTINEL: [u8; HASH_LEN] = [0u8; HASH_LEN];
 
+/// Write the sentinel over each scanned occurrence.
+fn overwrite_with_sentinel(data: &mut [u8], rewrites: &[Rewrite]) {
+    for rewrite in rewrites {
+        let offset = rewrite.offset as usize;
+        data[offset..offset + HASH_LEN].copy_from_slice(&SENTINEL);
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("rewrite references index {index} but the path has {len} references")]
@@ -73,13 +81,12 @@ impl RefTable {
         self.hashes.is_empty()
     }
 
-    /// Replace every reference-hash occurrence with the sentinel, returning
-    /// the normalized bytes and the position table to restore them. Offsets
-    /// index the file content, identical in normalized and original bytes
-    /// (the sentinel is hash-length).
-    pub fn normalize(&self, data: &[u8]) -> (Bytes, Vec<Rewrite>) {
+    /// Find every reference-hash occurrence. Offsets index the file
+    /// content; the sentinel is hash-length, so offsets are identical in
+    /// original and normalized bytes.
+    fn scan(&self, data: &[u8]) -> Vec<Rewrite> {
         if self.hashes.is_empty() {
-            return (Bytes::copy_from_slice(data), Vec::new());
+            return Vec::new();
         }
         let scanner = self.scanner.get_or_init(|| {
             // All patterns are hash-length, so LeftmostLongest yields the
@@ -90,21 +97,37 @@ impl RefTable {
                 .build(&self.hashes)
                 .expect("aho-corasick build over fixed-length hashes")
         });
-        let mut out = Vec::with_capacity(data.len());
-        let mut rewrites = Vec::new();
-        // Start of the unmatched run not yet copied into `out`.
-        let mut last = 0;
-        for m in scanner.find_iter(data) {
-            out.extend_from_slice(&data[last..m.start()]);
-            rewrites.push(Rewrite {
-                offset: out.len() as u64,
+        scanner
+            .find_iter(data)
+            .map(|m| Rewrite {
+                offset: m.start() as u64,
                 ref_index: m.pattern().as_u32(),
-            });
-            out.extend_from_slice(&SENTINEL);
-            last = m.end();
+            })
+            .collect()
+    }
+
+    /// Replace every reference-hash occurrence with the sentinel, returning
+    /// the normalized bytes and the position table to restore them.
+    ///
+    /// Reference-free files (empty table or no occurrences) are returned as
+    /// a cheap clone of `data`, so mmap-backed file bytes stay zero-copy.
+    pub fn normalize(&self, data: &Bytes) -> (Bytes, Vec<Rewrite>) {
+        let rewrites = self.scan(data);
+        if rewrites.is_empty() {
+            return (data.clone(), rewrites);
         }
-        out.extend_from_slice(&data[last..]);
+        let mut out = data.to_vec();
+        overwrite_with_sentinel(&mut out, &rewrites);
         (Bytes::from(out), rewrites)
+    }
+
+    /// [`Self::normalize`] operating on a mutable buffer the caller owns
+    /// (e.g. a copy-on-write mapping): occurrences are overwritten in
+    /// place, so only the touched pages cost memory.
+    pub fn normalize_in_place(&self, data: &mut [u8]) -> Vec<Rewrite> {
+        let rewrites = self.scan(data);
+        overwrite_with_sentinel(data, &rewrites);
+        rewrites
     }
 
     /// Undo [`Self::normalize`]: copy each recorded reference hash back into
@@ -161,6 +184,7 @@ mod tests {
         content.extend_from_slice(b"/lib and self ");
         content.extend_from_slice(SELF.as_bytes());
         content.extend_from_slice(b" suffix padding past the hash-length bound");
+        let content = Bytes::from(content);
 
         let (normalized, rewrites) = table.normalize(&content);
         assert_eq!(rewrites.len(), 2);
@@ -170,6 +194,12 @@ mod tests {
         let mut restored = normalized.to_vec();
         table.restore(&mut restored, &rewrites).unwrap();
         assert_eq!(restored, content);
+
+        // In-place normalization must produce identical output.
+        let mut in_place = content.to_vec();
+        let in_place_rewrites = table.normalize_in_place(&mut in_place);
+        assert_eq!(in_place, normalized);
+        assert_eq!(in_place_rewrites, rewrites);
     }
 
     #[test]
@@ -186,8 +216,8 @@ mod tests {
         b.extend_from_slice(GLIBC_B.as_bytes());
         b.extend_from_slice(b" trailer bytes beyond the hash window");
 
-        let (na, ra) = build_a.normalize(&a);
-        let (nb, rb) = build_b.normalize(&b);
+        let (na, ra) = build_a.normalize(&Bytes::from(a));
+        let (nb, rb) = build_b.normalize(&Bytes::from(b));
         assert_eq!(na, nb);
         assert_eq!(ra, rb);
     }
@@ -195,10 +225,25 @@ mod tests {
     #[test]
     fn empty_table_is_a_noop() {
         let table = RefTable::new(&[]);
-        let data = b"no references here, just content bytes to scan".to_vec();
+        let data = Bytes::from_static(b"no references here, just content bytes to scan");
         let (normalized, rewrites) = table.normalize(&data);
-        assert_eq!(normalized.as_ref(), data.as_slice());
+        assert_eq!(normalized, data);
         assert!(rewrites.is_empty());
+    }
+
+    #[test]
+    fn reference_free_content_is_not_copied() {
+        // Files without any occurrence must share the input buffer (cheap
+        // Bytes clone), so mmap-backed large files stay zero-copy.
+        let table = RefTable::new(&[store_path(GLIBC_A, "glibc")]);
+        let data = Bytes::from(vec![b'x'; 256 * 1024]);
+        let (normalized, rewrites) = table.normalize(&data);
+        assert!(rewrites.is_empty());
+        assert_eq!(
+            normalized.as_ptr(),
+            data.as_ptr(),
+            "expected a zero-copy clone"
+        );
     }
 
     #[test]

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -28,17 +28,13 @@
 //! `docs/gc.als`):
 //!
 //! * **Version protection**: packs referenced by *any surviving manifest
-//!   version* are never deleted. A drain's commit merges its drain-start
-//!   snapshot back in, which can resurrect references GC just dropped —
-//!   but the snapshot is one of the surviving versions, so everything it
-//!   can resurrect stays protected until cleanup ages the version out.
-//!   Garbage therefore survives one extra run.
-//! * **Recency**: packs whose newest REST entry was created *or accessed*
-//!   within min_age are never deleted — a drain may have just uploaded
-//!   the pack, or CAS-deduped onto it (which touches it; see
-//!   [`crate::pipeline::upload_pack`]). Recency is re-checked with a fresh
-//!   listing right before the REST deletes, so a re-upload landing after
-//!   the commit wins over the stale delete set.
+//!   version* are never deleted. A drain commit can only resurrect
+//!   references from one of those versions, so garbage survives one extra
+//!   run instead of being deleted out from under a concurrent drain.
+//! * **Recency**: packs created *or accessed* within min_age are never
+//!   deleted, because a drain may have just uploaded or CAS-touched them
+//!   without having committed yet. Recency is re-checked with a fresh
+//!   listing right before the REST deletes.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::ExitCode;
@@ -493,15 +489,11 @@ pub fn plan(
         });
     }
 
-    // CAS no-op trap: a job whose copies reproduce a single fully-live source
-    // pack byte-identically (frames are copied verbatim, in offset order)
-    // would produce the same content-addressed key → already_exists → the
-    // upload is skipped and the LRU clock is NOT reset. Since repack sources
-    // are also excluded from touching, such a pack would idle into GitHub's
-    // 7-day eviction while still referenced. Drop the job and let the pack
-    // be touched instead. This covers both the trivial single-source case
-    // and the tier-split case where consolidation isolates one pack's chunks
-    // into their own job.
+    // CAS no-op trap: a job that would reproduce a single fully-live source
+    // pack byte-identically hits already_exists on upload, which skips the
+    // LRU reset while the source is also excluded from touching. The pack
+    // would idle into GitHub's 7-day eviction while still referenced. Drop
+    // the job and let the pack be touched instead.
     plan.repack_jobs.retain(|job| {
         let sources: BTreeSet<PackHash> = job.copies.iter().map(|copy| copy.from.pack).collect();
         if sources.len() == 1 {
@@ -828,12 +820,11 @@ impl GcContext {
             .collect())
     }
 
-    /// Union of the pack tables of every surviving manifest version —
-    /// exactly the references a concurrent drain commit can resurrect (its
-    /// snapshot is one of these versions), so nothing in this set may be
-    /// deleted. A version that vanished since the listing protects
-    /// nothing; one that fails to decode aborts the run (deleting with
-    /// unknown references is unsafe).
+    /// Union of the pack tables of every surviving manifest version. This
+    /// is exactly what a concurrent drain commit can resurrect, so nothing
+    /// in this set may be deleted. A vanished version protects nothing. A
+    /// version that fails to decode aborts the run, since deleting with
+    /// unknown references is unsafe.
     pub async fn protected_packs(&self) -> Result<BTreeSet<PackHash>, Error> {
         let prefix = format!("{}#", self.manifest_prefix);
         let entries = self.rest.list_caches(&prefix).await?;

--- a/src/gha/savemutable.rs
+++ b/src/gha/savemutable.rs
@@ -18,20 +18,15 @@
 //! assumes a crashed peer and skips over that index.
 //!
 //! Consistency model (verified against the real service): **reservations
-//! are strongly consistent within a ref scope** (two writers in the same
-//! scope can never both reserve the same key) but **lookups are eventually
-//! consistent** (a
-//! just-finalized entry may not be returned by load() for a while).
-//! Cache entry uniqueness is per (key, version, ref scope): writers in
-//! different scopes (a PR job and a default-branch job) can both reserve
-//! and finalize the same key. Their lineages fork; the PR-scoped fork is
-//! discarded with its branch (see "PR scope isolation" in the README), so
-//! the no-lost-writes merge guarantee below is scope-local. The
-//! conflict-retry loop therefore re-loads until it sees the version that
-//! blocked it; the stale-skip window must be comfortably larger than the
-//! observed propagation lag, otherwise lag would be misdiagnosed as a
-//! crashed writer and the lagging version's changes dropped (benign for a
-//! lossy cache — those paths get rebuilt — but wasteful).
+//! are strongly consistent within a ref scope** while **lookups are
+//! eventually consistent**. Uniqueness is per (key, version, ref scope): a
+//! PR job and a default-branch job can both finalize the same key. The
+//! PR-scoped fork is discarded with its branch (see "PR scope isolation"
+//! in the README), so the no-lost-writes merge guarantee is scope-local.
+//! The conflict-retry loop re-loads until it sees the version that blocked
+//! it. The stale-skip window must exceed the observed propagation lag, or
+//! lag gets misdiagnosed as a crashed writer and the lagging changes are
+//! dropped.
 
 use std::time::Duration;
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -51,6 +51,19 @@ const UPLOAD_CONCURRENCY: usize = 4;
 /// width is capped at the CPU count.
 const CHUNK_CONCURRENCY: usize = 32;
 
+/// Upper bound on the summed NAR size of paths chunked and verified
+/// concurrently. The path-count cap alone does not bound memory: a few
+/// multi-hundred-MiB paths in flight at once would stack their buffers.
+/// Large paths serialize against this budget instead; small paths are
+/// unaffected.
+const CHUNK_INFLIGHT_NAR_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Semaphore permits for one path's chunk-and-verify stage: its NAR size,
+/// clamped so a path larger than the whole budget still runs (alone).
+fn chunk_permits(nar_size: u64) -> u32 {
+    nar_size.clamp(1, CHUNK_INFLIGHT_NAR_BYTES) as u32
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("GHA cache error: {0}")]
@@ -396,9 +409,17 @@ impl PipelineContext {
             // whole batch, and a deterministic failure would then keep every
             // later drain (including the shutdown drain) from caching
             // anything.
+            let inflight = Arc::new(tokio::sync::Semaphore::new(
+                CHUNK_INFLIGHT_NAR_BYTES as usize,
+            ));
             let mut verified = futures_util::stream::iter(to_push)
                 .map(|(path, info)| {
+                    let inflight = inflight.clone();
                     tokio::spawn(async move {
+                        let _permit = inflight
+                            .acquire_many(chunk_permits(info.nar_size))
+                            .await
+                            .expect("in-flight NAR byte semaphore is never closed");
                         let started = std::time::Instant::now();
                         // The path's own references drive both normalization
                         // (so chunks stay stable across dependency-hash
@@ -704,6 +725,15 @@ mod tests {
         assert!(!arch.is_empty() && !os.is_empty(), "system: {system}");
         assert!(!["x86", "arm", "macos"].contains(&arch), "arch: {arch}");
         assert_ne!(os, "macos", "os must use the Nix spelling");
+    }
+
+    #[test]
+    fn chunk_permits_clamp_to_the_budget() {
+        assert_eq!(chunk_permits(0), 1);
+        assert_eq!(chunk_permits(4096), 4096);
+        // A path bigger than the whole budget must still get permits it can
+        // actually acquire (it runs alone).
+        assert_eq!(u64::from(chunk_permits(u64::MAX)), CHUNK_INFLIGHT_NAR_BYTES);
     }
 
     #[test]

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -1,6 +1,6 @@
 //! The substituter: Nix binary cache protocol served from the manifest.
 //!
-//! Three routes (axum), mounted into `hestia serve`:
+//! Routes (axum), mounted into `hestia serve`:
 //!
 //! * `GET /nix-cache-info` — store dir, mass-query flag, priority.
 //! * `GET /{hash}.narinfo` — manifest lookup; a hit is recorded in the


### PR DESCRIPTION

Every regular file was copied wholesale during reference normalization,
even when it contained no references, doubling the resident size of
large binaries during a drain.

RefTable::normalize now returns a cheap Bytes clone when nothing
matches, and files >= 64 MiB with references are normalized in place on
a copy-on-write mapping, so only pages containing an occurrence are
copied. Unmappable or resized files fall back to the buffered path.

Peak anonymous RSS of a worst-case drain (chromium closure, 108 paths)
drops from 1.78 GB to 1.22 GB.
