### PR TITLE
pipeline: bypass upstream filter for drv closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,10 @@ Notes:
   come from the normal cache flow (earlier builds or upstream
   substituters), so shared uncached dependencies are rebuilt by every
   matrix job that needs them.
-* Input sources (fetched tarballs, patched srcs) count against the cache
-  quota. `upstream-cache-filter` does not skip them, because sources carry
-  no upstream signature.
+* With closure expansion enabled, registered derivation closures bypass
+  `upstream-cache-filter` so `/closure` exports remain importable into a
+  fresh store. Their inputs, including upstream-signed sources, therefore
+  count against the cache quota.
 * Each matrix row also carries `attr`, so `nix build .#${{ matrix.attr }}`
   works as a per-job-eval fallback.
 * GitHub limits a matrix to 256 jobs and a step output to 1 MB.
@@ -264,13 +265,7 @@ jobs:
 
 The drain at the end of the eval job uploads the drvs together with their
 input closure (input drvs and sources), so the build jobs substitute them
-from the cache. Notes:
-
-* Dependency *outputs* are not part of a drv's closure; they come from the
-  normal cache flow (earlier builds or upstream substituters).
-* Input sources (fetched tarballs, patched srcs) are uploaded too and count
-  against the cache quota. `upstream-cache-filter` does not skip them,
-  because sources carry no upstream signature.
+from the cache.
 
 ## Security
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -5,8 +5,9 @@
 //! 1. Query path info from the store database for every buffered path,
 //!    expanded to its runtime closure unless disabled.
 //! 2. Filter: invalid paths, upstream-signed paths (when the upstream
-//!    cache filter is enabled), paths already in the manifest (those get
-//!    their `last_pushed` clock bumped instead).
+//!    cache filter is enabled, except for derivation closures used by the
+//!    closure API), paths already in the manifest (those get their
+//!    `last_pushed` clock bumped instead).
 //! 3. Chunk each new path (FastCDC over NAR events) and verify the chunked
 //!    representation reproduces the NAR hash recorded by Nix.
 //! 4. Pack new chunks, upload the pack (Twirp reserve → Azure PUT →
