### PR TITLE
release: bump version to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,7 +999,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hestia"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "axum",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hestia"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2024"
 license = "MIT"
 description = "Nix binary cache backed by the GitHub Actions cache (v2 API)"


### PR DESCRIPTION
Version bump for v3.0.0. Tag will be pushed once this lands.