### PR TITLE
prefetch: support filtered drv closures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", features = [
   "time",
   "sync",
   "io-util",
+  "process",
 ] }
 
 # Accept-loop errno classification (unix sockets are unix-only anyway)

--- a/README.md
+++ b/README.md
@@ -98,10 +98,7 @@ jobs:
         with:
           wait-manifest-version: ${{ needs.eval.outputs.manifest-version }}
       - name: Prefetch drv closure
-        run: |
-          hashes=$(printf '%s\n' ${{ matrix.installables }} |
-            awk -F/ '{printf "%s%s", (NR > 1 ? "," : ""), substr($NF, 1, 32)}')
-          curl -fsS "http://$HESTIA_LISTEN/closure/$hashes" | nix-store --import
+        run: "$HESTIA_BIN" prefetch ${{ matrix.installables }}
       - run: nix build -L ${{ matrix.installables }}
 ```
 
@@ -117,12 +114,13 @@ checks.x86_64-linux.mycheck = pkgs.hello.overrideAttrs (old: {
 });
 ```
 
-The prefetch step pulls the whole drv closure with one request
-(`GET /closure/<hash>[,<hash>]` streams it in `nix-store --export`
-format, references first; unknown roots return 404) instead of letting
-`nix build` substitute thousands of paths one narinfo+NAR round trip at
-a time. Importing unsigned paths requires the calling user to be a Nix
-trusted user, which the default GitHub runner setup already is.
+The prefetch step prepares any references omitted by the upstream filter,
+then pulls the Hestia-backed part of the drv closure with one request
+(`GET /closure/<hash>[,<hash>]` streams it in `nix-store --export` format,
+references first; unknown roots return 404). This keeps the Hestia-backed paths
+from being substituted one narinfo+NAR round trip at a time.
+Importing unsigned paths requires the calling user to be a Nix trusted user,
+which the default GitHub runner setup already is.
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Notes:
   `upstream-cache-filter` so `/closure` exports remain importable into a
   fresh store. Their inputs, including upstream-signed sources, therefore
   count against the cache quota.
+* To filter these closures, enable `upstream-cache-filter` in both jobs and
+  `filter-drv-closures` in the eval job, then use `hestia prefetch` in build
+  jobs. Direct `/closure` imports cannot prepare omitted references, and
+  existing entries remain until no cached drv references them.
 * Each matrix row also carries `attr`, so `nix build .#${{ matrix.attr }}`
   works as a per-job-eval fallback.
 * GitHub limits a matrix to 256 jobs and a step output to 1 MB.
@@ -214,6 +218,7 @@ All inputs are optional; the defaults work for the quick start above.
 | `drain-timeout` | `300` | Seconds the post-job step waits for the final upload. |
 | `upstream-cache-filter` | `false` | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
 | `upstream-cache-key-names` | `cache.nixos.org-1` | Space-separated key names treated as upstream caches by the filter. |
+| `filter-drv-closures` | `false` | Apply the upstream filter to registered derivation closures; requires `upstream-cache-filter`. Use `hestia prefetch` for bulk closure fetching. |
 | `no-closure` | `false` | Cache built paths only, without their runtime closure. |
 
 The GC workflow takes one input: `dry-run` (plan only, delete nothing); see

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,13 @@ inputs:
       `upstream-cache-filter`.
     required: false
     default: ""