@@ -327,12 +328,29 @@ impl PipelineContext {
         // Blocking sqlite I/O happens off the async runtime.
         let store = self.store.clone();
         let expand_closure = self.expand_closure;
-        let lookups = tokio::task::spawn_blocking(move || {
-            if expand_closure {
-                store.query_closure(paths)
+        let (lookups, upstream_filter_bypass) = tokio::task::spawn_blocking(move || {
+            // Matrix prefetch requires registered `.drv` closures to be
+            // self-contained, so their members bypass the upstream filter.
+            let bypass_roots: BTreeSet<String> = if expand_closure {
+                paths
+                    .iter()
+                    .filter(|path| path.ends_with(".drv"))
+                    .cloned()
+                    .collect()
             } else {
-                store.query_batch(paths)
-            }
+                BTreeSet::new()
+            };
+            let lookups = if expand_closure {
+                store.query_closure(paths)?
+            } else {
+                store.query_batch(paths)?
+            };
+            let bypass: BTreeSet<String> = store
+                .query_closure(bypass_roots)?
+                .into_iter()
+                .map(|(path, _)| path)
+                .collect();
+            Ok::<_, PathInfoError>((lookups, bypass))
         })
         .await
         .expect("store database query task panicked")?;
@@ -358,7 +376,9 @@ impl PipelineContext {
                 }
             };
 
-            if self.upstream.is_upstream_signed(&info.signatures) {
+            if !upstream_filter_bypass.contains(&path)
+                && self.upstream.is_upstream_signed(&info.signatures)
+            {
                 stats.skipped_upstream += 1;
                 continue;
             }

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -2,9 +2,9 @@
 //!
 //! Opt-in (`hestia serve --upstream-cache-filter`): when enabled, anything
 //! carrying a signature from a trusted upstream cache (cache.nixos.org by
-//! default) is already served by that cache and would only waste GHA cache
-//! quota, so the write pipeline skips it. By default the filter is off and
-//! everything is cached, upstream-served paths included.
+//! default) is already served by that cache, so the write pipeline normally
+//! skips it to save GHA cache quota. By default the filter is off and everything
+//! is cached, upstream-served paths included.
 //!
 //! The check is on the signature's *key name* only — no cryptographic
 //! verification. That is deliberate: a forged signature name in the local
@@ -42,8 +42,7 @@ impl UpstreamFilter {
         self.trusted_keys.iter().any(|key| key == key_name)
     }
 
-    /// True if any of `signatures` was made by a trusted upstream key,
-    /// i.e. the signed path should be skipped by the write pipeline.
+    /// True if any of `signatures` was made by a trusted upstream key.
     pub fn is_upstream_signed<'a>(
         &self,
         signatures: impl IntoIterator<Item = &'a Signature>,

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -421,7 +421,7 @@ async fn nar_round_trips_with_matching_hash() {
 }
 
 #[tokio::test]
-async fn closure_export_imports_into_a_fresh_store() {
+async fn drv_closure_bypasses_upstream_filter_and_imports_into_a_fresh_store() {
     timed(async {
         // The prefetch endpoint: one request streams the whole closure in
         // `nix-store --export` format; `nix-store --import` is the format
@@ -429,15 +429,43 @@ async fn closure_export_imports_into_a_fresh_store() {
         let Some(store) = ScratchStore::create() else {
             return;
         };
-        let (top, dep) = store.add_paths_with_reference("closure-export");
+        let drv = store.instantiate_drv("closure-upstream-filter");
+        let references = match store
+            .database()
+            .query(&drv.to_string_lossy())
+            .expect("store database query failed")
+        {
+            hestia::pathinfo::Lookup::Found(info) => info.references,
+            other => panic!("drv must be valid in the store database, got {other:?}"),
+        };
+        let signed_reference = store.store_dir_path().join(
+            references
+                .first()
+                .expect("drv must have an input reference")
+                .to_string(),
+        );
+        store.sign_path(&signed_reference, "cache.nixos.org-1");
+        let unrelated_upstream = store.add_fixture("unrelated-upstream", 13);
+        store.sign_path(&unrelated_upstream, "cache.nixos.org-1");
 
         let fake = FakeGha::start().await;
         let http = reqwest::Client::new();
-        push_paths(&fake, &http, &store, &[&top, &dep]).await;
+        let ctx = pipeline_context(&fake, &http, store.database());
+        let stats = ctx
+            .run(
+                to_path_set(&[&drv, &unrelated_upstream]),
+                BTreeSet::new(),
+                now_unix(),
+            )
+            .await
+            .expect("pipeline run failed");
+        assert_eq!(stats.paths_received, 2);
+        assert_eq!(stats.skipped_upstream, 1);
+
         let substituter = RunningSubstituter::start(&fake, &http, &store).await;
 
         let response = substituter
-            .get(&http, &format!("closure/{}", path_hash_str(&top)))
+            .get(&http, &format!("closure/{}", path_hash_str(&drv)))
             .await;
         assert_eq!(response.status(), 200);
         let body = response.bytes().await.expect("reading export stream");
@@ -469,14 +497,17 @@ async fn closure_export_imports_into_a_fresh_store() {
             String::from_utf8_lossy(&output.stderr)
         );
 
-        // The whole closure landed: top plus its reference.
-        assert_trees_equal(&top, &destination.physical_path(&top));
-        assert_trees_equal(&dep, &destination.physical_path(&dep));
+        // The whole drv closure landed, including the upstream-signed input.
+        assert_trees_equal(&drv, &destination.physical_path(&drv));
+        assert_trees_equal(
+            &signed_reference,
+            &destination.physical_path(&signed_reference),
+        );
 
         // Prefetched paths count as accessed (GC liveness).
         let accessed = substituter.access_log.snapshot();
-        assert!(accessed.contains(&path_hash_of(&top)));
-        assert!(accessed.contains(&path_hash_of(&dep)));
+        assert!(accessed.contains(&path_hash_of(&drv)));
+        assert!(accessed.contains(&path_hash_of(&signed_reference)));
 
         // Unknown roots are a 404, not a partial stream.
         let miss = substituter


### PR DESCRIPTION
With `upstream-cache-filter` enabled, the write pipeline omitted upstream-signed inputs from registered drv closures. `/closure` exports only manifest members, but drv metadata still references those omitted inputs, so `nix-store --import` fails in a fresh store.

When closure expansion is enabled, the pipeline derives the paths reachable from registered `.drv` roots using metadata from the existing store query and exempts only those paths from the upstream filter. Unrelated upstream-signed roots in the same drain remain filtered, without an additional database query.

This keeps registered drv closure exports self-contained at the cost of caching upstream-signed paths reachable from those roots. The README documents the resulting cache quota impact.

A follow-up could preserve the quota savings by exposing filtered references to a dedicated prefetch client. It could realize paths available through the build runner's configured substituters before importing the closure, but doing this robustly needs additional client/API design and is out of scope here.

Closes #122.