### PR TITLE
chunker: raise FastCDC parameters to 64/256/1024 KiB

### DIFF
--- a/hestia-core/src/chunker.rs
+++ b/hestia-core/src/chunker.rs
@@ -25,9 +25,9 @@ use crate::refnorm::RefTable;
 
 /// FastCDC parameters. Pinned: changing them changes every chunk boundary
 /// and therefore invalidates all existing chunks in the cache.
-pub const MIN_CHUNK_SIZE: u32 = 16 * 1024;
-pub const AVG_CHUNK_SIZE: u32 = 64 * 1024;
-pub const MAX_CHUNK_SIZE: u32 = 256 * 1024;
+pub const MIN_CHUNK_SIZE: u32 = 64 * 1024;
+pub const AVG_CHUNK_SIZE: u32 = 256 * 1024;
+pub const MAX_CHUNK_SIZE: u32 = 1024 * 1024;
 
 /// FastCDC min/avg/max boundaries as a value, so experiments (e.g.
 /// `examples/chunk_sweep.rs`) can chunk with non-default parameters.
@@ -872,13 +872,13 @@ mod tests {
 
     #[test]
     fn chunking_is_deterministic() {
-        let data = test_data(1024 * 1024, 42);
+        let data = test_data(4 * 1024 * 1024, 42);
         let first = chunk_data(&data);
         let second = chunk_data(&data);
         assert_eq!(first, second);
         assert!(
             first.len() > 4,
-            "1 MiB should produce several chunks, got {}",
+            "4 MiB should produce several chunks, got {}",
             first.len()
         );
     }

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -202,7 +202,7 @@ mod tests {
         assert_eq!(
             summarize(&stats),
             "pushed 4 paths, 3 already cached, 2 upstream-signed, 1 invalid \
-             (446.1 KiB in 2.0s, 2.2 MiB/s); manifest m2#7"
+             (446.1 KiB in 2.0s, 2.2 MiB/s); manifest m3#7"
         );
         assert_eq!(
             stage_breakdown(&stats),
@@ -222,7 +222,7 @@ mod tests {
             elapsed_ms: 600,
             ..DrainStats::default()
         };
-        assert_eq!(summarize(&stats), "pushed 2 paths; manifest m2#3");
+        assert_eq!(summarize(&stats), "pushed 2 paths; manifest m3#3");
         assert_eq!(
             stage_breakdown(&stats),
             "load 0.1s, chunk 0.4s, commit 0.1s, total 0.6s"
@@ -271,7 +271,7 @@ mod tests {
         };
         assert_eq!(
             summarize(&stats),
-            "pushed 1 path (1.0 MiB in 1.0s, 2.0 MiB/s); manifest m2#1"
+            "pushed 1 path (1.0 MiB in 1.0s, 2.0 MiB/s); manifest m3#1"
         );
         assert_eq!(
             stage_breakdown(&stats),

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -33,13 +33,13 @@ use crate::substituter::ManifestStore;
 use crate::upstream::UpstreamFilter;
 use futures_util::{StreamExt as _, TryStreamExt as _};
 
-/// SaveMutable family prefix for the manifest ("m2" → keys `m2#1`, `m2#2`,
-/// …). Bumped from "m" when reference normalization changed the chunk
-/// format: the pre-existing `m#N` sequence chunked NARs verbatim, so those
-/// chunks would never dedup against normalized ones. A fresh namespace
-/// ignores the old manifest outright rather than carrying dead entries
-/// forward; its orphaned packs age out through GC and eviction.
-pub const MANIFEST_PREFIX: &str = "m2";
+/// SaveMutable family prefix for the manifest ("m3" → keys `m3#1`, `m3#2`,
+/// …). Bumped on every chunk-format change, because old chunks never dedup
+/// against new ones: "m" → "m2" for reference normalization, "m2" → "m3"
+/// for the 64/256/1024 KiB FastCDC parameters. A fresh namespace ignores
+/// the old manifest rather than carrying dead entries forward; its
+/// orphaned packs age out through GC and eviction.
+pub const MANIFEST_PREFIX: &str = "m3";
 
 /// Compressed bytes per pack before a new pack is started.
 pub const PACK_TARGET_SIZE: u64 = 64 * 1024 * 1024;


### PR DESCRIPTION

A chunk-size sweep over real closures showed dedup is nearly insensitive
to chunk size in the 64 KiB - 1 MiB range: reference normalization
already removes most churn, and cross-version redundancy is dominated by
whole-file-identical paths. Chunk count, however, drives metadata and
CPU: 256 KiB average cuts the encoded manifest by ~26-35 % and chunking
time by ~40 %, for only ~1-9 % more incremental upload bytes.

bin/bench-drain.sh on a 14.7 GiB / 2084-path system closure: drain
51.9s -> 40.2s, closure export 95.1s -> 78.9s, uploaded bytes -1.8 %
(cold cache).

Chunk boundaries are part of the cache format: old chunks never dedup
against new ones, and old >256 KiB chunks would fail the extraction size
bound. Bump the manifest namespace to m3 so the daemon starts fresh and
old packs age out through GC and eviction.