+  filter-drv-closures:
+    description: >
+      Apply upstream-cache-filter to registered derivation closures. Requires
+      `upstream-cache-filter`; use `hestia prefetch` to retain bulk closure
+      fetching.
+    required: false
+    default: "false"
   no-closure:
     description: >
       Cache built paths only, without their runtime closure (dependencies

--- a/action/README.md
+++ b/action/README.md
@@ -83,6 +83,7 @@ integration tests use it.
 | `drain-timeout` | `300` | Seconds the post-job step waits for the final upload. |
 | `upstream-cache-filter` | `false` | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
 | `upstream-cache-key-names` | `cache.nixos.org-1` | Space-separated key names treated as upstream caches by the filter. |
+| `filter-drv-closures` | `false` | Apply the upstream filter to registered derivation closures; requires `upstream-cache-filter`. Use `hestia prefetch` for bulk closure fetching. |
 | `no-closure` | `false` | Cache built paths only, without their runtime closure. |
 
 ## Garbage collection

--- a/action/action.yml
+++ b/action/action.yml
@@ -62,6 +62,13 @@ inputs:
       `upstream-cache-filter`.
     required: false
     default: ""
+  filter-drv-closures:
+    description: >
+      Apply upstream-cache-filter to registered derivation closures. Requires
+      `upstream-cache-filter`; use `hestia prefetch` to retain bulk closure
+      fetching.
+    required: false
+    default: "false"
   no-closure:
     description: >
       Cache built paths only, without their runtime closure (dependencies

--- a/action/main.js
+++ b/action/main.js
@@ -356,6 +356,9 @@ function serveFlags() {
   for (const name of getInput('upstream-cache-key-names').split(/\s+/).filter(Boolean)) {
     flags.push('--upstream-cache-key-name', name);
   }
+  if (getInput('filter-drv-closures') === 'true') {
+    flags.push('--filter-drv-closures');
+  }
   if (getInput('no-closure') === 'true') {
     flags.push('--no-closure');
   }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,18 @@ setups, or hacking on hestia).
 | `--no-closure` | off | Cache built paths only, without their runtime closure. |
 | `--db-path <PATH>` | `/nix/var/nix/db/db.sqlite` | Nix store database to read path metadata from. |
 
+## `hestia prefetch` — bulk drv closure fetch
+
+Prepares references omitted from the Hestia manifest through the runner's
+configured Nix substituters, then imports the Hestia-backed closure in one
+request. It accepts the `<drvPath>^*` values emitted by `hestia matrix` and
+requires Nix 2.15 or newer.
+
+| Flag / argument | Default | Description |
+|---|---|---|
+| `--listen <ADDR>` | `$HESTIA_LISTEN`, else `127.0.0.1:37515` | Running Hestia server address. |
+| `<STORE_PATH>...` | — | Store paths or `<drvPath>^*` installables to prefetch. |
+
 ## `hestia hook` — post-build-hook client
 
 | Flag | Default | Description |
@@ -55,4 +67,5 @@ Always exits 0 (a failing post-build-hook would fail the build).
 | `GITHUB_API_URL` | gc | REST API base URL (override for GHES). |
 | `GITHUB_REF_NAME` | serve | Default for `--branch`. |
 | `GITHUB_RUN_ID` | serve | Roots written by the same workflow run merge by union (matrix legs); different runs replace each other's root. |
+| `HESTIA_LISTEN` | prefetch | Address exported by the action for the running Hestia server. |
 | `OUT_PATHS` | hook | Set by Nix when invoking the post-build-hook. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,12 +15,13 @@ setups, or hacking on hestia).
 | `--system <SYSTEM>` | detected | Nix system part of the root key (e.g. `x86_64-linux`). |
 | `--upstream-cache-filter` | off | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
 | `--upstream-cache-key-name <KEY_NAME>` | `cache.nixos.org-1` | Key names treated as upstream caches by the filter. Repeatable. |
+| `--filter-drv-closures` | off | Apply the upstream filter to registered derivation closures. Requires `--upstream-cache-filter`; use `hestia prefetch` to retain bulk closure fetching. |
 | `--no-closure` | off | Cache built paths only, without their runtime closure. |
 | `--db-path <PATH>` | `/nix/var/nix/db/db.sqlite` | Nix store database to read path metadata from. |
 
 ## `hestia prefetch` — bulk drv closure fetch
 
-Prepares references omitted from the Hestia manifest through the runner's
+Prepares references omitted by `--filter-drv-closures` through the runner's
 configured Nix substituters, then imports the Hestia-backed closure in one
 request. It accepts the `<drvPath>^*` values emitted by `hestia matrix` and
 requires Nix 2.15 or newer.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,11 @@ pub struct ServeArgs {
     )]
     pub upstream_cache_key_names: Vec<String>,
 
+    /// Apply --upstream-cache-filter to registered derivation closures.
+    /// Use `hestia prefetch` to retain bulk closure fetching.
+    #[arg(long, requires = "upstream_cache_filter")]
+    pub filter_drv_closures: bool,
+
     /// Push built paths only; do not expand them to their runtime closure.
     #[arg(long)]
     pub no_closure: bool,
