### PR TITLE
action: add read-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ All inputs are optional; the defaults work for the quick start above.
 | `upstream-cache-filter` | `false` | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
 | `upstream-cache-key-names` | `cache.nixos.org-1` | Space-separated key names treated as upstream caches by the filter. |
 | `filter-drv-closures` | `false` | Apply the upstream filter to registered derivation closures; requires `upstream-cache-filter`. Use `hestia prefetch` for bulk closure fetching. |
+| `read-only` | `false` | Substitute from the cache but never write to it (no post-build-hook, no drain). |
 | `no-closure` | `false` | Cache built paths only, without their runtime closure. |
 
 The GC workflow takes one input: `dry-run` (plan only, delete nothing); see

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,13 @@ inputs:
       fetching.
     required: false
     default: "false"
+  read-only:
+    description: >
+      Substitute from the cache but never write to it: no post-build-hook,
+      no drain, and the daemon refuses uploads. For jobs that should only
+      consume what a central job cached.
+    required: false
+    default: "false"
   no-closure:
     description: >
       Cache built paths only, without their runtime closure (dependencies

--- a/action/README.md
+++ b/action/README.md
@@ -84,6 +84,7 @@ integration tests use it.
 | `upstream-cache-filter` | `false` | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
 | `upstream-cache-key-names` | `cache.nixos.org-1` | Space-separated key names treated as upstream caches by the filter. |
 | `filter-drv-closures` | `false` | Apply the upstream filter to registered derivation closures; requires `upstream-cache-filter`. Use `hestia prefetch` for bulk closure fetching. |
+| `read-only` | `false` | Substitute from the cache but never write to it (no post-build-hook, no drain). |
 | `no-closure` | `false` | Cache built paths only, without their runtime closure. |
 
 ## Garbage collection

--- a/action/action.yml
+++ b/action/action.yml
@@ -69,6 +69,13 @@ inputs:
       fetching.
     required: false
     default: "false"
+  read-only:
+    description: >
+      Substitute from the cache but never write to it: no post-build-hook,
+      no drain, and the daemon refuses uploads. For jobs that should only
+      consume what a central job cached.
+    required: false
+    default: "false"
   no-closure:
     description: >
       Cache built paths only, without their runtime closure (dependencies

--- a/action/main.js
+++ b/action/main.js
@@ -46,6 +46,10 @@ function getInput(name) {
   return (process.env[`INPUT_${name.toUpperCase()}`] || '').trim();
 }
 
+function readOnly() {
+  return getInput('read-only') === 'true';
+}
+
 /**
  * Save a value for this invocation's post step (the runner exposes it there
  * as STATE_<name>). Unlike exported environment variables, state is not
@@ -280,7 +284,9 @@ function writeHookShim(installDir, hestiaBin, socket) {
 function configureNix(installDir, listen, hookShim) {
   // nix has a single post-build-hook slot and our conf wins (applied last,
   // see below): warn instead of silently disabling a pre-existing hook.
-  const show = spawnSync('nix', ['config', 'show', 'post-build-hook'], { encoding: 'utf8' });
+  const show = hookShim
+    ? spawnSync('nix', ['config', 'show', 'post-build-hook'], { encoding: 'utf8' })
+    : { status: 1 };
   const previousHook = show.status === 0 ? show.stdout.trim() : '';
   if (previousHook) {
     console.log(
@@ -294,7 +300,7 @@ function configureNix(installDir, listen, hookShim) {
     conf,
     '# written by the hestia-cache action\n' +
       `extra-substituters = http://${listen}?trusted=true&priority=30\n` +
-      `post-build-hook = ${hookShim}\n` +
+      (hookShim ? `post-build-hook = ${hookShim}\n` : '') +
       'fallback = true\n' +
       // Without this, nix's on-disk narinfo cache remembers a 404 for an
       // hour: on persistent self-hosted runners the next job would skip
@@ -361,6 +367,9 @@ function serveFlags() {
   }
   if (getInput('no-closure') === 'true') {
     flags.push('--no-closure');
+  }
+  if (readOnly()) {
+    flags.push('--read-only');
   }
   const waitManifestVersion = getInput('wait-manifest-version');
   if (waitManifestVersion && waitManifestVersion !== '0') {
@@ -455,7 +464,10 @@ async function main() {
   const socket = getInput('socket') || path.join(installDir, 'hook.sock');
 
   const hestiaBin = await installBinary(installDir);
-  const hookShim = writeHookShim(installDir, hestiaBin, socket);
+  // Read-only: no post-build-hook, so nothing is registered (and chunked)
+  // in the first place; --read-only additionally makes the daemon refuse
+  // writes from other clients (hestia matrix, manual hooks, final drain).
+  const hookShim = readOnly() ? null : writeHookShim(installDir, hestiaBin, socket);
   configureNix(installDir, listen, hookShim);
   const daemonPid = startDaemon(hestiaBin, listen, socket, logFile);
   await waitForReadiness(listen, logFile, daemonPid);
@@ -474,6 +486,7 @@ async function main() {
   saveState('socket', socket);
   saveState('serveLog', logFile);
   saveState('drainTimeout', getInput('drain-timeout') || '300');
+  saveState('readOnly', readOnly() ? 'true' : '');
   saveState('daemonPid', String(daemonPid));
 }
 

--- a/action/post.js
+++ b/action/post.js
@@ -28,11 +28,17 @@ function main() {
 
   const socket = getState('socket');
   const timeout = getState('drainTimeout') || '300';
+  const readOnly = getState('readOnly') === 'true';
 
-  console.log('hestia-cache: draining (uploading built paths, committing the manifest)');
-  const drain = spawnSync(binary, ['drain', '--socket', socket, '--timeout', timeout], {
-    stdio: 'inherit',
-  });
+  let drain = { status: 0 };
+  if (readOnly) {
+    console.log('hestia-cache: read-only mode; skipping drain');
+  } else {
+    console.log('hestia-cache: draining (uploading built paths, committing the manifest)');
+    drain = spawnSync(binary, ['drain', '--socket', socket, '--timeout', timeout], {
+      stdio: 'inherit',
+    });
+  }
   if (drain.error) {
     // spawnSync does not throw on launch failures (e.g. ENOENT when the
     // temp dir was cleaned mid-job); without this the only output is the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,6 +16,7 @@ setups, or hacking on hestia).
 | `--upstream-cache-filter` | off | Skip paths signed by an upstream cache instead of caching them (saves quota for big closures). |
 | `--upstream-cache-key-name <KEY_NAME>` | `cache.nixos.org-1` | Key names treated as upstream caches by the filter. Repeatable. |
 | `--filter-drv-closures` | off | Apply the upstream filter to registered derivation closures. Requires `--upstream-cache-filter`; use `hestia prefetch` to retain bulk closure fetching. |
+| `--read-only` | off | Serve the cache for substitution but never write to it (no uploads, no manifest commits). |
 | `--no-closure` | off | Cache built paths only, without their runtime closure. |
 | `--db-path <PATH>` | `/nix/var/nix/db/db.sqlite` | Nix store database to read path metadata from. |
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,11 @@ pub struct ServeArgs {
     #[arg(long)]
     pub no_closure: bool,
 
+    /// Serve the cache for substitution but never write to it (no
+    /// uploads, no manifest commits).
+    #[arg(long)]
+    pub read_only: bool,
+
     /// Nix store database to read path metadata from.
     #[arg(long, default_value = crate::pathinfo::DEFAULT_DB_PATH)]
     pub db_path: PathBuf,
@@ -205,6 +210,7 @@ mod tests {
         assert!(!args.upstream_cache_filter);
         assert!(!args.filter_drv_closures);
         assert!(!args.no_closure);
+        assert!(!args.read_only);
         assert_eq!(args.upstream_cache_key_names, vec!["cache.nixos.org-1"]);
         assert_eq!(
             args.db_path,
@@ -231,6 +237,7 @@ mod tests {
             "company-cache-1",
             "--filter-drv-closures",
             "--no-closure",
+            "--read-only",
             "--db-path",
             "/custom/db.sqlite",
         ]);
@@ -245,6 +252,7 @@ mod tests {
         assert!(args.upstream_cache_filter);
         assert!(args.filter_drv_closures);
         assert!(args.no_closure);
+        assert!(args.read_only);
         assert_eq!(
             args.upstream_cache_key_names,
             vec![

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -228,10 +228,11 @@ pub struct PipelineContext {
     /// Compressed bytes per pack ([`PACK_TARGET_SIZE`] in production; tests
     /// use small values to exercise pack splitting).
     pub pack_target_size: u64,
-    /// Runtime token has no writable cache scope (`check_run`, fork
-    /// `pull_request`); the write pipeline is skipped so a drain is a clean
-    /// no-op instead of failing at the first reservation. Set by a
-    /// background probe at startup ([`crate::serve`]).
+    /// The write pipeline is skipped so a drain is a clean no-op. Set by
+    /// `serve --read-only`, or by a background probe at startup
+    /// ([`crate::serve`]) when the runtime token has no writable cache
+    /// scope (`check_run`, fork `pull_request`) and the first reservation
+    /// would fail anyway.
     pub read_only: Arc<AtomicBool>,
     /// Where committed manifests are published for the substituter.
     ///

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -588,8 +588,9 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
         .unwrap_or_else(|| "local".to_string());
     let system = args.system.clone().unwrap_or_else(pipeline::current_system);
 
-    // Set by the write probe spawned once the listeners are bound (below).
-    let read_only = Arc::new(AtomicBool::new(false));
+    // Explicit via --read-only, else set by the write probe spawned once
+    // the listeners are bound (below).
+    let read_only = Arc::new(AtomicBool::new(args.read_only));
 
     let store_dir = store.store_dir().clone();
     let root_key = pipeline::root_key(&branch, &system);
@@ -715,7 +716,9 @@ pub async fn run(args: &ServeArgs) -> ExitCode {
     // cannot delay readiness; it resolves long before the post-step drain.
     // An unreachable cache is inconclusive: stay writable and let the real
     // drain surface any genuine failure.
-    {
+    if args.read_only {
+        eprintln!("hestia serve: read-only mode; nothing will be written to the cache");
+    } else {
         let twirp = twirp.clone();
         let read_only = read_only.clone();
         tokio::spawn(async move {

--- a/tests/serve_daemon.rs
+++ b/tests/serve_daemon.rs
@@ -79,6 +79,41 @@ impl RunningDaemon {
     }
 }
 
+/// Read-only mode (`serve --read-only` or a read-only token): hooked and
+/// accessed paths never reach the cache, neither via an explicit drain nor
+/// via the final drain at shutdown.
+#[tokio::test]
+async fn read_only_daemon_never_writes() {
+    let Some(store) = ScratchStore::create() else {
+        return;
+    };
+    let fixture = store.add_fixture("read-only", 47);
+
+    let fake = FakeGha::start().await;
+    let http = reqwest::Client::new();
+    let daemon = RunningDaemon::start(
+        store_socket_path(&store),
+        None,
+        PipelineContext {
+            read_only: std::sync::Arc::new(true.into()),
+            ..pipeline_context(&fake, &http, store.database())
+        },
+    )
+    .await;
+
+    daemon.add(&[&fixture]).await;
+    daemon.access_log.record(path_hash_of(&fixture));
+    let response = daemon.request(&Request::Drain).await;
+    assert!(response.ok, "{:?}", response.error);
+    assert_eq!(response.stats.expect("stats").pushed, 0);
+
+    daemon.add(&[&fixture]).await;
+    let stats = daemon.stop().await.expect("final drain");
+    assert_eq!(stats.manifest_version, 0);
+    assert!(committed_manifest(&fake, &http).await.is_none());
+    assert!(fake.blob_requests().is_empty());
+}
+
 #[tokio::test]
 async fn hook_drain_status_lifecycle() {
     let Some(store) = ScratchStore::create() else {


### PR DESCRIPTION
Workflow permissions cannot scope ACTIONS_RUNTIME_TOKEN, so consume-only
jobs had no way to disable cache writes.

read-only: true skips the post-build-hook and the post-step drain, and
passes serve --read-only (pre-setting the existing write-probe flag) so
the final drain and other socket clients cannot write either.

Closes #137