@@ -198,6 +203,7 @@ mod tests {
         assert_eq!(args.branch, None);
         assert_eq!(args.system, None);
         assert!(!args.upstream_cache_filter);
+        assert!(!args.filter_drv_closures);
         assert!(!args.no_closure);
         assert_eq!(args.upstream_cache_key_names, vec!["cache.nixos.org-1"]);
         assert_eq!(
@@ -223,6 +229,7 @@ mod tests {
             "cache.nixos.org-1",
             "--upstream-cache-key-name",
             "company-cache-1",
+            "--filter-drv-closures",
             "--no-closure",
             "--db-path",
             "/custom/db.sqlite",
@@ -236,6 +243,7 @@ mod tests {
         assert_eq!(args.branch.as_deref(), Some("main"));
         assert_eq!(args.system.as_deref(), Some("riscv64-linux"));
         assert!(args.upstream_cache_filter);
+        assert!(args.filter_drv_closures);
         assert!(args.no_closure);
         assert_eq!(
             args.upstream_cache_key_names,
@@ -260,6 +268,11 @@ mod tests {
             ])
             .is_err()
         );
+    }
+
+    #[test]
+    fn filtering_drv_closures_requires_the_filter_flag() {
+        assert!(Cli::try_parse_from(["hestia", "serve", "--filter-drv-closures"]).is_err());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,8 @@ pub enum Command {
     /// Evaluate a flake with nix-eval-jobs and emit a GitHub Actions build
     /// matrix (drv closures registered for upload).
     Matrix(MatrixArgs),
+    /// Fetch a cached closure and prepare its external references.
+    Prefetch(PrefetchArgs),
     /// Send $OUT_PATHS from a Nix post-build-hook to the daemon.
     Hook(HookArgs),
     /// Tell the daemon to upload pending paths and commit the manifest.
@@ -116,6 +118,18 @@ pub struct MatrixArgs {
     /// Maximum time to wait for the drv upload to finish, in seconds.
     #[arg(long, value_name = "SECONDS", default_value_t = 300)]
     pub drain_timeout: u64,
+}
+
+#[derive(Args, Debug)]
+pub struct PrefetchArgs {
+    /// Address of the running Hestia server
+    /// [default: $HESTIA_LISTEN, or 127.0.0.1:37515].
+    #[arg(long)]
+    pub listen: Option<String>,
+
+    /// Store paths to prefetch; `<drvPath>^*` installables are accepted.
+    #[arg(required = true, value_name = "STORE_PATH")]
+    pub paths: Vec<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod gha;
 pub mod hook;
 pub mod matrix;
 pub mod pipeline;
+pub mod prefetch;
 pub mod serve;
 pub mod substituter;
 pub mod upstream;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::process::ExitCode;
 use clap::Parser;
 
 use hestia::cli::{Cli, Command};
-use hestia::{drain, gc, hook, matrix, serve};
+use hestia::{drain, gc, hook, matrix, prefetch, serve};
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -11,6 +11,7 @@ async fn main() -> ExitCode {
     match cli.command {
         Command::Serve(args) => serve::run(&args).await,
         Command::Matrix(args) => matrix::run(&args).await,
+        Command::Prefetch(args) => prefetch::run(&args).await,
         Command::Hook(args) => hook::run(&args).await,
         Command::Drain(args) => drain::run(&args).await,
         Command::Gc(args) => gc::run(&args).await,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -5,9 +5,9 @@
 //! 1. Query path info from the store database for every buffered path,
 //!    expanded to its runtime closure unless disabled.
 //! 2. Filter: invalid paths, upstream-signed paths (when the upstream
-//!    cache filter is enabled, except for derivation closures used by the
-//!    closure API), paths already in the manifest (those get their
-//!    `last_pushed` clock bumped instead).
+//!    cache filter is enabled; derivation closures bypass it unless
+//!    explicitly configured otherwise), paths already in the manifest
+//!    (those get their `last_pushed` clock bumped instead).
 //! 3. Chunk each new path (FastCDC over NAR events) and verify the chunked
 //!    representation reproduces the NAR hash recorded by Nix.
 //! 4. Pack new chunks, upload the pack (Twirp reserve → Azure PUT →
@@ -215,6 +215,9 @@ pub struct PipelineContext {
     /// Substituted dependencies never trigger the post-build-hook, so
     /// without expansion they are never cached.
     pub expand_closure: bool,
+    /// Apply the upstream filter to derivation closure members instead of
+    /// keeping those closures self-contained.
+    pub filter_drv_closures: bool,
     /// Manifest root key, e.g. `main-x86_64-linux`.
     pub root_key: String,
     /// Workflow run id (`$GITHUB_RUN_ID`); see [`Root::merge`].
@@ -328,10 +331,9 @@ impl PipelineContext {
         // Blocking sqlite I/O happens off the async runtime.
         let store = self.store.clone();
         let expand_closure = self.expand_closure;
+        let filter_drv_closures = self.filter_drv_closures;
         let (lookups, upstream_filter_bypass) = tokio::task::spawn_blocking(move || {
-            // Matrix prefetch requires registered `.drv` closures to be
-            // self-contained, so their members bypass the upstream filter.
-            let bypass_roots: BTreeSet<String> = if expand_closure {
+            let bypass_roots: BTreeSet<String> = if expand_closure && !filter_drv_closures {
                 paths
                     .iter()
                     .filter(|path| path.ends_with(".drv"))

--- a/src/prefetch.rs
+++ b/src/prefetch.rs
@@ -1,0 +1,170 @@
+//! `hestia prefetch`: prepare external references, then bulk-import a
+//! closure from the local Hestia daemon.
+
+use std::process::{ExitCode, ExitStatus, Stdio};
+
+use tokio::io::AsyncWriteExt as _;
+use tokio::process::Command;
+
+use crate::cli::{DEFAULT_LISTEN, PrefetchArgs};
+use crate::manifest::{PathHash, StorePath};
+use crate::pathinfo::StoreDir;
+
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error("invalid store path or drv installable: {0}")]
+    InvalidPath(String),
+    #[error("request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("cannot run {command}: {source}")]
+    Spawn {
+        command: &'static str,
+        source: std::io::Error,
+    },
+    #[error("{operation} failed with {status}")]
+    Nix {
+        operation: &'static str,
+        status: ExitStatus,
+    },
+    #[error("writing paths to nix build failed: {0}")]
+    PrepareWrite(#[source] std::io::Error),
+    #[error("writing the closure to nix-store --import failed: {0}")]
+    ImportWrite(#[source] std::io::Error),
+}
+
+fn root_hashes(paths: &[String]) -> Result<String, Error> {
+    let store_dir = StoreDir::default();
+    let mut hashes = Vec::with_capacity(paths.len());
+    for installable in paths {
+        let path = installable.strip_suffix("^*").unwrap_or(installable);
+        let path = store_dir
+            .parse::<StorePath>(path)
+            .map_err(|_| Error::InvalidPath(installable.clone()))?;
+        hashes.push(PathHash::from_store_path(&path).to_string());
+    }
+    Ok(hashes.join(","))
+}
+
+async fn prepare_external_paths(paths: &str) -> Result<(), Error> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+    // Literal store paths (without `^` output selectors) are opaque Nix
+    // installables: this substitutes even `.drv` paths without building
+    // their outputs. Stdin keeps large closures clear of ARG_MAX.
+    let mut child = Command::new("nix")
+        .args(["build", "--no-link", "--stdin"])
+        .stdin(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|source| Error::Spawn {
+            command: "nix build",
+            source,
+        })?;
+    let mut stdin = child.stdin.take().expect("nix stdin was piped");
+    stdin
+        .write_all(paths.as_bytes())
+        .await
+        .map_err(Error::PrepareWrite)?;
+    stdin.write_all(b"\n").await.map_err(Error::PrepareWrite)?;
+    drop(stdin);
+    let status = child.wait().await.map_err(|source| Error::Spawn {
+        command: "nix build",
+        source,
+    })?;
+    if !status.success() {
+        return Err(Error::Nix {
+            operation: "nix build --no-link",
+            status,
+        });
+    }
+    Ok(())
+}
+
+async fn import_closure(mut response: reqwest::Response) -> Result<(), Error> {
+    let mut child = Command::new("nix-store")
+        .arg("--import")
+        .stdin(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|source| Error::Spawn {
+            command: "nix-store --import",
+            source,
+        })?;
+    let mut stdin = child.stdin.take().expect("nix-store stdin was piped");
+    while let Some(chunk) = response.chunk().await? {
+        stdin.write_all(&chunk).await.map_err(Error::ImportWrite)?;
+    }
+    drop(stdin);
+    let status = child.wait().await.map_err(|source| Error::Spawn {
+        command: "nix-store --import",
+        source,
+    })?;
+    if !status.success() {
+        return Err(Error::Nix {
+            operation: "nix-store --import",
+            status,
+        });
+    }
+    Ok(())
+}
+
+async fn run_inner(args: &PrefetchArgs) -> Result<(), Error> {
+    let hashes = root_hashes(&args.paths)?;
+    let listen = args
+        .listen
+        .clone()
+        .or_else(|| std::env::var("HESTIA_LISTEN").ok())
+        .unwrap_or_else(|| DEFAULT_LISTEN.to_string());
+    let base = format!("http://{listen}");
+    let http = reqwest::Client::new();
+
+    let external_references = http
+        .get(format!("{base}/closure/{hashes}/external-references"))
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    prepare_external_paths(&external_references).await?;
+
+    let closure = http
+        .get(format!("{base}/closure/{hashes}"))
+        .send()
+        .await?
+        .error_for_status()?;
+    import_closure(closure).await
+}
+
+pub async fn run(args: &PrefetchArgs) -> ExitCode {
+    match run_inner(args).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("hestia prefetch: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hashes_are_extracted_from_matrix_installables() {
+        let paths = vec![
+            "/nix/store/00000000000000000000000000000000-a.drv^*".to_string(),
+            "/nix/store/11111111111111111111111111111111-b.drv".to_string(),
+        ];
+        assert_eq!(
+            root_hashes(&paths).unwrap(),
+            "00000000000000000000000000000000,11111111111111111111111111111111"
+        );
+    }
+
+    #[test]
+    fn malformed_installable_is_rejected() {
+        let err = root_hashes(&[".#check".to_string()]).unwrap_err();
+        assert!(matches!(err, Error::InvalidPath(_)));
+    }
+}

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -599,6 +599,7 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         store,
         upstream,
         expand_closure: !args.no_closure,
+        filter_drv_closures: args.filter_drv_closures,
         root_key: root_key.clone(),
         run_id: std::env::var("GITHUB_RUN_ID")
             .ok()

--- a/src/substituter.rs
+++ b/src/substituter.rs
@@ -17,6 +17,8 @@
 //!   (comma-separated), restricted to manifest members, streamed in
 //!   `nix-store --export` format for a one-request prefetch via
 //!   `nix-store --import`.
+//! * `GET /closure/{hashes}/external-references` — references required by
+//!   that export but omitted from the manifest, one store path per line.
 //!
 //! A semaphore caps concurrent pack reads so parallel narinfo queries
 //! from Nix (`WantMassQuery: 1`) do not flood the GHA cache API.
@@ -722,6 +724,10 @@ impl Substituter {
             .route("/{file}", get(narinfo))
             .route("/nar/{file}", get(nar))
             .route("/closure/{hashes}", get(closure))
+            .route(
+                "/closure/{hashes}/external-references",
+                get(closure_external_references),
+            )
             .with_state(state)
     }
 
@@ -1072,6 +1078,17 @@ fn closure_order(manifest: &Manifest, roots: &[PathHash]) -> Vec<PathHash> {
     order
 }
 
+fn closure_roots(manifest: &Manifest, hashes: &str) -> Option<Vec<PathHash>> {
+    let roots: Vec<PathHash> = hashes
+        .split(',')
+        .filter(|part| !part.is_empty())
+        .map(str::parse)
+        .collect::<Result<_, _>>()
+        .ok()?;
+    (!roots.is_empty() && roots.iter().all(|root| manifest.paths.contains_key(root)))
+        .then_some(roots)
+}
+
 /// Fetch and frame one window of a closure export.
 async fn export_window(
     state: &Substituter,
@@ -1116,23 +1133,12 @@ async fn closure(State(state): State<Arc<Substituter>>, Path(hashes): Path<Strin
     let _activity = state.touch();
     state.manifest_ready().await;
 
-    let mut roots = Vec::new();
-    for part in hashes.split(',').filter(|part| !part.is_empty()) {
-        match part.parse::<PathHash>() {
-            Ok(hash) => roots.push(hash),
-            Err(_) => return StatusCode::NOT_FOUND.into_response(),
-        }
-    }
     let view = state.manifest.view();
     // Every requested root must be servable; a partial closure would make
     // the import succeed and the subsequent build fail confusingly.
-    if roots.is_empty()
-        || !roots
-            .iter()
-            .all(|root| view.manifest.paths.contains_key(root))
-    {
+    let Some(roots) = closure_roots(&view.manifest, &hashes) else {
         return StatusCode::NOT_FOUND.into_response();
-    }
+    };
     let order = closure_order(&view.manifest, &roots);
 
     // Stream the closure in windows: each window's chunks are fetched as
@@ -1169,6 +1175,31 @@ async fn closure(State(state): State<Arc<Substituter>>, Path(hashes): Path<Strin
         axum::body::Body::from_stream(stream),
     )
         .into_response()
+}
+
+async fn closure_external_references(
+    State(state): State<Arc<Substituter>>,
+    Path(hashes): Path<String>,
+) -> Result<String, StatusCode> {
+    let _activity = state.touch();
+    state.manifest_ready().await;
+
+    let view = state.manifest.view();
+    let roots = closure_roots(&view.manifest, &hashes).ok_or(StatusCode::NOT_FOUND)?;
+    Ok(closure_order(&view.manifest, &roots)
+        .into_iter()
+        .flat_map(|hash| view.manifest.paths[&hash].references.iter())
+        .filter(|reference| {
+            !view
+                .manifest
+                .paths
+                .contains_key(&PathHash::from_store_path(reference))
+        })
+        .map(|reference| format!("{}/{reference}", state.store_dir))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>()
+        .join("\n"))
 }
 
 #[cfg(test)]

--- a/tests/prefetch_cli.rs
+++ b/tests/prefetch_cli.rs
@@ -1,0 +1,96 @@
+//! Integration test for `hestia prefetch`: HTTP planning followed by the
+//! batched Nix substitution and import operations.
+
+use std::os::unix::fs::PermissionsExt as _;
+
+use axum::Router;
+use axum::routing::get;
+
+const HESTIA_BIN: &str = env!("CARGO_BIN_EXE_hestia");
+
+async fn external_references() -> &'static str {
+    concat!(
+        "/nix/store/00000000000000000000000000000002-valid\n",
+        "/nix/store/00000000000000000000000000000003-missing",
+    )
+}
+
+async fn closure() -> &'static [u8] {
+    b"nix-export-stream"
+}
+
+#[tokio::test]
+async fn prepares_and_imports_in_order() {
+    let temp = tempfile::tempdir().unwrap();
+    let fake_nix = temp.path().join("nix");
+    let fake_nix_store = temp.path().join("nix-store");
+    std::fs::write(
+        &fake_nix,
+        r#"#!/bin/sh
+printf 'nix %s\n' "$*" >> "$PREFETCH_LOG"
+cat > "$PREFETCH_PATHS"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &fake_nix_store,
+        r#"#!/bin/sh
+printf 'nix-store %s\n' "$*" >> "$PREFETCH_LOG"
+cat > "$PREFETCH_IMPORT"
+"#,
+    )
+    .unwrap();
+    std::fs::set_permissions(&fake_nix, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::set_permissions(&fake_nix_store, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let router = Router::new()
+        .route(
+            "/closure/{hashes}/external-references",
+            get(external_references),
+        )
+        .route("/closure/{hashes}", get(closure));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+
+    let log = temp.path().join("nix-store.log");
+    let prepared = temp.path().join("prepared");
+    let imported = temp.path().join("imported");
+    let path = std::env::join_paths(std::iter::once(temp.path().to_path_buf()).chain(
+        std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()),
+    ))
+    .unwrap();
+    let output = tokio::process::Command::new(HESTIA_BIN)
+        .arg("prefetch")
+        .args([
+            "/nix/store/00000000000000000000000000000000-a.drv^*",
+            "/nix/store/11111111111111111111111111111111-b.drv^*",
+        ])
+        .env("HESTIA_LISTEN", addr.to_string())
+        .env("PATH", path)
+        .env("PREFETCH_LOG", &log)
+        .env("PREFETCH_PATHS", &prepared)
+        .env("PREFETCH_IMPORT", &imported)
+        .output()
+        .await
+        .unwrap();
+    server.abort();
+
+    assert!(
+        output.status.success(),
+        "prefetch failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(&log).unwrap(),
+        concat!("nix build --no-link --stdin\n", "nix-store --import\n",)
+    );
+    assert_eq!(
+        std::fs::read_to_string(&prepared).unwrap(),
+        concat!(
+            "/nix/store/00000000000000000000000000000002-valid\n",
+            "/nix/store/00000000000000000000000000000003-missing\n",
+        )
+    );
+    assert_eq!(std::fs::read(&imported).unwrap(), b"nix-export-stream");
+}

--- a/tests/substituter.rs
+++ b/tests/substituter.rs
@@ -440,8 +440,9 @@ async fn drv_closure_bypasses_upstream_filter_and_imports_into_a_fresh_store() {
         };
         let signed_reference = store.store_dir_path().join(
             references
-                .first()
-                .expect("drv must have an input reference")
+                .iter()
+                .find(|reference| reference.to_string().ends_with(".drv"))
+                .expect("drv must have an input derivation")
                 .to_string(),
         );
         store.sign_path(&signed_reference, "cache.nixos.org-1");
@@ -514,6 +515,69 @@ async fn drv_closure_bypasses_upstream_filter_and_imports_into_a_fresh_store() {
             .get(&http, "closure/00000000000000000000000000000000")
             .await;
         assert_eq!(miss.status(), 404);
+
+        let filtered_fake = FakeGha::start().await;
+        let filtered_ctx = hestia::pipeline::PipelineContext {
+            filter_drv_closures: true,
+            ..pipeline_context(&filtered_fake, &http, store.database())
+        };
+        let stats = filtered_ctx
+            .run(
+                to_path_set(&[&drv, &unrelated_upstream]),
+                BTreeSet::new(),
+                now_unix(),
+            )
+            .await
+            .expect("pipeline run failed");
+        assert_eq!(stats.skipped_upstream, 2);
+
+        let filtered_substituter = RunningSubstituter::start(&filtered_fake, &http, &store).await;
+        let external_references = filtered_substituter
+            .get(
+                &http,
+                &format!("closure/{}/external-references", path_hash_str(&drv)),
+            )
+            .await;
+        assert_eq!(external_references.status(), 200);
+        assert_eq!(
+            external_references.text().await.unwrap(),
+            signed_reference.display().to_string()
+        );
+
+        let filtered_destination = store.create_destination();
+        let installable = format!(
+            "/nix/store/{}^*",
+            drv.file_name().unwrap().to_string_lossy()
+        );
+        let nix_config = format!(
+            "experimental-features = nix-command\nsubstitute = true\nsubstituters = {}\nrequire-sigs = false\n",
+            substituter.store_url
+        );
+        let output = tokio::process::Command::new(env!("CARGO_BIN_EXE_hestia"))
+            .arg("prefetch")
+            .arg("--listen")
+            .arg(
+                filtered_substituter
+                    .base_url
+                    .strip_prefix("http://")
+                    .unwrap(),
+            )
+            .arg(installable)
+            .env("NIX_REMOTE", &filtered_destination.uri)
+            .env("NIX_CONFIG", nix_config)
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "hestia prefetch failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_trees_equal(&drv, &filtered_destination.physical_path(&drv));
+        assert_trees_equal(
+            &signed_reference,
+            &filtered_destination.physical_path(&signed_reference),
+        );
     })
     .await;
 }

--- a/tests/support/common.rs
+++ b/tests/support/common.rs
@@ -46,6 +46,7 @@ pub fn pipeline_context_with(
         store,
         upstream: UpstreamFilter::default(),
         expand_closure: true,
+        filter_drv_closures: false,
         root_key: TEST_ROOT_KEY.to_string(),
         run_id: Some("test-run".to_string()),
         manifest_prefix: MANIFEST_PREFIX.to_string(),


### PR DESCRIPTION
With closure expansion enabled, registered `.drv` closures currently bypass `upstream-cache-filter` to keep `/closure` exports self-contained for fresh-store imports. For explicitly registered matrix closures, the trade-off is that upstream-signed inputs may be retained, reducing some of the filter's cache-quota savings.

Add an opt-in `filter-drv-closures` action input (`hestia serve --filter-drv-closures`) that applies the upstream filter to those closures. It requires `upstream-cache-filter`, and the default behavior remains unchanged.

A filtered export may reference paths that are absent from the Hestia manifest. `GET /closure/<hashes>/external-references` reports those direct external references, and the new `hestia prefetch` command prepares them through the runner's configured Nix substituters before importing the Hestia-backed part of the closure. The README matrix example now uses this command instead of the inline hash/curl pipeline.

Follow-up to #132.